### PR TITLE
Restored support for Boost 1.43 (boost::filesystem v2).

### DIFF
--- a/src/IECore/DeepImageWriter.cpp
+++ b/src/IECore/DeepImageWriter.cpp
@@ -146,6 +146,9 @@ void DeepImageWriter::registerDeepImageWriter( const std::string &extensions, Ca
 
 DeepImageWriterPtr DeepImageWriter::create( const std::string &fileName )
 {
+	/// \todo We can stop using this deprecated form when we no longer need to be compatible
+	/// with boost 1.43. At that point we can use path.extension().string() and compile with
+	/// BOOST_FILESYSTEM_NO_DEPRECATED.
 	std::string ext = boost::filesystem::extension( boost::filesystem::path( fileName ) );
 
 	ExtensionsToFnsMap *m = extensionsToFns();

--- a/src/IECore/FileSequenceFunctions.cpp
+++ b/src/IECore/FileSequenceFunctions.cpp
@@ -64,6 +64,20 @@
 
 #endif
 
+#if BOOST_VERSION < 104400
+
+	// Boost 1.44.0 introduced Filesystem v3, which we use by defining BOOST_FILESYSTEM_VERSION=3 via
+	// the build process. Prior versions of boost didn't have this version, so we need this define
+	// to help write code suitable for both.
+
+	#define PATH_TO_STRING filename()
+
+#else
+
+	#define PATH_TO_STRING filename().string()
+
+#endif
+
 using namespace IECore;
 
 void IECore::findSequences( const std::vector< std::string > &names, std::vector< FileSequencePtr > &sequences, size_t minSequenceSize )
@@ -181,7 +195,7 @@ void IECore::ls( const std::string &path, std::vector< FileSequencePtr > &sequen
 	 	std::vector< std::string > files;
 		for ( boost::filesystem::directory_iterator it( path ); it != end; ++it )
 		{
-			files.push_back( it->path().filename().string() );
+			files.push_back( it->path().PATH_TO_STRING );
 		}
 
 		findSequences( files, sequences, minSequenceSize );
@@ -203,9 +217,9 @@ void IECore::ls( const std::string &sequencePath, FileSequencePtr &sequence, siz
 
  	std::vector< std::string > files;
 
-	boost::filesystem::path dir = boost::filesystem::path( sequencePath ).branch_path();
+	boost::filesystem::path dir = boost::filesystem::path( sequencePath ).parent_path();
 
-	std::string baseSequencePath = boost::filesystem::path( sequencePath ).filename().string();
+	std::string baseSequencePath = boost::filesystem::path( sequencePath ).PATH_TO_STRING;
 
 	const std::string::size_type first = baseSequencePath.find_first_of( '#' );
 	assert( first != std::string::npos );
@@ -225,7 +239,7 @@ void IECore::ls( const std::string &sequencePath, FileSequencePtr &sequence, siz
 
 	for ( boost::filesystem::directory_iterator it( dirToCheck ); it != end; ++it )
 	{
-		const std::string fileName = it->path().filename().string();
+		const std::string fileName = it->path().PATH_TO_STRING;
 
 		if ( fileName.size() >= std::min( prefix.size(), suffix.size() ) && fileName.substr( 0, prefix.size() ) == prefix && fileName.substr( fileName.size() - suffix.size(), suffix.size() ) == suffix )
 		{


### PR DESCRIPTION
Previously we moved to v3 of the boost filesystem library, because v2 is no longer supported in versions >= 1.50. But we still need to build with boost 1.43 to support Arnold on OS X, which links to that version and doesn't hide the symbols, and filesystem v3 wasn't introduced until boost 1.44. This fix reinstates support for 1.43, and adds a todo for when we can finally leave 1.43 behind.
