### PR TITLE
Fixed IECore::Lookup for OS X.

### DIFF
--- a/include/IECore/Lookup.h
+++ b/include/IECore/Lookup.h
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2009, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,9 +36,11 @@
 #ifndef IECORE_LOOKUP_H
 #define IECORE_LOOKUP_H
 
-#include "OpenEXR/ImathColor.h"
-
 #include <vector>
+
+#include "boost/function.hpp"
+
+#include "OpenEXR/ImathColor.h"
 
 namespace IECore
 {
@@ -54,13 +57,11 @@ class Lookup
 	
 		typedef X XType;
 		typedef Y YType;
+		typedef boost::function<Y ( X )> Function;
 	
 		Lookup();
-	
-		template<class Function>
 		Lookup( const Function &function, XType xMin, XType xMax, unsigned numSamples );
 
-		template<class Function>
 		void init( const Function &function, XType xMin, XType xMax, unsigned numSamples );
 		
 		inline Y operator() ( X x ) const;

--- a/include/IECore/Lookup.inl
+++ b/include/IECore/Lookup.inl
@@ -1,6 +1,7 @@
 //////////////////////////////////////////////////////////////////////////
 //
 //  Copyright (c) 2009, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013, John Haddon. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -51,14 +52,12 @@ Lookup<X, Y>::Lookup()
 }
 
 template<typename X, typename Y>
-template<class Function>
 Lookup<X, Y>::Lookup( const Function &function, XType xMin, XType xMax, unsigned numSamples )
 {
 	init( function, xMin, xMax, numSamples );
 }
 
 template<typename X, typename Y>
-template<class Function>
 void Lookup<X, Y>::init( const Function &function, XType xMin, XType xMax, unsigned numSamples )
 {
 	m_values.resize( numSamples );


### PR DESCRIPTION
I'm not sure why the compiler didn't like the templated constructor, but using boost::function instead fixes the problem and makes it more flexible anyway.
