### PR TITLE
Reflect api changes in Alembic_1.1.2+

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1539,6 +1539,7 @@ corePythonModuleEnv.Append( LIBS = os.path.basename( coreEnv.subst( "$INSTALL_LI
 corePythonModuleEnv.Append( LIBS = os.path.basename( corePythonEnv.subst( "$INSTALL_PYTHONLIB_NAME" ) ) )
 corePythonModule = corePythonModuleEnv.SharedLibrary( "python/IECore/_IECore", corePythonModuleSources )
 corePythonModuleEnv.Depends( corePythonModule, coreLibrary )
+corePythonModuleEnv.Depends( corePythonModule, corePythonLibrary )
 
 corePythonModuleInstall = corePythonModuleEnv.Install( "$INSTALL_PYTHON_DIR/IECore", corePythonScripts + corePythonModule )
 corePythonModuleEnv.AddPostAction( "$INSTALL_PYTHON_DIR/IECore", lambda target, source, env : makeSymLinks( corePythonEnv, corePythonEnv["INSTALL_PYTHON_DIR"] ) )

--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicInput.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicInput.cpp
@@ -226,10 +226,8 @@ Imath::Box3d AlembicInput::boundAtSample( size_t sampleIndex ) const
 		{
 			throw IECore::Exception( "No stored bounds available" );
 		}
-		
-		XformSample sample;
-		iXFormSchema.get( sample, ISampleSelector( (index_t)sampleIndex ) );
-		return sample.getChildBounds();
+
+		return iXFormSchema.getChildBoundsProperty().getValue( ISampleSelector( (index_t)sampleIndex ) );
 	}
 	else
 	{

--- a/contrib/IECoreAlembic/src/IECoreAlembic/FromAlembicPolyMeshConverter.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/FromAlembicPolyMeshConverter.cpp
@@ -76,13 +76,13 @@ IECore::ObjectPtr FromAlembicPolyMeshConverter::doAlembicConversion( const Alemb
 	
 	MeshPrimitivePtr result = new IECore::MeshPrimitive( verticesPerFace, vertexIds, "linear", points );
 	
-	IN3fGeomParam &normals = iPolyMeshSchema.getNormalsParam();
+	IN3fGeomParam normals = iPolyMeshSchema.getNormalsParam();
 	if( normals.valid() )
 	{
 		convertGeomParam( normals, sampleSelector, result );
 	}
 	
-	Alembic::AbcGeom::IV2fGeomParam &uvs = iPolyMeshSchema.getUVsParam();
+	Alembic::AbcGeom::IV2fGeomParam uvs = iPolyMeshSchema.getUVsParam();
 	convertUVs( uvs, sampleSelector, result );
 	
 	ICompoundProperty arbGeomParams = iPolyMeshSchema.getArbGeomParams();

--- a/contrib/IECoreAlembic/src/IECoreAlembic/FromAlembicSubDConverter.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/FromAlembicSubDConverter.cpp
@@ -82,7 +82,7 @@ IECore::ObjectPtr FromAlembicSubDConverter::doAlembicConversion( const Alembic::
 	
 	MeshPrimitivePtr result = new IECore::MeshPrimitive( verticesPerFace, vertexIds, interpolation, points );
 	
-	Alembic::AbcGeom::IV2fGeomParam &uvs = iSubDSchema.getUVsParam();
+	Alembic::AbcGeom::IV2fGeomParam uvs = iSubDSchema.getUVsParam();
 	convertUVs( uvs, sampleSelector, result );
 	
 	ICompoundProperty arbGeomParams = iSubDSchema.getArbGeomParams();


### PR DESCRIPTION
These changes to IECoreAlembic allow it to build against Alembic 1.1.2 and newer.

From the Alembic 1.1.2 release notes...

> Child bounds are no longer written and read via the schema's sample class, 
> instead the child bounds property is directly exposed on the schema. 
> Normals and UVs IGeomParams are no longer returned by reference. 

Also includes a minor fix to the SConstruct. It adds a missing dependency to the Python module ensuring correct behaviour for multicore builds.
