### PR TITLE
LinkedScene: adding ability to store tags in scene locations with links

### DIFF
--- a/include/IECore/LinkedScene.h
+++ b/include/IECore/LinkedScene.h
@@ -44,13 +44,14 @@ IE_CORE_FORWARDDECLARE( LinkedScene );
 
 /// Implements a scene that have references (links) to external scenes.
 /// Links can be created at any location in a scene. When a link is created in a given location,
-/// the object, tags, bounds and children will be loaded from the linked scene (with time remapping). The transform, attributes
-/// are still loaded from the main scene.
+/// the object, bounds and children will be loaded from the linked scene (with time remapping). The transform, attributes
+/// are still loaded from the main scene. Tags defined in the link location will be applied (when read) to all the child transforms from the linked scene.
 /// This class wraps another SceneInterface object that is responsible for actually storing the data
 /// (we call it the "main scene"). Links are represented as an attribute in the main scene called "SceneInterface:link".
 /// When created for reading, this class provides seamless access to the hierarchy inside the linked scenes, 
 /// concatenating the two hierarchies in a single path that uniquely identify that location. The time is also 
-/// transparently translated.
+/// transparently translated. Tags that were saved in the linked scene are propagated to the main scene, 
+/// to keep consistent behavior.
 /// When writing, there's no access to the contents of the indexed scene. Instead, it creates the links by either
 /// (1) calls to the function writeLink() or 
 /// (2) calls to the function writeAttribute( LinkedScene::linkSceneAttribute, LinkedScene::linkAttributeData(), ... ). 
@@ -123,7 +124,7 @@ class LinkedScene : public  SampledSceneInterface
 		virtual void writeAttribute( const Name &name, const Object *attribute, double time );
 
 		virtual bool hasTag( const Name &name ) const;
-		virtual void readTags( NameList &tags, bool includeChildren ) const;
+		virtual void readTags( NameList &tags, bool includeChildren = true ) const;
 		virtual void writeTags( const NameList &tags );
 
 		virtual bool hasObject() const;

--- a/include/IECore/SceneCache.h
+++ b/include/IECore/SceneCache.h
@@ -141,6 +141,12 @@ class SceneCache : public SampledSceneInterface
 		IE_CORE_FORWARDDECLARE( Implementation );
 		virtual SceneCachePtr duplicate( ImplementationPtr& implementation ) const;
 		SceneCache( ImplementationPtr& implementation );
+
+		/// LinkedScene need to specify whether the tag is supposed to be saved
+		/// as a local tag or a tag that was artificially inherited from the child transforms.
+		void writeTags( const NameList &tags,  bool fromChildren );
+
+		friend class LinkedScene;
 		
 	private :
 

--- a/src/IECore/SceneCache.cpp
+++ b/src/IECore/SceneCache.cpp
@@ -899,6 +899,7 @@ class SceneCache::WriterImplementation : public SceneCache::Implementation
 			{
 				// we represent inherited tags as empty directories and local tags as a IndexedIO::File of bool type, so
 				// we can easily filter them when reading by entry type.
+				// Inherited tags do not override local tags.
 				if ( fromChildren )
 				{
 					if ( !io->hasEntry( *tIt ) )
@@ -1943,6 +1944,12 @@ void SceneCache::writeTags( const NameList &tags )
 {
 	WriterImplementation *writer = WriterImplementation::writer( m_implementation.get() );
 	writer->writeTags( tags );
+}
+
+void SceneCache::writeTags( const NameList &tags, bool fromChildren )
+{
+	WriterImplementation *writer = WriterImplementation::writer( m_implementation.get() );
+	writer->writeTags( tags, fromChildren );
 }
 
 bool SceneCache::hasObject() const


### PR DESCRIPTION
These tags will, at reading time, be returned to all the child locations as if the linked scene had that tag on all levels.

This will be useful if, for example, users need to tag an entire external asset and later on the context of the whole scene, be able to view only those assets. Or also, know where the assets start in the hierarchy.
