### PR TITLE
Added outTime plug to SceneShapeInterface that is directly computed from...

### DIFF
--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -119,6 +119,7 @@ class SceneShapeInterface: public MPxComponentShape
 		
 		// protected variables, used by derived classes to set attribute dependencies
 		static MObject aTime;
+		static MObject aOutTime;
 		static MObject aOutputObjects;
 		static MObject aAttributes;
 		static MObject aTransform;

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -278,8 +278,8 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 					maya.cmds.setAttr( childNode+".drawTagsFilter", " ".join(commonTags),type="string" )
 			
 			# Connect child time to its parent so they're in sync
-			if not maya.cmds.isConnected( node+".time", childNode+".time" ):
-				maya.cmds.connectAttr( node+".time", childNode+".time", f=True )
+			if not maya.cmds.isConnected( node+".outTime", childNode+".time" ):
+				maya.cmds.connectAttr( node+".outTime", childNode+".time", f=True )
 
 			if maya.cmds.listRelatives( childTransform, parent = True, f=True ) != [ transform ]:
 				maya.cmds.parent( childTransform, transform, relative=True )

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -101,6 +101,7 @@ MObject SceneShapeInterface::aDrawChildBounds;
 MObject SceneShapeInterface::aDrawTagsFilter;
 MObject SceneShapeInterface::aQuerySpace;
 MObject SceneShapeInterface::aTime;
+MObject SceneShapeInterface::aOutTime;
 MObject SceneShapeInterface::aSceneQueries;
 MObject SceneShapeInterface::aAttributeQueries;
 MObject SceneShapeInterface::aOutputObjects;
@@ -225,6 +226,13 @@ MStatus SceneShapeInterface::initialize()
 	
 	s = addAttribute( aTime );
 
+	aOutTime = uAttr.create( "outTime", "otm", MFnUnitAttribute::kTime, 0.0, &s );
+	uAttr.setReadable( true );
+	uAttr.setWritable( false );
+	uAttr.setStorable( false );
+	
+	s = addAttribute( aOutTime );
+	
 	// Queries
 	
 	aSceneQueries = tAttr.create( "queryPaths", "qpa", MFnData::kString, &s );
@@ -431,6 +439,8 @@ MStatus SceneShapeInterface::initialize()
 	attributeAffects( aQuerySpace, aTransform );
 	attributeAffects( aQuerySpace, aBound );
 	attributeAffects( aQuerySpace, aOutputObjects );
+	
+	attributeAffects( aTime, aOutTime );
 
 	return s;
 }
@@ -842,6 +852,14 @@ MStatus SceneShapeInterface::compute( const MPlug &plug, MDataBlock &dataBlock )
 				currentElement.setString( value );
 			}
 		}
+	}
+	else if( topLevelPlug == aOutTime )
+	{
+		MDataHandle timeHandle = dataBlock.inputValue( aTime );
+		MTime time = timeHandle.asTime();
+		
+		MDataHandle outTimeHandle = dataBlock.outputValue( aOutTime );
+		outTimeHandle.setMTime( time );
 	}
 
 	return MS::kSuccess;

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -138,7 +138,7 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertTrue( maya.cmds.isConnected( fn.fullPathName()+".outTransform[0].outTranslate", "|test|sceneShape_1.translate" ) )
 		self.assertTrue( maya.cmds.isConnected( fn.fullPathName()+".outTransform[0].outRotate", "|test|sceneShape_1.rotate" ) )
 		self.assertTrue( maya.cmds.isConnected( fn.fullPathName()+".outTransform[0].outScale", "|test|sceneShape_1.scale" ) )
-		self.assertTrue( maya.cmds.isConnected( fn.fullPathName()+".time", childFn.fullPathName()+".time" ) )
+		self.assertTrue( maya.cmds.isConnected( fn.fullPathName()+".outTime", childFn.fullPathName()+".time" ) )
 		
 		maya.cmds.setAttr( childFn.fullPathName()+".drawGeometry", 1 )
 		result = childFn.expandOnce()
@@ -155,7 +155,7 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertTrue( maya.cmds.isConnected( childFn.fullPathName()+".outTransform[0].outRotate", "|test|sceneShape_1|child.rotate" ) )
 		self.assertTrue( maya.cmds.isConnected( childFn.fullPathName()+".outTransform[0].outScale", "|test|sceneShape_1|child.scale" ) )
 		self.assertEqual( maya.cmds.getAttr( result[0].fullPathName()+".drawGeometry"), 1 )
-		self.assertTrue( maya.cmds.isConnected( childFn.fullPathName()+".time", result[0].fullPathName()+".time" ) )
+		self.assertTrue( maya.cmds.isConnected( childFn.fullPathName()+".outTime", result[0].fullPathName()+".time" ) )
 		
 		
 	def testCollapse( self ) :

--- a/test/IECoreMaya/SceneShapeTest.py
+++ b/test/IECoreMaya/SceneShapeTest.py
@@ -284,6 +284,9 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertEqual( round(maya.cmds.getAttr( node+".outTransform[2].outRotate.outRotateZ")), -30.0 )
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[2].outScale"), [(1.0, 1.0, 1.0)] )
 		
+		maya.cmds.setAttr( node+'.time', 5 )
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 5 )
+		
 		
 	def testAnimPlugValues( self ) :
 		
@@ -301,6 +304,7 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		maya.cmds.setAttr( node+".queryPaths[2]", "/1/2/3", type="string")
 
 		maya.cmds.currentTime( 0 )
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 0 )
 
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[0].outTranslate"), [(1.0, 0.0, 0.0)] )
 		self.assertAlmostEqual( maya.cmds.getAttr( node+".outTransform[0].outRotateX"), 0.0 )
@@ -321,6 +325,7 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[2].outScale"), [(1.0, 1.0, 1.0)] )
 		
 		maya.cmds.currentTime( 48 )
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 48 )
 
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[0].outTranslate"), [(1.0, 2.0, 0.0)] )
 		self.assertAlmostEqual( maya.cmds.getAttr( node+".outTransform[0].outRotateX"), 0.0 )
@@ -341,6 +346,7 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[2].outScale"), [(1.0, 1.0, 1.0)] )
 		
 		maya.cmds.currentTime( 60 )
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 60 )
 
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[0].outTranslate"), [(1.0, 2.5, 0.0)] )
 		self.assertAlmostEqual( maya.cmds.getAttr( node+".outTransform[0].outRotateX"), 0.0 )
@@ -362,6 +368,7 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		
 		maya.cmds.currentTime( 0 )
 		maya.cmds.setAttr( node+".querySpace", 1)
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 0 )
 
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[0].outTranslate"), [(1.0, 0.0, 0.0)] )
 		self.assertAlmostEqual( maya.cmds.getAttr( node+".outTransform[0].outRotateX"), 0.0 )
@@ -382,6 +389,7 @@ class SceneShapeTest( IECoreMaya.TestCase ) :
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[2].outScale"), [(1.0, 1.0, 1.0)] )
 		
 		maya.cmds.currentTime( 48 )
+		self.assertEqual( maya.cmds.getAttr( node+".outTime" ), 48 )
 
 		self.assertEqual( maya.cmds.getAttr( node+".outTransform[0].outTranslate"), [(1.0, 2.0, 0.0)] )
 		self.assertAlmostEqual( maya.cmds.getAttr( node+".outTransform[0].outRotateX"), 0.0 )


### PR DESCRIPTION
... the input time plug. Used to connect input time of children to parent outTime when expanding. 
The extra output plug is needed because Maya can't handle input plug to input plug connections in batch mode.
