### PR TITLE
Patch for loading multiple ieCoreHoudini plugins.

### DIFF
--- a/src/IECoreHoudini/plugin/Plugin.cpp
+++ b/src/IECoreHoudini/plugin/Plugin.cpp
@@ -184,6 +184,12 @@ void newGeometryPrim( GA_PrimitiveFactory *factory )
 		GA_FAMILY_NONE, ( std::string( GU_CortexPrimitive::typeName ) + "s" ).c_str()
 	);
 	
+	if ( !primDef )
+	{
+		std::cerr << "Warning: Duplicate definition for GU_CortexPrimitive. Make sure only 1 version of the ieCoreHoudini plugin is on your path." << std::endl;
+		return;
+	}
+	
 	/// \todo: This method is silly. Should we just give up and do the whole registration in GU_CortexPrimitive?
 	GU_CortexPrimitive::setTypeDef( primDef );
 	


### PR DESCRIPTION
Houdini loads all plugins on the path, regardless of whether they have been seen before. This means that when installing things in a studio setup, several versions of the plugin may be loaded, for example a user install for testing and the central install. This commit prevents such situations from seg faulting, and instead prints a warning to stderr. Currently the only conflict will be the definition of GU_CortexPrimitive. Since the correct library will still be loaded, I think the warning can be ignored in most situations.
