### PR TITLE
FromHoudiniGroupConverter ignores internal groups

### DIFF
--- a/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
@@ -128,12 +128,17 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniGroupConverter::canConve
 	for ( int i=0; i < primGroups.entries(); ++i )
 	{
 		const GA_ElementGroup *group = primGroups[i];
+		if ( group->getInternal() )
+		{
+			continue;
+		}
+		
 		if ( group->entries() == numPrims )
 		{
 			return Admissible;
 		}
 		
-		externalGroups |= ( !group->getInternal() );
+		externalGroups = true;
 	}
 	
 	if ( externalGroups )


### PR DESCRIPTION
This fixes a bug where the group converter would take preference just because of the selection state. I've verified the fix, but unfortunately I can't write a test case, because there doesn't appear to be any way to create internal groups from python...
