### PR TITLE
Defaulted ParticleReader realType parameter to "float".

### DIFF
--- a/src/IECore/ParticleMeshOp.cpp
+++ b/src/IECore/ParticleMeshOp.cpp
@@ -396,6 +396,8 @@ ObjectPtr ParticleMeshOp::doOperation( const CompoundObject * operands )
 		throw IOException( "Could not create reader for particle cache file" );
 	}
 
+	reader->realTypeParameter()->setValue( "native" );
+
 	ConstObjectPtr positionAttributeData = positionAttributeParameter()->getValue();
 	const std::string &positionAttribute = staticPointerCast<const StringData>(positionAttributeData)->readable();
 	DataPtr positionData = reader->readAttribute( positionAttribute );

--- a/src/IECore/ParticleReader.cpp
+++ b/src/IECore/ParticleReader.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2010, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -84,7 +84,7 @@ ParticleReader::ParticleReader( const std::string &description )
 	m_realTypeParameter = new IntParameter(
 		"realType",
 		"The type of data to use to represent real values.",
-		Native,
+		Float,
 		Native,
 		Double,
 		realTypePresets,

--- a/test/IECore/NParticleReader.py
+++ b/test/IECore/NParticleReader.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2009, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2009-2013, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -49,6 +49,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleFrame2.mc" )
 		self.assertEqual( type( r ), IECore.NParticleReader )
+		r.parameters()["realType"].setValue( "native" )
 
 		self.assertEqual( r.numParticles(), 4 )
 		self.assertEqual( len(r.frameTimes()), 1 )
@@ -93,6 +94,7 @@ class TestNParticleReader( unittest.TestCase ) :
 		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleFrame2.mc" )
 		self.assertEqual( type( r ), IECore.NParticleReader )
 		r["convertPrimVarNames"].setValue( IECore.BoolData( False ) )
+		r["realType"].setValue( "native" )
 		self.assertFalse( r.parameters()["convertPrimVarNames"].getTypedValue() )
 
 		self.assertEqual( r.numParticles(), 4 )
@@ -128,6 +130,7 @@ class TestNParticleReader( unittest.TestCase ) :
 	def testMultiFrameFiles( self ) :
 
 		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleMultipleFrames.mc" )
+		r.parameters()["realType"].setValue( "native" )
 		
 		self.assertTrue( r.parameters()["convertPrimVarNames"].getTypedValue() )
 		self.assertEqual( len(r.frameTimes()), 10 )
@@ -305,6 +308,7 @@ class TestNParticleReader( unittest.TestCase ) :
 		
 		r = IECore.Reader.create( "test/IECore/data/iffFiles/nClothFrame3.mc" )
 		self.assertEqual( type( r ), IECore.NParticleReader )
+		r.parameters()["realType"].setValue( "native" )
 		
 		self.assertEqual( r.numParticles(), 349 )
 		self.assertEqual( len(r.frameTimes()), 1 )

--- a/test/IECore/PDCReader.py
+++ b/test/IECore/PDCReader.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2007-2010, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -31,7 +31,9 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
+
 from __future__ import with_statement
+
 import unittest
 import sys
 import os
@@ -50,6 +52,7 @@ class TestPDCReader( unittest.TestCase ) :
 	def testReadWithPrimVarConversion( self ) :
 
 		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r.parameters()["realType"].setValue( "native" )
 		self.assertEqual( type( r ), IECore.PDCParticleReader )
 		self.assertTrue( r.parameters()["convertPrimVarNames"].getTypedValue() )
 		
@@ -118,6 +121,7 @@ class TestPDCReader( unittest.TestCase ) :
 		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
 		self.assertEqual( type( r ), IECore.PDCParticleReader )
 		
+		r["realType"].setValue( "native" )
 		r["convertPrimVarNames"].setValue( IECore.BoolData( False ) )
 		self.assertFalse( r.parameters()["convertPrimVarNames"].getTypedValue() )
 

--- a/test/IECore/PDCWriter.py
+++ b/test/IECore/PDCWriter.py
@@ -86,6 +86,7 @@ class TestPDCWriter( unittest.TestCase ) :
 		w.write()
 
 		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r.parameters()["realType"].setValue( "native" )
 		p2 = r.read()
 
 		self.assertEqual( p, p2 )
@@ -102,6 +103,7 @@ class TestPDCWriter( unittest.TestCase ) :
 		w.write()
 
 		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r.parameters()["realType"].setValue( "native" )
 		p2 = r.read()
 
 		self.assertEqual( p.keys(), p2.keys() )
@@ -122,9 +124,9 @@ class TestPDCWriter( unittest.TestCase ) :
 
 		self.assertEqual( p.keys(), p2.keys() )
 		
-		# we can't expect them to come back as colours, because there's not support for that in pdcs - they should therefore come back as double vectors
-		self.assertEqual( p2["color3f"].data, IECore.V3dData( IECore.V3d( 1 ) ) )
-		self.assertEqual( p2["color3fVector"].data, IECore.V3dVectorData( [ IECore.V3d( 1 ), IECore.V3d( 2 ), IECore.V3d( 3 ) ] ) )
+		# we can't expect them to come back as colours, because there's not support for that in pdcs - they should therefore come back as float vectors
+		self.assertEqual( p2["color3f"].data, IECore.V3fData( IECore.V3f( 1 ) ) )
+		self.assertEqual( p2["color3fVector"].data, IECore.V3fVectorData( [ IECore.V3f( 1 ), IECore.V3f( 2 ), IECore.V3f( 3 ) ] ) )
 	
 	def tearDown( self ) :
 


### PR DESCRIPTION
This means that all PointsPrimitives loaded with default settings are now compatible with our Renderer backends. This makes the Readers much easier to use in Gaffer, and makes it possible to preview particle caches without type specific code.

Fixes #69.
