### PR TITLE
Fixed transform matrix order in Group.globalTransformMatrix()

### DIFF
--- a/src/IECore/Group.cpp
+++ b/src/IECore/Group.cpp
@@ -94,7 +94,7 @@ Imath::M44f Group::globalTransformMatrix( float time ) const
 {
 	if( m_parent )
 	{
-		return m_parent->globalTransformMatrix( time ) * transformMatrix( time );
+		return transformMatrix( time ) * m_parent->globalTransformMatrix( time );
 	}
 	return transformMatrix( time );
 }

--- a/test/IECore/Group.py
+++ b/test/IECore/Group.py
@@ -285,6 +285,30 @@ class TestGroup( unittest.TestCase ) :
 		
 		g.setTransform( MatrixTransform( M44f() ) )
 		self.assertNotEqual( g.hash(), h )
+	
+	def testGlobalTransform( self ) :
+	
+		g = Group()
+		childGroup = Group()
+		
+		g.addChild( childGroup )
+		
+		parentTransform = TransformationMatrixf()
+		parentTransform.rotate = Eulerf( 0,3.1415926/2,0 )
+		
+		childTransform = TransformationMatrixf()
+		childTransform.translate = V3f( 1, 0, 2 )
+		
+		childGroup.setTransform( MatrixTransform( childTransform.transform ) )
+		g.setTransform( MatrixTransform( parentTransform.transform ) )
+		
+		# child group's translation should have been rotated 90 degrees about the y axis:
+		childGroupGlobalTranslation = childGroup.globalTransformMatrix().extractSHRT()[3]
+		self.assertAlmostEqual( childGroupGlobalTranslation.x, 2, 4 )
+		self.assertAlmostEqual( childGroupGlobalTranslation.y, 0, 4 )
+		self.assertAlmostEqual( childGroupGlobalTranslation.z, -1, 4 )
+		
+		
 		
 	def tearDown( self ) :
 


### PR DESCRIPTION
Was trying to use this to fix the ieRendering light reposition tool when hierarchical transforms are present, and noticed the matrix multiplication was in the wrong order...
