### PR TITLE
Removed IECoreGL dependency on GLUT.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -341,18 +341,6 @@ o.Add(
 	"",
 )
 
-o.Add(
-	"GLUT_INCLUDE_PATH",
-	"The path to the directory with glut.h in it.",
-	"$GLEW_INCLUDE_PATH",
-)
-
-o.Add(
-	"GLUT_LIB_PATH",
-	"The path to the directory with libGLUT in it.",
-	"$GLEW_LIB_PATH",
-)
-
 # Maya options
 
 o.Add(
@@ -1823,7 +1811,6 @@ if env["WITH_GL"] and doConfigure :
 		
 		"CXXFLAGS" : [
 			"-isystem", "$GLEW_INCLUDE_PATH",
-			"-isystem", "$GLUT_INCLUDE_PATH",
 			# These are to work around warnings in boost::wave
 			# while still using -Werror.
 			"-Wno-format",
@@ -1831,7 +1818,6 @@ if env["WITH_GL"] and doConfigure :
 		],
 		"LIBPATH" : [
 			"$GLEW_LIB_PATH",
-			"$GLUT_LIB_PATH",
 		],
 	}
 	
@@ -1840,7 +1826,6 @@ if env["WITH_GL"] and doConfigure :
 	
 	c = Configure( glEnv )
 	
-	## \todo We need to check for GLUT here too
 	if not c.CheckLibWithHeader( env.subst( "GLEW$GLEW_LIB_SUFFIX" ), "glew.h", "CXX" ) :
 	
 		sys.stderr.write( "WARNING : GLEW library not found, not building IECoreGL - check GLEW_INCLUDE_PATH and GLEW_LIB_PATH.\n" )
@@ -1857,7 +1842,6 @@ if env["WITH_GL"] and doConfigure :
 			glEnv.Append(
 				FRAMEWORKS = [
 					"OpenGL",
-					"GLUT",
 				]
 			)
 		else :
@@ -1865,7 +1849,6 @@ if env["WITH_GL"] and doConfigure :
 				LIBS = [
 					"GL",
 					"GLU",
-					"glut",
 				]
 			)
 

--- a/src/IECoreGL/IECoreGL.cpp
+++ b/src/IECoreGL/IECoreGL.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2008, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
 //
 //  Copyright 2010 Dr D Studios Pty Limited (ACN 127 184 954) (Dr. D Studios), 
 //  its affiliates and/or its licensors.
@@ -35,19 +35,20 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include <boost/version.hpp>
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-
-#include "IECoreGL/IECoreGL.h"
 #include "IECoreGL/GL.h"
-#include "IECoreGL/GLUT.h"
+#include "IECoreGL/IECoreGL.h"
+
+#if defined( __APPLE__ )
+
+#include <OpenGL/OpenGL.h>
+
+#elif defined( __linux__ )
+
+#include "GL/glx.h"
+
+#endif
 
 #include "IECore/MessageHandler.h"
-
-static void nullDisplayFunc()
-{
-}
 
 void IECoreGL::init( bool glAlreadyInitialised )
 {
@@ -56,31 +57,61 @@ void IECoreGL::init( bool glAlreadyInitialised )
 	{
 		if( !glAlreadyInitialised )
 		{
-			
-			// the mac version of glut changes the current directory during initialisation,
-			// so we have to change it back again ourselves.
-			boost::filesystem::path currentPath = boost::filesystem::current_path();
-			
-				int argc = 1;
-				const char *argv[] = { "IECoreGL" };
-				glutInit( &argc, const_cast<char**>( argv ) );
 
-#if BOOST_VERSION >= 103500
-				boost::filesystem::current_path( currentPath );
-#else
-				std::string cwd = currentPath.string();
-				const char *cwd_cptr = cwd.c_str();
-				chdir( cwd_cptr );
+#if defined( __APPLE__ )
+
+			CGLPixelFormatAttribute attributes[2] =
+			{
+				kCGLPFAAccelerated, // no software rendering
+				(CGLPixelFormatAttribute)0
+			};
+			CGLPixelFormatObj pixelFormat;
+			GLint numVirtualScreens;
+			CGLChoosePixelFormat( attributes, &pixelFormat, &numVirtualScreens );
+
+			CGLContextObj context;
+			CGLCreateContext( pixelFormat, 0, &context );
+			CGLDestroyPixelFormat( pixelFormat );
+
+			CGLSetCurrentContext( context );
+
+#elif defined( __linux__ )
+						
+			int numFBConfigs = 0;
+			Display *display = XOpenDisplay( NULL );
+			GLXFBConfig *fbConfigs = glXChooseFBConfig( display, DefaultScreen( display ), NULL, &numFBConfigs );
+			
+			int contextAttribs[] =
+			{
+    			GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
+    			GLX_CONTEXT_MINOR_VERSION_ARB, 3,
+    			GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+    			None
+			};
+			
+			typedef GLXContext (*glXCreateContextAttribsARBProc)( Display *, GLXFBConfig, GLXContext, Bool, const int * );
+			glXCreateContextAttribsARBProc glXCreateContextAttribsARB = (glXCreateContextAttribsARBProc) glXGetProcAddressARB( (const GLubyte *) "glXCreateContextAttribsARB" );
+			
+			GLXContext openGLContext = glXCreateContextAttribsARB( display, fbConfigs[0], 0, True, contextAttribs );
+			
+			int pbufferAttribs[] = {
+    			GLX_PBUFFER_WIDTH,  32,
+    			GLX_PBUFFER_HEIGHT, 32,
+    			None
+			};
+
+			GLXPbuffer pbuffer = glXCreatePbuffer( display, fbConfigs[0], pbufferAttribs );
+
+			glXMakeContextCurrent( display, pbuffer, pbuffer, openGLContext );
+
+			XFree( fbConfigs );
+			XSync( display, False );
+
 #endif
 
-			/// \todo We're making a window here to make glut initialise a gl context,
-			/// so that glewInit() works. But we should figure out how to initialise
-			/// GL ourselves and avoid the annoying window popping up at the beginning.
-			int window = glutCreateWindow( "IECoreGL Initial Window" );
-			glutDisplayFunc( nullDisplayFunc );
-			glutDestroyWindow( window );
 		}
-		GLenum initStatus = glewInit();
+
+		const GLenum initStatus = glewInit();
 		if( initStatus!=GLEW_OK )
 		{
 			IECore::msg( IECore::Msg::Error, "IECoreGL::init", boost::format( "GLEW initialisation failed (%s)." ) % glewGetErrorString( initStatus ) );


### PR DESCRIPTION
We were only using it to create a context suitable for running the tests and other standalone programs, and it always popped up a window annoyingly.

This is the first of a series of pull requests where I'll be bringing stuff over from the coreGLMac branch until we have master building on both Mac and Linux again. The history on coreGLMac is a mess due to me stumbling around in the dark learning git and inconvenient truths about OpenGL on OSX all at the same time. So I'll be making new, more sensible, commits rather than making one big merge request.
