### PR TITLE
Fixed PTCParticleReader build.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1642,7 +1642,7 @@ if doConfigure :
 		riPythonSources = sorted( glob.glob( "src/IECoreRI/bindings/*.cpp" ) )
 		riPythonScripts = glob.glob( "python/IECoreRI/*.py" )
 	
-		if c.CheckHeader( "pointcloud.h" ) :
+		if c.CheckCXXHeader( "pointcloud.h" ) :
 			
 			riEnv.Append( CPPFLAGS = "-DIECORERI_WITH_PTC" )
 			riPythonModuleEnv.Append( CPPFLAGS = "-DIECORERI_WITH_PTC" )

--- a/include/IECoreRI/PTCParticleReader.h
+++ b/include/IECoreRI/PTCParticleReader.h
@@ -72,6 +72,8 @@ class PTCParticleReader : public IECore::ParticleReader
 		/// This method overwrites the base class implementation.
 		virtual IECore::ObjectPtr doOperation( const IECore::CompoundObject * operands );
 
+		virtual std::string positionPrimVarName();
+
 	private :
 
 		static const ReaderDescription<PTCParticleReader> m_readerDescription;

--- a/src/IECoreRI/PTCParticleReader.cpp
+++ b/src/IECoreRI/PTCParticleReader.cpp
@@ -574,3 +574,8 @@ CompoundDataPtr PTCParticleReader::readAttributes( const std::vector<std::string
 
 	return result;
 }
+
+std::string PTCParticleReader::positionPrimVarName()
+{
+	return "P";
+}


### PR DESCRIPTION
When we switched to specifying includes with -isystem in the CXXFLAGS, the configure check for pointcloud.h started failing, and we stopped building PTCParticleReader. This is fixed by using CheckCXXHeader which uses CXXFLAGS rather than CheckHeader, which doesn't.

Adding PTCParticleReader back into the build revealed another problem - it didn't implement the fairly recent pure virtual positionPrimVarName() method and therefore couldn't be instantiated, so this commit also implements that method.
