### PR TITLE
Fixed SOP merging for GEO_CortexPrimitives

### DIFF
--- a/include/IECoreHoudini/GEO_CortexPrimitive.h
+++ b/include/IECoreHoudini/GEO_CortexPrimitive.h
@@ -61,6 +61,7 @@ class GEO_CortexPrimitive : public GEO_Primitive
 		virtual void clearForDeletion();
 		virtual bool isDegenerate() const;
 		virtual void copyUnwiredForMerge( const GA_Primitive *src, const GA_MergeMap &map );
+		virtual void transform( const UT_Matrix4 &xform );
 		virtual const GA_PrimitiveJSON* getJSON() const;
 		virtual void reverse();
 		


### PR DESCRIPTION
Correctly copying the GEO_CortexPrimitives in copyUnwiredForMerged, and implemented transform() method, so the copied prims are transformed correctly. This also fixes their use in an xform SOP.
