### PR TITLE
Added typeName argument to registerRunTimeTyped().

### DIFF
--- a/python/IECore/registerRunTimeTyped.py
+++ b/python/IECore/registerRunTimeTyped.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2007-2010, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -66,18 +66,17 @@ __nextDynamicRunTimeTypedId = None
 # class for it to properly implement the RunTimeTyped interface. It should
 # be called once for all python classes inheriting from RunTimeTyped. It also
 # calls registerTypeId() for you.
-# baseClass is deprecated.
-# \todo Remove deprecation warning and baseClass parameter on Cortex 6.
 # typId is optional and if not defined, this function will associate a dynamic Id
 #       in the range FirstDynamicTypeId and LastDynamicTypeId from TypeIds.h.
 #       It's necessary to specify type Id for Object derived class or anything that
 #       is serializable.
-def registerRunTimeTyped( typ, typId = None, baseClass = None ) :
+# If typeName is not specified then the name of the class itself is used - you may wish
+# to provide an explicit typeName in order to prefix the name with a module name.
+def registerRunTimeTyped( typ, typId = None, typeName = None ) :
 
-	if not baseClass is None :
-		IECore.warning( "%s: Passing base class is deprecated in registerRunTimeTyped." % typ )
-
-	typeName = typ.__name__
+	if typeName is None :
+		typeName = typ.__name__
+	
 	runTypedBaseClass = filter( lambda c: issubclass( c, IECore.RunTimeTyped ), typ.__bases__ )[0]
 
 	# constants below are the same as in TypeIds.h

--- a/test/IECore/RunTimeTyped.py
+++ b/test/IECore/RunTimeTyped.py
@@ -177,6 +177,27 @@ class TestRunTimeTyped( unittest.TestCase ) :
 		self.failIf( IECore.RunTimeTyped.inheritsFrom( IECore.TypeId.MeshPrimitive, IECore.TypeId.Writer ) )
 		self.failIf( IECore.RunTimeTyped.inheritsFrom( "MeshPrimitive", "Writer" ) )
 
+	def testRegisterPrefixedTypeName( self ) :
+	
+		class Prefixed( IECore.ParameterisedProcedural ) :
+		
+			def __init__( self ) :
+			
+				IECore.ParameterisedProcedural.__init__( self, "" )
+				
+		prefixedTypeName = "SomeModuleName::Prefixed"
+		IECore.registerRunTimeTyped( Prefixed, typeName = prefixedTypeName )
+
+		self.assertEqual( Prefixed.staticTypeName(), prefixedTypeName )
+		self.assertEqual( IECore.RunTimeTyped.typeIdFromTypeName( Prefixed.staticTypeName() ), Prefixed.staticTypeId() )
+		
+		p = Prefixed()
+		self.assertEqual( p.typeName(), prefixedTypeName )
+		self.assertEqual( p.typeId(), IECore.RunTimeTyped.typeIdFromTypeName( Prefixed.staticTypeName() ) )
+		
+		self.assertTrue( p.isInstanceOf( IECore.VisibleRenderable.staticTypeId() ) )
+		self.assertTrue( p.isInstanceOf( IECore.ParameterisedProcedural.staticTypeId() ) )
+		self.assertTrue( p.isInstanceOf( IECore.RunTimeTyped.staticTypeId() ) )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows typenames prefixed with the module name to be passed, overriding the typename autogenerated from the class name. There could be an argument for just autogenerating names prefixed with the module name, but that has potential knock-on effects to existing code which is relying on the old names. It's also impossible within python to find the fully qualified path to a nested class, so in that case we'd still want the ability to specify a typename explicitly.

Also removed the deprecated baseClass argument, which was documented as being scheduled for removal in Cortex 6.
