### PR TITLE
Fixed MurmurHash bug where empty strings had no effect on a hash.

### DIFF
--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -112,7 +112,7 @@ inline MurmurHash &MurmurHash::append( const char *data )
 
 inline MurmurHash &MurmurHash::append( const std::string &data )
 {
-	append( data.c_str(), data.size(), sizeof( char ) );
+	append( data.c_str(), data.size() + 1, sizeof( char ) );
 	return *this;
 }
 

--- a/test/IECore/MurmurHashTest.py
+++ b/test/IECore/MurmurHashTest.py
@@ -69,7 +69,7 @@ class MurmurHashTest( unittest.TestCase ) :
 		h.append( "the quick brown fox jumps over the lazy dog" )
 		self.assertEqual(
 			str( h ),
-			"bce4e9fee2ad86b30ae2e374406e4b7f",
+			"f476fee540bfc268dc36e7f3d95ddb72",
 		)
 
 		h = IECore.MurmurHash()
@@ -199,7 +199,23 @@ class MurmurHashTest( unittest.TestCase ) :
 		
 		h2.copyFrom( h1 )
 		self.assertEqual( h1, h2 )
-			
+	
+	def testHashOfEmptyStrings( self ) :
+	
+		h1 = IECore.MurmurHash()
+		h2 = IECore.MurmurHash()
+		
+		h2.append( "" )
+		self.assertNotEqual( h1, h2 )
+		
+		h1 = IECore.MurmurHash()
+		h2 = IECore.MurmurHash()
+		
+		h1.append( IECore.StringVectorData( [ "" ] ) )
+		h2.append( IECore.StringVectorData( [ "", "" ] ) )
+		
+		self.assertNotEqual( h1, h2 )
+		
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
The terminating null character is now considered to be part of the string. This is consistent with the general principle that the low level MurmurHash code should hash the contents of memory (with type information provided only to allow byte order to be dealt with properly).

It could be argued that the other array hashes should also include some sort of terminator to allow empty arrays to have some effect on the hash, but I'm not sure that that's right. At the low level I would consider that they shouldn't, because then they represent more than what's there in memory, and at the high level with VectorData we have additional information to ensure the hash changes anyway.
