### PR TITLE
Assert removal

### DIFF
--- a/src/IECore/FileIndexedIO.cpp
+++ b/src/IECore/FileIndexedIO.cpp
@@ -144,10 +144,6 @@ FileIndexedIO::StreamFile::StreamFile( const std::string &filename, IndexedIO::O
 		}
 
 	}
-
-	assert( m_stream );
-	assert( m_stream->is_complete() );
-	assert( m_index );
 }
 
 void FileIndexedIO::StreamFile::flush( size_t endPosition )

--- a/src/IECore/MemoryIndexedIO.cpp
+++ b/src/IECore/MemoryIndexedIO.cpp
@@ -94,9 +94,6 @@ MemoryIndexedIO::StreamFile::StreamFile( const char *buf, size_t size, IndexedIO
 		std::stringstream *f = new std::stringstream( std::string(buf, size), std::ios::binary | std::ios::in | std::ios::out );
 		setStream( f, false );
 	}
-	assert( m_stream );
-	assert( m_stream->is_complete() );
-	assert( m_index );
 }
 
 void MemoryIndexedIO::StreamFile::flush( size_t endPosition )

--- a/src/IECore/StreamIndexedIO.cpp
+++ b/src/IECore/StreamIndexedIO.cpp
@@ -1172,8 +1172,6 @@ void StreamIndexedIO::Index::writeNode( Node *node, F &f )
 			else
 			{
 				Node *child = static_cast< Node * >(p);
-				/// Check tree consistency before writing
-				assert( child->m_parent == this );
 				writeNode( child, f );
 			}
 		}
@@ -1646,7 +1644,6 @@ IndexedIO::OpenMode StreamIndexedIO::StreamFile::openMode() const
 void StreamIndexedIO::StreamFile::setStream( std::iostream *stream, bool emptyFile )
 {
 	m_stream = stream;
-	assert( m_stream->is_complete() );
 	if ( m_openmode & IndexedIO::Append && emptyFile )
 	{
 		m_openmode = (m_openmode ^ IndexedIO::Append) | IndexedIO::Write;
@@ -1682,8 +1679,6 @@ void StreamIndexedIO::StreamFile::flush( size_t endPosition )
 
 bool StreamIndexedIO::StreamFile::canRead( std::iostream &f )
 {
-	assert( f.is_complete() );
-
 	f.seekg( 0, std::ios::end );
 	Imf::Int64 end = f.tellg();
 


### PR DESCRIPTION
Removed several assert() calls which were causing syntax errors when compiling cortex in debug mode.
