### PR TITLE
Replaced OpenGL 3 function calls with their 2.1 extensions

### DIFF
--- a/src/IECoreGL/CurvesPrimitive.cpp
+++ b/src/IECoreGL/CurvesPrimitive.cpp
@@ -236,7 +236,7 @@ void CurvesPrimitive::renderInstances( size_t numInstances ) const
 {
 	ensureVertIds();
 	Buffer::ScopedBinding indexBinding( *(m_memberData->vertIdsBuffer), GL_ELEMENT_ARRAY_BUFFER );
-	glDrawElementsInstanced( GL_LINES, m_memberData->numVertIds, GL_UNSIGNED_INT, 0, numInstances );
+	glDrawElementsInstancedARB( GL_LINES, m_memberData->numVertIds, GL_UNSIGNED_INT, 0, numInstances );
 }
 
 const std::string &CurvesPrimitive::cubicLinesGeometrySource()

--- a/src/IECoreGL/DiskPrimitive.cpp
+++ b/src/IECoreGL/DiskPrimitive.cpp
@@ -102,7 +102,7 @@ void DiskPrimitive::addPrimitiveVariable( const std::string &name, const IECore:
 
 void DiskPrimitive::renderInstances( size_t numInstances ) const
 {
-	glDrawArraysInstanced( GL_TRIANGLE_FAN, 0, m_nPoints, numInstances );
+	glDrawArraysInstancedARB( GL_TRIANGLE_FAN, 0, m_nPoints, numInstances );
 }
 
 Imath::Box3f DiskPrimitive::bound() const

--- a/src/IECoreGL/MeshPrimitive.cpp
+++ b/src/IECoreGL/MeshPrimitive.cpp
@@ -153,7 +153,7 @@ void MeshPrimitive::addPrimitiveVariable( const std::string &name, const IECore:
 void MeshPrimitive::renderInstances( size_t numInstances ) const
 {
 	unsigned vertexCount = m_memberData->vertIds->readable().size();
-	glDrawArraysInstanced( GL_TRIANGLES, 0, vertexCount, numInstances );
+	glDrawArraysInstancedARB( GL_TRIANGLES, 0, vertexCount, numInstances );
 }
 
 Imath::Box3f MeshPrimitive::bound() const

--- a/src/IECoreGL/PointsPrimitive.cpp
+++ b/src/IECoreGL/PointsPrimitive.cpp
@@ -305,7 +305,7 @@ void PointsPrimitive::render( const State *currentState, IECore::TypeId style ) 
 
 void PointsPrimitive::renderInstances( size_t numInstances ) const
 {
-	glDrawArraysInstanced( GL_POINTS, 0, m_memberData->points->readable().size(), numInstances );
+	glDrawArraysInstancedARB( GL_POINTS, 0, m_memberData->points->readable().size(), numInstances );
 }
 
 Imath::Box3f PointsPrimitive::bound() const

--- a/src/IECoreGL/QuadPrimitive.cpp
+++ b/src/IECoreGL/QuadPrimitive.cpp
@@ -109,7 +109,7 @@ void QuadPrimitive::renderInstances( size_t numInstances ) const
 	}
 	
 	Buffer::ScopedBinding indexBinding( *m_vertIdsBuffer, GL_ELEMENT_ARRAY_BUFFER );
-	glDrawElementsInstanced( GL_TRIANGLES, m_vertIds->readable().size(), GL_UNSIGNED_INT, 0, numInstances );
+	glDrawElementsInstancedARB( GL_TRIANGLES, m_vertIds->readable().size(), GL_UNSIGNED_INT, 0, numInstances );
 }
 
 Imath::Box3f QuadPrimitive::bound() const

--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -423,15 +423,15 @@ struct Shader::Setup::MemberData : public IECore::RefCounted
 		virtual void bind()
 		{
 			Buffer::ScopedBinding binding( *m_buffer );
-			glEnableVertexAttribArray( m_attributeIndex );
-			glVertexAttribPointer( m_attributeIndex, m_size, m_type, false, 0, 0 );
-			glVertexAttribDivisor( m_attributeIndex, m_divisor );
+			glEnableVertexAttribArrayARB( m_attributeIndex );
+			glVertexAttribPointerARB( m_attributeIndex, m_size, m_type, false, 0, 0 );
+			glVertexAttribDivisorARB( m_attributeIndex, m_divisor );
 		}
 		
 		virtual void unbind()
 		{
-			glVertexAttribDivisor( m_attributeIndex, 0 );
-			glDisableVertexAttribArray( m_attributeIndex );
+			glVertexAttribDivisorARB( m_attributeIndex, 0 );
+			glDisableVertexAttribArrayARB( m_attributeIndex );
 		}
 		
 		private :

--- a/src/IECoreGL/SpherePrimitive.cpp
+++ b/src/IECoreGL/SpherePrimitive.cpp
@@ -143,7 +143,7 @@ void SpherePrimitive::renderInstances( size_t numInstances ) const
 	}
 	
 	Buffer::ScopedBinding indexBinding( *m_vertIdsBuffer, GL_ELEMENT_ARRAY_BUFFER );
-	glDrawElementsInstanced( GL_TRIANGLES, m_vertIds->readable().size(), GL_UNSIGNED_INT, 0, numInstances );
+	glDrawElementsInstancedARB( GL_TRIANGLES, m_vertIds->readable().size(), GL_UNSIGNED_INT, 0, numInstances );
 }
 
 Imath::Box3f SpherePrimitive::bound() const


### PR DESCRIPTION
On Linux we can make a 3.3 context with backwards compatibility with previous extensions. On OSX we can either create a 3.2 context with /no backwards compatibility/ or we can create a 2.1 context. Since we're still using some 2.1 functionality which hasn't made it into 3, we need to use a 2.1 context on OSX, so we use one everywhere to keep things maintainable.

In the longer term the best solution is to move to pure OpenGL 3.3 everywhere.
