### PR TITLE
IECoreMaya fixed dag menu GL bug for sceneShapes

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -306,7 +306,7 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 		allTransformChildren = maya.cmds.listRelatives( transform, f=True, type = "transform" ) or []
 		
 		for child in allTransformChildren:
-			# Do a bunch of tests first!
+			# \todo check for connections and new parented nodes
 			maya.cmds.delete( child )
 		
 		maya.cmds.setAttr( node+".objectOnly", l=False )

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -320,10 +320,12 @@ def __selectedSceneShapes() :
 	
 	selectedSceneShapes = maya.cmds.ls( sl=True, l=True )
 	for shape in selectedSceneShapes:
-		if maya.cmds.nodeType( shape ) == "ieSceneShape" and not shape in allSceneShapes:
-			allSceneShapes.append( shape )
+		# Make sure we have the shape name, it could be a component 
+		shapeName = shape.split(".f[")[0]
+		if maya.cmds.nodeType( shapeName ) == "ieSceneShape" and not shapeName in allSceneShapes:
+			allSceneShapes.append( shapeName )
 		else:
-			children = maya.cmds.listRelatives( shape, children=True, type="ieSceneShape", fullPath=True )
+			children = maya.cmds.listRelatives( shapeName, children=True, type="ieSceneShape", fullPath=True ) or []
 			for child in children:
 				if not child in allSceneShapes:
 					allSceneShapes.append( child )

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1022,8 +1022,6 @@ void SceneShapeInterface::recurseBuildScene( IECoreGL::Renderer * renderer, cons
 	if( drawBounds && pathStr != "/" )
 	{
 		AttributeBlock aBox(renderer);
-		renderer->setAttribute( "gl:primitive:wireframe", new BoolData( true ) );
-		renderer->setAttribute( "gl:primitive:solid", new BoolData( false ) );
 		renderer->setAttribute( "gl:curvesPrimitive:useGLLines", new BoolData( true ) );
 
 		Box3d b = subSceneInterface->readBound( time );

--- a/src/IECoreMaya/SceneShapeUI.cpp
+++ b/src/IECoreMaya/SceneShapeUI.cpp
@@ -388,9 +388,12 @@ bool SceneShapeUI::select( MSelectInfo &selectInfo, MSelectionList &selectionLis
 		glMatrixMode( GL_PROJECTION );
 		glLoadMatrixd( projectionMatrix.getValue() );
 		
-		// Need OcclusionQuery Selector mode to be able to select child bounds. Will have to check IDRender would improve performances.
-		IECoreGL::Selector::Mode selectionMode = IECoreGL::Selector::OcclusionQuery;
-		
+		IECoreGL::Selector::Mode selectionMode = IECoreGL::Selector::IDRender;
+		if( selectInfo.displayStatus() == M3dView::kHilite && !selectInfo.singleSelection() )
+		{
+			selectionMode = IECoreGL::Selector::OcclusionQuery;
+		}
+
 		IECoreGL::Selector selector;
 		selector.begin( Imath::Box2f( Imath::V2f( 0 ), Imath::V2f( 1 ) ), selectionMode );
 				
@@ -400,8 +403,8 @@ bool SceneShapeUI::select( MSelectInfo &selectInfo, MSelectionList &selectionLis
 
 			if( selectInfo.displayStatus() != M3dView::kHilite )
 			{
-				// we're not in component selection mode. we'd like to be able to select the procedural
-				// object using the bounding box so we draw it too.
+				// We're not in component selection mode. We'd like to be able to select the scene shape
+				// using the bounding box so we draw it too.
 				IECoreGL::BoxPrimitive::renderWireframe( IECore::convert<Imath::Box3f>( sceneShape->boundingBox() ) );
 			}
 			


### PR DESCRIPTION
Fixed GL bug when showing scene shape dag menu by keeping default values for gl:primitive when drawing bboxes with only gl:curvesPrimitive:useGLLines turned on, and selector mode in SceneShapeUI::select set to IERender except in multiple selection component mode. 
