### PR TITLE
Click Selection of GR_CortexPrimitives

### DIFF
--- a/include/IECoreHoudini/GR_CortexPrimitive.h
+++ b/include/IECoreHoudini/GR_CortexPrimitive.h
@@ -96,6 +96,10 @@ class GR_CortexPrimitive : public GR_Primitive
 		static IECoreGL::StatePtr g_wireConstGhost;
 		static IECoreGL::StatePtr g_wireConstBG;
 		static IECoreGL::StatePtr g_pick;
+		static IECoreGL::StatePtr g_selected;
+		static IECoreGL::StatePtr g_wireSelected;
+		static IECoreGL::StatePtr g_wireConstBGSelected;
+		static IECoreGL::StatePtr g_wireConstGhostSelected;
 
 };
 

--- a/src/IECoreHoudini/GR_CortexPrimitive.cpp
+++ b/src/IECoreHoudini/GR_CortexPrimitive.cpp
@@ -179,10 +179,14 @@ IECoreGL::StatePtr GR_CortexPrimitive::g_wireShaded = 0;
 IECoreGL::StatePtr GR_CortexPrimitive::g_wireConstGhost = 0;
 IECoreGL::StatePtr GR_CortexPrimitive::g_wireConstBG = 0;
 IECoreGL::StatePtr GR_CortexPrimitive::g_pick = 0;
+IECoreGL::StatePtr GR_CortexPrimitive::g_selected = 0;
+IECoreGL::StatePtr GR_CortexPrimitive::g_wireSelected = 0;
+IECoreGL::StatePtr GR_CortexPrimitive::g_wireConstBGSelected = 0;
+IECoreGL::StatePtr GR_CortexPrimitive::g_wireConstGhostSelected = 0;
 
 IECoreGL::State *GR_CortexPrimitive::getState( GR_RenderMode mode, GR_RenderFlags flags, const GR_DisplayOption *opt )
 {
-	if ( !g_lit || !g_shaded || !g_wire || !g_wireLit || !g_wireShaded || !g_wireConstGhost || !g_wireConstBG || !g_pick )
+	if ( !g_lit || !g_shaded || !g_wire || !g_wireLit || !g_wireShaded || !g_wireConstGhost || !g_wireConstBG || !g_pick || !g_selected || !g_wireSelected || !g_wireConstBGSelected || !g_wireConstGhostSelected )
 	{
 		g_shaded = new IECoreGL::State( true );
 		g_shaded->add( new IECoreGL::PointsPrimitive::UseGLPoints( IECoreGL::ForAll ) );
@@ -247,6 +251,20 @@ IECoreGL::State *GR_CortexPrimitive::getState( GR_RenderMode mode, GR_RenderFlag
 			),
 			true
 		);
+		
+		g_selected = new IECoreGL::State( *g_shaded );
+		g_selected->add( new IECoreGL::Primitive::DrawWireframe( true ) );
+		IECoreGL::WireframeColorStateComponentPtr selectionColor = new IECoreGL::WireframeColorStateComponent( IECore::convert<Imath::Color4f>( opt->common().getColor( GR_OBJECT_SELECT_COLOR ) ) );
+		g_selected->add( selectionColor.get() );
+		
+		g_wireSelected = new IECoreGL::State( *g_wire );
+		g_wireSelected->add( selectionColor.get() );
+		
+		g_wireConstBGSelected = new IECoreGL::State( *g_wireConstBG );
+		g_wireConstBGSelected->add( selectionColor.get() );
+		
+		g_wireConstGhostSelected = new IECoreGL::State( *g_wireConstGhost );
+		g_wireConstGhostSelected->add( selectionColor.get() );
 	}
 	
 	switch ( mode )
@@ -255,6 +273,11 @@ IECoreGL::State *GR_CortexPrimitive::getState( GR_RenderMode mode, GR_RenderFlag
 		case GR_RENDER_MATERIAL :
 		case GR_RENDER_MATERIAL_WIREFRAME :
 		{
+			if ( isObjectSelection() )
+			{
+				return g_selected;
+			}
+
 			if ( flags & GR_RENDER_FLAG_WIRE_OVER )
 			{
 				if ( flags & GR_RENDER_FLAG_UNLIT )
@@ -274,14 +297,29 @@ IECoreGL::State *GR_CortexPrimitive::getState( GR_RenderMode mode, GR_RenderFlag
 		}
 		case GR_RENDER_WIREFRAME :
 		{
+			if ( isObjectSelection() )
+			{
+				return g_wireSelected;
+			}
+
 			return g_wire;
 		}
 		case GR_RENDER_HIDDEN_LINE :
 		{
+			if ( isObjectSelection() )
+			{
+				return g_wireConstBGSelected;
+			}
+
 			return g_wireConstBG;
 		}
 		case GR_RENDER_GHOST_LINE :
 		{
+			if ( isObjectSelection() )
+			{
+				return g_wireConstGhostSelected;
+			}
+
 			return g_wireConstGhost;
 		}
 		// hovering on GU_CortexPrimitives during GR_RENDER_OBJECT_PICK mode flips the mode


### PR DESCRIPTION
This request allows users to pick-select our custom primitives in the viewport (which will jump the network pane to the corresponding node). Previously, only drag selection would do this. I've also added highlighting for selected objects, so you can actually tell what is selected in the viewport.
