### PR TITLE
Restored virtual nature of MeshPrimitive/NurbsPrimitive setTopology().

### DIFF
--- a/include/IECore/MeshPrimitive.h
+++ b/include/IECore/MeshPrimitive.h
@@ -76,7 +76,8 @@ class MeshPrimitive : public Primitive
 		int maxVerticesPerFace() const;
 		const IntVectorData *vertexIds() const;
 		const std::string &interpolation() const;
-		void setTopology( ConstIntVectorDataPtr verticesPerFace, ConstIntVectorDataPtr vertexIds, const std::string &interpolation = "linear" );
+		/// \todo Remove virtual-ness for Cortex 9.
+		virtual void setTopology( ConstIntVectorDataPtr verticesPerFace, ConstIntVectorDataPtr vertexIds, const std::string &interpolation = "linear" );
 		void setTopologyUnchecked( ConstIntVectorDataPtr verticesPerFace, ConstIntVectorDataPtr vertexIds, size_t numVertices, const std::string &interpolation = "linear" );
 		void setInterpolation( const std::string &interpolation );
 		PolygonIterator faceBegin();

--- a/include/IECore/NURBSPrimitive.h
+++ b/include/IECore/NURBSPrimitive.h
@@ -72,7 +72,8 @@ class NURBSPrimitive : public Primitive
 		float vMax() const;
 		int vVertices() const;
 		int vSegments() const;
-		void setTopology(  int uOrder, ConstFloatVectorDataPtr uKnot, float uMin, float uMax,
+		/// \todo Remove virtual-ness for Cortex 9.
+		virtual void setTopology(  int uOrder, ConstFloatVectorDataPtr uKnot, float uMin, float uMax,
 			int vOrder, ConstFloatVectorDataPtr vKnot, float vMin, float vMax );
 		//@}
 


### PR DESCRIPTION
Also added todos to remove it in the next major version. We still want to remove the virtual - we just feel that at this stage in the Cortex 8 development, it is time to lock down on compatibility in preparation for an 8.0.0 release.
