### PR TITLE
Houdini SceneCache ROP Re-rooting patch

### DIFF
--- a/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
+++ b/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
@@ -171,7 +171,7 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::renderFrame( fpreal time, UT_Interrupt *bo
 
 		if ( reRoot )
 		{
-			outScene = m_outScene->createChild( node->getName().toStdString() );
+			outScene = m_outScene->child( node->getName().toStdString(), SceneInterface::CreateIfMissing );
 		}
 	}
 	

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -1414,6 +1414,8 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		attr.setDisplayFlag( True )
 		attr.setRenderFlag( True )
 		rop = self.rop( geo )
+		rop.parm( "trange" ).set( 1 )
+		rop.parmTuple( "f" ).set( ( 1, 10, 1 ) )
 		rop.parm( "execute" ).pressButton()
 		self.assertEqual( rop.errors(), "" )
 		output = IECore.SceneCache( TestSceneCache.__testOutFile, IECore.IndexedIO.OpenMode.Read )


### PR DESCRIPTION
There was a bug in the re-rooting code when caching more than one frame.
