### PR TITLE
Fixed erroneous compute on SceneShape outputObjects.

### DIFF
--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -133,6 +133,7 @@ class SceneShapeInterface: public MPxComponentShape
 		static MObject aTime;
 		static MObject aOutTime;
 		static MObject aOutputObjects;
+		static MObject aObjectDependency;
 		static MObject aAttributes;
 		static MObject aTransform;
 		static MObject aBound;
@@ -218,6 +219,10 @@ class SceneShapeInterface: public MPxComponentShape
 		NameToGroupMap m_nameToGroupMap;
 		HashToName m_hashToName;
 		InstanceArray m_instances;
+		
+		IE_CORE_FORWARDDECLARE( PostLoadCallback );
+		PostLoadCallbackPtr m_postLoadCallback;
+
 };
 
 }


### PR DESCRIPTION
A Maya bug causes mesh attributes to compute on scene open, even when nothing should be
pulling on them. While dynamic attributes can work around this issue for single meshes,
arrays of meshes suffer from the erroneous compute as either static or dynamic attributes.

We work around the problem by adding a PostLoadCallback if the node was created while the
scene is being read from disk. This callback is used to short circuit the compute which
was triggered on scene open. Since the compute may have actually been necessary, we use
this dummy dependency attribute to dirty the output object attributes immediately following
load. At this point the callback deletes itself, and the newly dirtied output objects will
re-compute if something was actually pulling on them.
