### PR TITLE
Fixed bugs in interpretation of "color" attribute in IECoreGL.

### DIFF
--- a/include/IECoreGL/Shader.h
+++ b/include/IECoreGL/Shader.h
@@ -161,7 +161,10 @@ class Shader : public IECore::RunTimeTyped
 				/// Binds the specified value to the named vertex attribute. The divisor will be passed to
 				/// glVertexAttribDivisor(). 
 				void addVertexAttribute( const std::string &name, IECore::ConstDataPtr value, GLuint divisor = 0 );
-		
+				
+				/// Returns true if this setup specifies a value for the standard "Cs" parameter.
+				bool hasCsValue() const;
+					
 				/// The ScopedBinding class cleanly binds and unbinds the shader
 				/// Setup, making the shader current and setting the uniform
 				/// and vertex values as necessary.

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -158,6 +158,14 @@ void Primitive::render( State *state ) const
 		const Shader *shader = uniformSetup->shader();
 		const Shader::Setup *primitiveSetup = shaderSetup( shader, state );
 		Shader::Setup::ScopedBinding primitiveBinding( *primitiveSetup );
+		// inherit Cs from the state if it isn't provided by the shader or a primitive variable
+		if( !uniformSetup->hasCsValue() && !primitiveSetup->hasCsValue() )
+		{
+			if( const Shader::Parameter *csParameter = primitiveSetup->shader()->csParameter() )
+			{
+				glUniform3fv( csParameter->location, 1, state->get<Color>()->value().getValue() );
+			}
+		}
 		// then we defer to the derived class to perform the draw call.
 		render( state, Primitive::DrawSolid::staticTypeId() );
 	}


### PR DESCRIPTION
The "color" attribute was being used incorrectly in two ways :
- It was affecting the wireframe colour, whereas the two should be independent
- It was affecting the solid colour when it should have been overridden by a shader Cs value

This is fixed by having the Primitive rendering code transfer the color attribute value from the state into the shader Cs parameter if and only if an override hasn't been applied as a shader parameter or primitive variable. This also removes reliance on the deprecated gl_Color shader global, which is nice.

In terms of visible effect in the IE pipeline, this fixes the drawing of lights for IEShading.
