### PR TITLE
Adding setPresets() to Parameter class.

### DIFF
--- a/include/IECore/CompoundParameter.h
+++ b/include/IECore/CompoundParameter.h
@@ -71,12 +71,14 @@ class CompoundParameter : public Parameter
 		/// of all the child objects.
 		/// \threading It is not safe to call this from multiple concurrent threads.
 		virtual const Object *defaultValue() const;
+		/// \deprecated Use getPresets instead.
+		virtual const PresetsContainer &presets() const;
 		/// If true was passed to adoptChildPresets at construction, then update the presets
 		/// with the intersection of the presets of all the child parameters, otherwise returns
 		/// an empty container or the presets defined by setPresets(). 
 		/// Please note that the map returned may differ between one call
 		/// to presets() and the next.
-		virtual const PresetsContainer &presets() const;
+		virtual const PresetsContainer &getPresets() const;
 		/// Defines presets for this Parameter.
 		/// Throws an exception if true was passed to adoptChildPresets at construction.
 		virtual void setPresets( const PresetsContainer &presets );

--- a/include/IECore/Parameter.h
+++ b/include/IECore/Parameter.h
@@ -78,8 +78,10 @@ class Parameter : public RunTimeTyped
 		const std::string &description() const;
 		/// Returns the default value for this parameter.
 		virtual const Object *defaultValue() const;
-		/// Returns the presets for this parameter.
+		/// \deprecated Use getPresets instead.
 		virtual const PresetsContainer &presets() const;
+		/// Returns the presets for this parameter.
+		virtual const PresetsContainer &getPresets() const;
 		/// Overrides the presets for this parameter.
 		virtual void setPresets( const PresetsContainer &presets );
 		/// Returns true if this parameter only accepts

--- a/src/IECore/CompoundParameter.cpp
+++ b/src/IECore/CompoundParameter.cpp
@@ -74,13 +74,18 @@ const Object *CompoundParameter::defaultValue() const
 
 const Parameter::PresetsContainer &CompoundParameter::presets() const
 {
+	return getPresets();
+}
+
+const Parameter::PresetsContainer &CompoundParameter::getPresets() const
+{
 	if( !m_adoptChildPresets )
 	{
-		return Parameter::presets();
+		return Parameter::getPresets();
 	}
 
 	// naughty? nah! it gives the right semantics to an outside observer
-	PresetsContainer &pr = const_cast<PresetsContainer &>( Parameter::presets() );
+	PresetsContainer &pr = const_cast<PresetsContainer &>( Parameter::getPresets() );
 	pr.clear();
 	if( !m_namesToParameters.size() )
 	{
@@ -88,12 +93,12 @@ const Parameter::PresetsContainer &CompoundParameter::presets() const
 	}
 
 	// get a references for each child preset map.
-	// we only want to call presets() once for
+	// we only want to call getPresets() once for
 	// each child as the map returned may change between calls.
 	vector<const PresetsContainer *> childPresets;
 	for( size_t i=0; i<m_parameters.size(); i++ )
 	{
-		childPresets.push_back( &(m_parameters[i]->presets()) );
+		childPresets.push_back( &(m_parameters[i]->getPresets()) );
 	}
 	
 	// find the intersection of all the child preset names

--- a/src/IECore/Parameter.cpp
+++ b/src/IECore/Parameter.cpp
@@ -93,6 +93,11 @@ const Object *Parameter::defaultValue() const
 
 const Parameter::PresetsContainer &Parameter::presets() const
 {
+	return getPresets();
+}
+
+const Parameter::PresetsContainer &Parameter::getPresets() const
+{
 	return m_presets;
 }
 
@@ -150,7 +155,7 @@ bool Parameter::valueValid( const Object *value, std::string *reason ) const
 	{
 		return true;
 	}
-	const PresetsContainer &pr = presets();
+	const PresetsContainer &pr = getPresets();
 	for( PresetsContainer::const_iterator it = pr.begin(); it!=pr.end(); it++ )
 	{
 		if( it->second->isEqualTo( value ) )
@@ -206,7 +211,7 @@ void Parameter::setValidatedValue( ObjectPtr value )
 
 void Parameter::setValue( const std::string &presetName )
 {
-	const PresetsContainer &pr = presets();
+	const PresetsContainer &pr = getPresets();
 	
 	PresetsContainer::const_iterator it;
 	for( it=pr.begin(); it != pr.end(); it++ )
@@ -256,7 +261,7 @@ std::string Parameter::getCurrentPresetName() const
 	// didn't have to do a copy of the value. but that breaks with CompoundParameter
 	// as it builds the value dynamically in getValue().
 	const Object *currentValue = getValue();
-	const PresetsContainer &pr = presets();
+	const PresetsContainer &pr = getPresets();
 	PresetsContainer::const_iterator it;
 	for( it=pr.begin(); it!=pr.end(); it++ )
 	{

--- a/src/IECoreMaya/FromMayaMeshConverter.cpp
+++ b/src/IECoreMaya/FromMayaMeshConverter.cpp
@@ -601,10 +601,10 @@ IECore::PrimitivePtr FromMayaMeshConverter::doPrimitiveConversion( MFnMesh &fnMe
 			unsigned int interpolationIndex = interpolationPlug.asInt(MDGContext::fsNormal, &st);
 			if ( st )
 			{
-				if ( interpolationIndex < m_interpolation->presets().size() - 1 )
+				if ( interpolationIndex < m_interpolation->getPresets().size() - 1 )
 				{
 					// convert interpolation index to the preset value
-					interpolation = staticPointerCast< StringData >( m_interpolation->presets()[interpolationIndex].second )->readable();
+					interpolation = staticPointerCast< StringData >( m_interpolation->getPresets()[interpolationIndex].second )->readable();
 				}
 				else
 				{

--- a/src/IECoreMaya/ToMayaMeshConverter.cpp
+++ b/src/IECoreMaya/ToMayaMeshConverter.cpp
@@ -495,7 +495,7 @@ bool ToMayaMeshConverter::setMeshInterpolationAttribute( MObject &object, std::s
 	int interpolationValue = 0;
 
 	FromMayaMeshConverter fromMaya(object);
-	const IECore::Parameter::PresetsContainer &presets = fromMaya.interpolationParameter()->presets();
+	const IECore::Parameter::PresetsContainer &presets = fromMaya.interpolationParameter()->getPresets();
 	IECore::Parameter::PresetsContainer::const_iterator it;
 
 	if ( interpolation != "default" )

--- a/src/IECoreNuke/PresetsOnlyParameterHandler.cpp
+++ b/src/IECoreNuke/PresetsOnlyParameterHandler.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2010-2011, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2010-2013, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -49,7 +49,8 @@ void PresetsOnlyParameterHandler::knobs( const IECore::Parameter *parameter, con
 	if( f.makeKnobs() )
 	{
 		m_names.clear();
-		for( Parameter::PresetsContainer::const_iterator it = parameter->presets().begin(); it!=parameter->presets().end(); it++ )
+		const Parameter::PresetsContainer &presets = parameter->getPresets();
+		for( Parameter::PresetsContainer::const_iterator it = presets.begin(); it!=presets.end(); it++ )
 		{
 			if( it->second->isEqualTo( parameter->defaultValue() ) )
 			{
@@ -79,12 +80,12 @@ void PresetsOnlyParameterHandler::setParameterValue( IECore::Parameter *paramete
 	{
 		presetIndex = (int)m_knob->get_value();
 	}
-	parameter->setValue( parameter->presets()[m_storage].second );
+	parameter->setValue( parameter->getPresets()[m_storage].second );
 }
 
 void PresetsOnlyParameterHandler::setKnobValue( const IECore::Parameter *parameter )
 {
-	const Parameter::PresetsContainer &presets = parameter->presets();
+	const Parameter::PresetsContainer &presets = parameter->getPresets();
 	std::string currentPresetName = parameter->getCurrentPresetName();
 	size_t presetIndex = 0;
 	for( Parameter::PresetsContainer::const_iterator it = presets.begin(); it!=presets.end(); it++, presetIndex++ )

--- a/src/IECorePython/ParameterBinding.cpp
+++ b/src/IECorePython/ParameterBinding.cpp
@@ -75,10 +75,10 @@ static void validate( Parameter &that, ObjectPtr value )
 	that.validate( value.get() );
 }
 
-static dict presets( Parameter &that )
+static dict getPresets( Parameter &that )
 {
 	dict result;
-	const Parameter::PresetsContainer &p = that.presets();
+	const Parameter::PresetsContainer &p = that.getPresets();
 	for( Parameter::PresetsContainer::const_iterator it=p.begin(); it!=p.end(); it++ )
 	{
 		result[it->first] = it->second->copy();
@@ -94,7 +94,7 @@ static void setPresets( Parameter &p, const object &presets )
 static boost::python::tuple presetNames( const Parameter &that )
 {
 	boost::python::list result;
-	const Parameter::PresetsContainer &p = that.presets();
+	const Parameter::PresetsContainer &p = that.getPresets();
 	for( Parameter::PresetsContainer::const_iterator it=p.begin(); it!=p.end(); it++ )
 	{
 		result.append( it->first );
@@ -105,7 +105,7 @@ static boost::python::tuple presetNames( const Parameter &that )
 static boost::python::tuple presetValues( const Parameter &that )
 {
 	boost::python::list result;
-	const Parameter::PresetsContainer &p = that.presets();
+	const Parameter::PresetsContainer &p = that.getPresets();
 	for( Parameter::PresetsContainer::const_iterator it=p.begin(); it!=p.end(); it++ )
 	{
 		result.append( it->second->copy() );
@@ -166,7 +166,8 @@ void bindParameter()
 		.def( "validate", (void (Parameter::*)() const)&Parameter::validate )
 		.def( "validate", &validate )
 		.add_property( "presetsOnly", &Parameter::presetsOnly )
-		.def( "presets", &presets, "Returns a dictionary containing presets for the parameter." )
+		.def( "presets", &getPresets, "Deprecated function. Use getPresets() instead." )
+		.def( "getPresets", &getPresets, "Returns a dictionary containing presets for the parameter." )
 		.def( "setPresets", &setPresets, "Sets the presets for the parameter from a dictionary." )
 		.def( "presetNames", &presetNames, "Returns a tuple containing the names of all presets for the parameter." )
 		.def( "presetValues", &presetValues, "Returns a tuple containing the values of all presets for the parameter." )

--- a/test/IECore/CompoundParameterTest.py
+++ b/test/IECore/CompoundParameterTest.py
@@ -179,7 +179,7 @@ class CompoundParameterTest( unittest.TestCase ) :
 
 		self.assertEqual( p.presetsOnly, True )
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 3 )
 		self.assert_( "one" in pr.keys() )
 		self.assert_( "two" in pr.keys() )
@@ -221,7 +221,7 @@ class CompoundParameterTest( unittest.TestCase ) :
 		)
 
 		self.assertEqual( p.presetsOnly, False )
-		self.assertEqual( len( p.presets() ), 0 )
+		self.assertEqual( len( p.getPresets() ), 0 )
 
 	def testLateValidation( self ) :
 
@@ -347,18 +347,18 @@ class CompoundParameterTest( unittest.TestCase ) :
 			members = []
 		)
 
-		self.assertEqual( p.presets(), {} )
+		self.assertEqual( p.getPresets(), {} )
 
 		p.addParameter( IntParameter( name = "i", description = "d", defaultValue = 10, presets = ( ( "one", 1 ), ( "two", 2 ) ) ) )
 
-		self.assertEqual( len( p.presets() ), 2 )
-		self.assertEqual( p.presets(), { "one" : CompoundObject( { "i" : IntData( 1 ) } ), "two" : CompoundObject( { "i" : IntData( 2 ) } ) } )
+		self.assertEqual( len( p.getPresets() ), 2 )
+		self.assertEqual( p.getPresets(), { "one" : CompoundObject( { "i" : IntData( 1 ) } ), "two" : CompoundObject( { "i" : IntData( 2 ) } ) } )
 
 		fParam = FloatParameter( name = "f", description = "d", defaultValue = 20, presets = ( ( "one", 1 ), ) )
 		p.addParameter( fParam )
 
-		self.assertEqual( len( p.presets() ), 1 )
-		self.assertEqual( p.presets(), { "one" : CompoundObject( { "i" : IntData( 1 ), "f" : FloatData( 1 ) } ) } )
+		self.assertEqual( len( p.getPresets() ), 1 )
+		self.assertEqual( p.getPresets(), { "one" : CompoundObject( { "i" : IntData( 1 ), "f" : FloatData( 1 ) } ) } )
 
 		p.insertParameter( IntParameter( name = "x", description = "x", defaultValue = 10 ), fParam )
 		self.assertEqual( p.keys(), [ "i", "x", "f" ] )
@@ -587,7 +587,7 @@ class CompoundParameterTest( unittest.TestCase ) :
 			],
 		)
 		
-		self.assertEqual( len( c.presets() ), 2 )
+		self.assertEqual( len( c.getPresets() ), 2 )
 		self.assertEqual( c.presetsOnly, True )
 		
 		# no adoption of presets
@@ -619,7 +619,7 @@ class CompoundParameterTest( unittest.TestCase ) :
 			adoptChildPresets = False,
 		)
 		
-		self.assertEqual( len( c.presets() ), 0 )
+		self.assertEqual( len( c.getPresets() ), 0 )
 		self.assertEqual( c.presetsOnly, False )
 		
 		# no adoption of presets without use of keyword parameters
@@ -653,7 +653,7 @@ class CompoundParameterTest( unittest.TestCase ) :
 			False,
 		)
 		
-		self.assertEqual( len( c.presets() ), 0 )
+		self.assertEqual( len( c.getPresets() ), 0 )
 		self.assertEqual( c.presetsOnly, False )
 		self.assertEqual( c.userData()["ud"].value, 10 )
 
@@ -672,11 +672,11 @@ class CompoundParameterTest( unittest.TestCase ) :
 				( "p2", p2 ),
 			]
 		)
-		pr = c.presets()
+		pr = c.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assertEqual( pr["p1"], p1 )
 		self.assertEqual( pr["p2"], p2 )
-		self.assertEqual( c.presetNames(), [ "p1", "p2" ] )
+		self.assertEqual( c.presetNames(), ( "p1", "p2" ) )
 		c.setValue("p1")
 		self.assertEqual( c.getValue(), p1 )
 		c.setValue("p2")

--- a/test/IECore/EXRImageWriter.py
+++ b/test/IECore/EXRImageWriter.py
@@ -223,11 +223,11 @@ class TestEXRWriter(unittest.TestCase):
 		img = r.read()
 
 		w = Writer.create( img, "test/IECore/data/exrFiles/output.exr" )
-		w['compression'].setValue( w['compression'].presets()['zip'] )
+		w['compression'].setValue( w['compression'].getPresets()['zip'] )
 		w.write()
 
 		w = EXRImageWriter()
-		w['compression'].setValue( w['compression'].presets()['zip'] )
+		w['compression'].setValue( w['compression'].getPresets()['zip'] )
 
 	def testBlindDataToHeader( self ) :
 

--- a/test/IECore/Parameters.py
+++ b/test/IECore/Parameters.py
@@ -98,7 +98,7 @@ class TestParameter( unittest.TestCase ) :
 			presetsOnly = True,
 		)
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 4 )
 		self.assertEqual( pr["p1"], FloatData( 40 ) )
 		self.assertEqual( pr["p2"], IntData( 60 ) )
@@ -127,7 +127,7 @@ class TestParameter( unittest.TestCase ) :
 			presetsOnly = True,
 		)
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 4 )
 		self.assertEqual( pr["p1"], FloatData( 40 ) )
 		self.assertEqual( pr["p2"], IntData( 60 ) )
@@ -137,7 +137,7 @@ class TestParameter( unittest.TestCase ) :
 		# overriding presets
 
 		p.setPresets( [] )
-		self.assertEqual( p.presets(), dict() )
+		self.assertEqual( p.getPresets(), dict() )
 
 		p.setPresets(
 			[
@@ -145,7 +145,7 @@ class TestParameter( unittest.TestCase ) :
 				( "p1", IntData( 60 ) ),
 			]
 		)
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assertEqual( pr["p5"], FloatData( 40 ) )
 		self.assertEqual( pr["p1"], IntData( 60 ) )
@@ -315,7 +315,7 @@ class TestNumericParameter( unittest.TestCase ) :
 			)
 		)
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 3 )
 		self.assertEqual( pr["one"], IntData( 1 ) )
 		self.assertEqual( pr["two"], IntData( 2 ) )
@@ -328,7 +328,7 @@ class TestNumericParameter( unittest.TestCase ) :
 				( "one", IntData( 1 ) ),
 			]
 		)
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assertEqual( pr["four"], IntData( 4 ) )
 		self.assertEqual( pr["one"], IntData( 1 ) )
@@ -421,7 +421,7 @@ class TestTypedParameter( unittest.TestCase ) :
 			presetsOnly = True,
 		)
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 3 )
 		self.assertEqual( pr["one"], V3fData( V3f( 1 ) ) )
 		self.assertEqual( pr["two"], V3fData( V3f( 2 ) ) )
@@ -437,7 +437,7 @@ class TestTypedParameter( unittest.TestCase ) :
 				( "one", V3fData( V3f(1) ) ),
 			]
 		)
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assertEqual( pr["four"], V3fData( V3f(4) ) )
 		self.assertEqual( pr["one"], V3fData( V3f(1) ) )
@@ -585,7 +585,7 @@ class TestValidatedStringParameter( unittest.TestCase ) :
 		p.setValue( StringData( "100" ) )
 		self.assertEqual( p.getValue(), StringData( "100" ) )
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assert_( "100" in pr.keys() )
 		self.assert_( "200" in pr.keys() )
@@ -831,7 +831,7 @@ class TestObjectParameter( unittest.TestCase ) :
 				( "one", V3fData( V3f(1) ) ),
 			]
 		)
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 2 )
 		self.assertEqual( pr["four"], V3fData( V3f(4) ) )
 		self.assertEqual( pr["one"], V3fData( V3f(1) ) )
@@ -881,7 +881,7 @@ class TestTypedObjectParameter( unittest.TestCase ) :
 			presetsOnly = True,
 		)
 
-		pr = p.presets()
+		pr = p.getPresets()
 		self.assertEqual( len( pr ), 3 )
 		self.assertEqual( pr["one"], mesh1 )
 		self.assertEqual( pr["two"], mesh2 )


### PR DESCRIPTION
This will allow dynamic interfaces to exist, by updating the shown presets based on value changes in other parameters in the same Parameterised object (most likely Ops).
The idea is to make Gaffer support a user hint that forces a given Parameter to be shown as a drop down list control, and then, use the change-value callback mechanism to update the presets and update the current value if not in the new presets.
