### PR TITLE
Couple of defines for building against PRMan17.

### DIFF
--- a/src/IECoreRI/Dspy.cpp
+++ b/src/IECoreRI/Dspy.cpp
@@ -280,6 +280,9 @@ PtDspyError Dspy::imageOpen( PtDspyImageHandle *image, const char *driverName, c
 PtDspyError Dspy::imageQuery( PtDspyImageHandle image, PtDspyQueryType type, int size, void *data )
 {
 	DisplayDriver *dd = static_cast<DisplayDriver *>( image );
+#ifdef PRMANEXPORT			
+	return PkDspyErrorUnsupported;
+#else				
 	if( type == PkProgressiveQuery )
 	{
 		if( (!dd->scanLineOrderOnly()) && dd->acceptsRepeatedData() )
@@ -293,6 +296,7 @@ PtDspyError Dspy::imageQuery( PtDspyImageHandle image, PtDspyQueryType type, int
 		return PkDspyErrorNone;
 	}
 	return PkDspyErrorUnsupported;
+#endif				
 }
 
 PtDspyError Dspy::imageData( PtDspyImageHandle image, int xMin, int xMaxPlusOne, int yMin, int yMaxPlusOne, int entrySize, const unsigned char *data )

--- a/src/IECoreRI/SLOReader.cpp
+++ b/src/IECoreRI/SLOReader.cpp
@@ -337,11 +337,13 @@ ObjectPtr SLOReader::doOperation( const CompoundObject * operands )
 	CompoundDataPtr annotations = new CompoundData;
 	result->blindData()->writable().insert( pair<string, DataPtr>( "ri:annotations", annotations ) );
 	
+#ifndef PRMANEXPORT
 	for( int i=1, n=Slo_GetNAnnotations(); i <= n; i++ )
 	{
 		const char *key = Slo_GetAnnotationKeyById( i );
 		annotations->writable()[key] = new StringData( Slo_GetAnnotationByKey( key ) );
 	}
+#endif
 
 	Slo_EndShader();
 	return result;


### PR DESCRIPTION
A couple of minor modifications to CoreRI so it compiles against PRMan 17.

Specifically PRMan does not have the PkProgressiveQuery display query type. Also, PRMan's SLO library doesn't have the annotation methods. It does have some support for meta data though - http://renderman.pixar.com/resources/current/rps/sloApi.html#meta-data. Maybe it could provide equivalent functionality?
