### PR TITLE
IECoreGL::ToGLTextureConverter option to add missing channels.

### DIFF
--- a/include/IECoreGL/ToGLTextureConverter.h
+++ b/include/IECoreGL/ToGLTextureConverter.h
@@ -95,7 +95,7 @@ class ToGLTextureConverter : public ToGLConverter
 	
 	private :
 
-		IECore::ImagePrimitivePtr createMissingChannels( IECore::ConstImagePrimitivePtr image ) const;
+		IECore::ImagePrimitivePtr createMissingChannels( const IECore::ImagePrimitive *image ) const;
 		IECore::ImagePrimitivePtr imageFromCompoundData( IECore::CompoundData::ConstPtr data ) const;
 		bool m_createMissingRGBChannels;
 

--- a/src/IECoreGL/ToGLTextureConverter.cpp
+++ b/src/IECoreGL/ToGLTextureConverter.cpp
@@ -123,7 +123,7 @@ IECore::RunTimeTypedPtr ToGLTextureConverter::doConversion( IECore::ConstObjectP
 	return t;
 }
 
-IECore::ImagePrimitivePtr ToGLTextureConverter::createMissingChannels( IECore::ConstImagePrimitivePtr image ) const
+IECore::ImagePrimitivePtr ToGLTextureConverter::createMissingChannels( const IECore::ImagePrimitive *image ) const
 {
 	IECore::ImagePrimitivePtr newImage = image->copy();
 	if( newImage->getChannel<float>( "R" ) == 0)

--- a/src/IECoreGL/bindings/ToGLTextureConverterBinding.cpp
+++ b/src/IECoreGL/bindings/ToGLTextureConverterBinding.cpp
@@ -48,8 +48,7 @@ namespace IECoreGL
 void bindToGLTextureConverter()
 {
 	IECorePython::RunTimeTypedClass<ToGLTextureConverter>()
-		.def( init< IECore::ConstObjectPtr >() )
-		.def( init< IECore::ConstObjectPtr, bool >() )
+		.def( init< IECore::ConstObjectPtr, bool >( boost::python::arg_( "createMissingRGBChannels" ) = false ) )
 	;
 }
 

--- a/test/IECoreGL/ToGLTextureConverter.py
+++ b/test/IECoreGL/ToGLTextureConverter.py
@@ -104,21 +104,11 @@ class TestToGLTexureConverter( unittest.TestCase ) :
 		cnd[ "R" ] = i[ "R" ].data
 
 		cd["channels"] = cnd
-		
-		exceptionOccured = False
-		try :
-			t = ToGLTextureConverter( cd ).convert()
-		except :
-			exceptionOccured = True
 
-		self.assertTrue( exceptionOccured )
-		
-		exceptionOccured = False
-		try :
-			t = ToGLTextureConverter( cd, True ).convert()
-		except :
-			exceptionOccured = True
-		self.assertFalse( exceptionOccured )
+		# We are missing a channel and so an exception should be thrown if we try to convert it with the default arguments.	
+		self.assertRaises( RuntimeError, ToGLTextureConverter( cd ).convert )
+
+		t = ToGLTextureConverter( cd, True ).convert()
 
 		ii = t.imagePrimitive()
 		self.assertTrue( "R" in ii.channelNames() )


### PR DESCRIPTION
- Added an optional argument to the IECoreGL::ToGLTextureConverter constructor that creates missing RGB channels rather than just throwing an exception.
- Updated the bindings for the above.
- Added test cases.
- Fixed preexisting typos.
