### PR TITLE
Optimized the LensDistortOp, improving the performace 4x

### DIFF
--- a/include/IECore/LensDistortOp.h
+++ b/include/IECore/LensDistortOp.h
@@ -68,6 +68,9 @@ class LensDistortOp : public IECore::WarpOp
 
 	private :
 
+		Imath::V2f distort( const Imath::V2f &p ) const;
+		Imath::V2f undistort( const Imath::V2f &p ) const;
+
 		enum Mode
 		{
 			kUndistort = 0,
@@ -80,6 +83,8 @@ class LensDistortOp : public IECore::WarpOp
 		IECore::IntParameterPtr m_modeParameter;
 		Imath::V2i m_imageSize;
 		Imath::Box2i m_imageDataWindow;
+		Imath::Box2i m_distortedDataWindow;
+		IECore::FloatVectorDataPtr m_cachePtr;
 };
 
 IE_CORE_DECLAREPTR( LensDistortOp );


### PR DESCRIPTION
Optimized the LensDistortOp by caching the distortion and doing a simple look-up from within the warp() method instead of recomputing it per channel.

Removed all conditional statements from the tight loops.
