### PR TITLE
Improved precision of CameraController operations.

### DIFF
--- a/include/IECore/CameraController.h
+++ b/include/IECore/CameraController.h
@@ -81,7 +81,7 @@ class CameraController : public boost::noncopyable
 		/// Computes the points on the near and far clipping planes that correspond
 		/// with the specified raster position. Points are computed in world space.
 		/// \todo Accept a V2f to provide extra precision and make this method const.
-		void unproject( const Imath::V2i rasterPosition, Imath::V3f &near, Imath::V3f &far );
+		void unproject( const Imath::V2f rasterPosition, Imath::V3f &near, Imath::V3f &far );
 		/// Projects the point in world space into a raster space position.
 		Imath::V2f project( const Imath::V3f &worldPosition ) const;
 		
@@ -99,19 +99,19 @@ class CameraController : public boost::noncopyable
 			Dolly
 		};
 		/// Starts a motion of the specified type.
-		void motionStart( MotionType motion, const Imath::V2i &startPosition );
+		void motionStart( MotionType motion, const Imath::V2f &startPosition );
 		/// Updates the camera position based on a changed mouse position. Can only
 		/// be called after motionStart() and before motionEnd().
-		void motionUpdate( const Imath::V2i &newPosition );
+		void motionUpdate( const Imath::V2f &newPosition );
 		/// End the current motion, ready to call motionStart() again if required.
-		void motionEnd( const Imath::V2i &endPosition );
+		void motionEnd( const Imath::V2f &endPosition );
 		//@}
 
 	private:
 
-		void track( const Imath::V2i &p );
-		void tumble( const Imath::V2i &p );
-		void dolly( const Imath::V2i &p );
+		void track( const Imath::V2f &p );
+		void tumble( const Imath::V2f &p );
+		void dolly( const Imath::V2f &p );
 
 		IE_CORE_FORWARDDECLARE( MemberData );
 

--- a/src/IECore/CameraController.cpp
+++ b/src/IECore/CameraController.cpp
@@ -62,7 +62,7 @@ struct CameraController::MemberData : public IECore::RefCounted
 
 	// motion state
 	MotionType motionType;
-	Imath::V2i motionStart;
+	Imath::V2f motionStart;
 	Imath::M44f motionMatrix;
 	float motionCentreOfInterest;
 	Imath::Box2f motionScreenWindow;
@@ -204,7 +204,7 @@ void CameraController::frame( const Imath::Box3f &box, const Imath::V3f &viewDir
 	m_data->screenWindow->writable() = screenWindow;
 }
 
-void CameraController::unproject( const Imath::V2i rasterPosition, Imath::V3f &near, Imath::V3f &far )
+void CameraController::unproject( const Imath::V2f rasterPosition, Imath::V3f &near, Imath::V3f &far )
 {
 	V2f ndc = V2f( rasterPosition ) / m_data->resolution->readable();
 	const Box2f &screenWindow = m_data->screenWindow->readable();
@@ -267,7 +267,7 @@ Imath::V2f CameraController::project( const Imath::V3f &worldPosition ) const
 	}
 }
 
-void CameraController::motionStart( MotionType motion, const Imath::V2i &startPosition )
+void CameraController::motionStart( MotionType motion, const Imath::V2f &startPosition )
 {
 	m_data->motionType = motion;
 	m_data->motionStart = startPosition;
@@ -276,7 +276,7 @@ void CameraController::motionStart( MotionType motion, const Imath::V2i &startPo
 	m_data->motionCentreOfInterest = m_data->centreOfInterest;
 }
 
-void CameraController::motionUpdate( const Imath::V2i &newPosition )
+void CameraController::motionUpdate( const Imath::V2f &newPosition )
 {
 	switch( m_data->motionType )
 	{
@@ -294,7 +294,7 @@ void CameraController::motionUpdate( const Imath::V2i &newPosition )
 	}
 }
 
-void CameraController::motionEnd( const Imath::V2i &endPosition )
+void CameraController::motionEnd( const Imath::V2f &endPosition )
 {
 	switch( m_data->motionType )
 	{
@@ -313,15 +313,15 @@ void CameraController::motionEnd( const Imath::V2i &endPosition )
 	m_data->motionType = None;
 }
 
-void CameraController::track( const Imath::V2i &p )
+void CameraController::track( const Imath::V2f &p )
 {
 	V2i resolution = m_data->resolution->readable();
 	Box2f screenWindow = m_data->screenWindow->readable();
 
-	V2i d = p - m_data->motionStart;
+	V2f d = p - m_data->motionStart;
 	V3f translate( 0.0f );
-	translate.x = -screenWindow.size().x * (float)d.x/(float)resolution.x;
-	translate.y = screenWindow.size().y * (float)d.y/(float)resolution.y;
+	translate.x = -screenWindow.size().x * d.x/(float)resolution.x;
+	translate.y = screenWindow.size().y * d.y/(float)resolution.y;
 	if( m_data->projection->readable()=="perspective" && m_data->fov )
 	{
 		translate *= tan( M_PI * m_data->fov->readable() / 360.0f ) * (float)m_data->centreOfInterest;
@@ -331,9 +331,9 @@ void CameraController::track( const Imath::V2i &p )
 	m_data->transform->matrix = t;
 }
 
-void CameraController::tumble( const Imath::V2i &p )
+void CameraController::tumble( const Imath::V2f &p )
 {
-	V2i d = p - m_data->motionStart;
+	V2f d = p - m_data->motionStart;
 
 	V3f centreOfInterestInWorld = V3f( 0, 0, -m_data->centreOfInterest ) * m_data->motionMatrix;
 	V3f xAxisInWorld = V3f( 1, 0, 0 );
@@ -355,7 +355,7 @@ void CameraController::tumble( const Imath::V2i &p )
 	m_data->transform->matrix = m_data->motionMatrix * t;
 }
 
-void CameraController::dolly( const Imath::V2i &p )
+void CameraController::dolly( const Imath::V2f &p )
 {
 	V2i resolution = m_data->resolution->readable();
 	V2f dv = V2f( (p - m_data->motionStart) ) / resolution;

--- a/src/IECorePython/CameraControllerBinding.cpp
+++ b/src/IECorePython/CameraControllerBinding.cpp
@@ -48,7 +48,7 @@ using namespace IECore;
 namespace IECorePython
 {
 
-static tuple unproject( CameraController &c, Imath::V2i &p )
+static tuple unproject( CameraController &c, Imath::V2f &p )
 {
 	Imath::V3f near, far;
 	c.unproject( p, near, far );

--- a/test/IECore/CameraControllerTest.py
+++ b/test/IECore/CameraControllerTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2011, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2011-2013, Image Engine Design Inc. All rights reserved.
 #  Copyright (c) 2012, John Haddon. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -49,15 +49,15 @@ class CameraControllerTest( unittest.TestCase ) :
 		
 		controller = IECore.CameraController( camera )
 		
-		near, far = controller.unproject( IECore.V2i( 0, 0 ) )
+		near, far = controller.unproject( IECore.V2f( 0, 0 ) )
 		self.assertEqual( near, IECore.V3f( -2, 1, -.1 ) )
 		self.assertEqual( far, IECore.V3f( -2, 1, -10 ) )
 		
-		near, far = controller.unproject( IECore.V2i( 500, 250 ) )
+		near, far = controller.unproject( IECore.V2f( 500, 250 ) )
 		self.assertEqual( near, IECore.V3f( 2, -1, -.1 ) )
 		self.assertEqual( far, IECore.V3f( 2, -1, -10 ) )
 		
-		near, far = controller.unproject( IECore.V2i( 250, 125 ) )
+		near, far = controller.unproject( IECore.V2f( 250, 125 ) )
 		self.assertEqual( near, IECore.V3f( 0, 0, -.1 ) )
 		self.assertEqual( far, IECore.V3f( 0, 0, -10 ) )
 
@@ -72,15 +72,15 @@ class CameraControllerTest( unittest.TestCase ) :
 		
 		controller = IECore.CameraController( camera )
 				
-		near, far = controller.unproject( IECore.V2i( 0, 0 ) )
+		near, far = controller.unproject( IECore.V2f( 0, 0 ) )
 		self.assertEqual( near, IECore.V3f( -.1, .05, -.1 ) )
 		self.assertEqual( far, IECore.V3f( -10, 5, -10 ) )
 		
-		near, far = controller.unproject( IECore.V2i( 500, 250 ) )
+		near, far = controller.unproject( IECore.V2f( 500, 250 ) )
 		self.assertEqual( near, IECore.V3f( .1, -.05, -.1 ) )
 		self.assertEqual( far, IECore.V3f( 10, -5, -10 ) )
 		
-		near, far = controller.unproject( IECore.V2i( 250, 125 ) )
+		near, far = controller.unproject( IECore.V2f( 250, 125 ) )
 		self.assertEqual( near, IECore.V3f( 0, 0, -.1 ) )
 		self.assertEqual( far, IECore.V3f( 0, 0, -10 ) )
 
@@ -96,7 +96,7 @@ class CameraControllerTest( unittest.TestCase ) :
 	
 		r = IECore.Rand48()
 		for i in range( 0, 100 ) :
-			rasterPosition = IECore.V2i( r.nexti() % 500, r.nexti() % 250 )
+			rasterPosition = IECore.V2f( r.nexti() % 500, r.nexti() % 250 )
 			near, far = controller.unproject( rasterPosition )
 			nearProjected = controller.project( near )
 			farProjected = controller.project( far )
@@ -120,7 +120,7 @@ class CameraControllerTest( unittest.TestCase ) :
 	
 		r = IECore.Rand48()
 		for i in range( 0, 100 ) :
-			rasterPosition = IECore.V2i( r.nexti() % 500, r.nexti() % 250 )
+			rasterPosition = IECore.V2f( r.nexti() % 500, r.nexti() % 250 )
 			near, far = controller.unproject( rasterPosition )
 			nearProjected = controller.project( near )
 			farProjected = controller.project( far )
@@ -140,8 +140,8 @@ class CameraControllerTest( unittest.TestCase ) :
 		
 		controller = IECore.CameraController( camera )
 		
-		controller.motionStart( controller.MotionType.Track, IECore.V2i( 0 ) )
-		controller.motionEnd( IECore.V2i( 10 ) )
+		controller.motionStart( controller.MotionType.Track, IECore.V2f( 0 ) )
+		controller.motionEnd( IECore.V2f( 10 ) )
 		
 		self.assertNotEqual( transform.transform(), originalMatrix )
 		


### PR DESCRIPTION
Raster positions are now represented as V2f rather than V2i, providing subpixel accuracy. This is needed for this Gaffer pull request :

https://github.com/ImageEngine/gaffer/pull/506
