### PR TITLE
IECoreMaya time connection from parent is preserved when expanding scene...

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -222,7 +222,7 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 
 		sceneFile = maya.cmds.getAttr( node+".file" )
 		sceneRoot = maya.cmds.getAttr( node+".root" )
-		
+
 		maya.cmds.setAttr( node+".querySpace", 1 )
 		maya.cmds.setAttr( node+".objectOnly", l=False )
 		maya.cmds.setAttr( node+".objectOnly", 1 )
@@ -232,6 +232,8 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 		drawChildBounds = maya.cmds.getAttr( node+".drawChildBounds" )
 		drawRootBound = maya.cmds.getAttr( node+".drawRootBound" )
 		drawTagsFilter = maya.cmds.getAttr( node+".drawTagsFilter" )
+		
+		timeConnection = maya.cmds.listConnections( node+".time", source = True, destination = False, plugs=True )
 		
 		newSceneShapeFns = []
 
@@ -264,7 +266,7 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 			maya.cmds.setAttr( childNode+".drawGeometry", drawGeo )
 			maya.cmds.setAttr( childNode+".drawChildBounds", drawChildBounds )
 			maya.cmds.setAttr( childNode+".drawRootBound", drawRootBound )
-			
+
 			if drawTagsFilter:
 				parentTags = drawTagsFilter.split()
 				childTags = fnChild.sceneInterface().readTags()
@@ -273,8 +275,11 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 					# Hide that child since it doesn't match any filter
 					maya.cmds.setAttr( childTransform+".visibility", 0 )
 				else:
-					maya.cmds.setAttr( childNode+".drawTagsFilter", " ".join(commonTags),type="string" )	
+					maya.cmds.setAttr( childNode+".drawTagsFilter", " ".join(commonTags),type="string" )
 			
+			# Connect child time to its parent so they're in sync
+			maya.cmds.connectAttr( node+".time", childNode+".time", f=True )
+
 			if maya.cmds.listRelatives( childTransform, parent = True, f=True ) != [ transform ]:
 				maya.cmds.parent( childTransform, transform, relative=True )
 			

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -324,7 +324,7 @@ MStatus SceneShapeInterface::initialize()
 	cAttr.setIndexMatters( true );
 	cAttr.setUsesArrayDataBuilder( true );
 	cAttr.setStorable( false );
-	
+
 	s = addAttribute( aTransform );
 	
 	// Bounding box
@@ -381,6 +381,8 @@ MStatus SceneShapeInterface::initialize()
 	cAttr.addChild( aBoundMin );
 	cAttr.addChild( aBoundMax );
 	cAttr.addChild( aBoundCenter );
+	cAttr.setReadable( true );
+	cAttr.setWritable( false );
 	cAttr.setArray( true );
 	cAttr.setIndexMatters( true );
 	cAttr.setUsesArrayDataBuilder( true );
@@ -409,6 +411,8 @@ MStatus SceneShapeInterface::initialize()
 
 	aAttributes = cAttr.create( "attributes", "ott" );
 	cAttr.addChild( aAttributeValues );
+	cAttr.setReadable( true );
+	cAttr.setWritable( false );
 	cAttr.setArray( true );
 	cAttr.setIndexMatters( true );
 	cAttr.setUsesArrayDataBuilder( true );


### PR DESCRIPTION
...Shapes.
When expanding a sceneShape, the time attributes of all children are now directly connected to the parent time attribute. Also minor fix on sceneShapeInterface attribute properties.
