### PR TITLE
Fixed bug when loading CoordinateSystems in Houdini

### DIFF
--- a/src/IECoreHoudini/GU_CortexPrimitive.cpp
+++ b/src/IECoreHoudini/GU_CortexPrimitive.cpp
@@ -69,17 +69,19 @@ GU_CortexPrimitive *GU_CortexPrimitive::build( GU_Detail *geo, const IECore::Obj
 	result->wireVertex( result->m_offset, point );
 	result->setObject( object );
 	
-	const IECore::VisibleRenderable *renderable = IECore::runTimeCast<const IECore::VisibleRenderable>( object );
-	if ( renderable )
+	if ( const IECore::VisibleRenderable *renderable = IECore::runTimeCast<const IECore::VisibleRenderable>( object ) )
 	{
 		geo->setPos3( point, IECore::convert<UT_Vector3>( renderable->bound().center() ) );
 		return result;
 	}
 	
-	const IECore::CoordinateSystem *coord = IECore::runTimeCast<const IECore::CoordinateSystem>( object );
-	if ( coord )
+	if ( const IECore::CoordinateSystem *coord = IECore::runTimeCast<const IECore::CoordinateSystem>( object ) )
 	{
-		geo->setPos3( point, IECore::convert<UT_Vector3>( coord->getTransform()->transform().translation() ) );
+		if ( const IECore::Transform *transform = coord->getTransform() )
+		{
+			geo->setPos3( point, IECore::convert<UT_Vector3>( transform->transform().translation() ) );
+		}
+		
 		return result;
 	}
 	

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -1988,6 +1988,28 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( prims[6].vertex( 0 ).point().position(), hou.Vector3( 3, 2, 0 ) )
 		self.assertEqual( prims[12].vertex( 0 ).point().position(), hou.Vector3( 6, 3, 0 ) )
 	
+	def testCoordinateSystemNoTransform( self ) :
+		
+		scene = IECore.SceneCache( TestSceneCache.__testFile, IECore.IndexedIO.OpenMode.Write )
+		coordChild = scene.createChild( "coord")
+		coord = IECore.CoordinateSystem()
+		coord.setName( "testing" )
+		coordChild.writeObject( coord, 0 )
+		
+		del scene, coordChild
+		
+		sop = self.sop()
+		sop.parm( "geometryType" ).set( IECoreHoudini.SceneCacheNode.GeometryType.Cortex )
+		prims = sop.geometry().prims()
+		self.assertEqual( len(prims), 1 )
+		
+		nameAttr = sop.geometry().findPrimAttrib( "name" )
+		self.assertEqual( sorted(nameAttr.strings()), [ "/coord" ] )
+		self.assertEqual( prims[0].attribValue( "name" ), "/coord" )
+		self.assertEqual( prims[0].type(), hou.primType.Custom )
+		self.assertEqual( prims[0].vertices()[0].point().number(), 0 )
+		self.assertEqual( prims[0].vertices()[0].point().position(), hou.Vector3( 0, 0, 0 ) )
+	
 	def testPointsDontAccumulate( self ) :
 		
 		obj = hou.node("/obj")


### PR DESCRIPTION
It had been trying to access the local transform, which may or may not exist.
