### PR TITLE
Extended the ImageDiffOp options.

### DIFF
--- a/include/IECore/ImageDiffOp.h
+++ b/include/IECore/ImageDiffOp.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2008-2011, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2008-2013, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -72,6 +72,9 @@ class ImageDiffOp : public Op
 		BoolParameter * skipMissingChannels();
 		const BoolParameter * skipMissingChannels() const;
 
+		BoolParameter * alignDisplayWindows();
+		const BoolParameter * alignDisplayWindows() const;
+
 	protected :
 
 		virtual ObjectPtr doOperation( const CompoundObject * operands );
@@ -82,6 +85,7 @@ class ImageDiffOp : public Op
 		ImagePrimitiveParameterPtr m_imageBParameter;
 		FloatParameterPtr m_maxErrorParameter;
 		BoolParameterPtr m_skipMissingChannelsParameter;
+		BoolParameterPtr m_alignDisplayWindowsParameter;
 
 		class FloatConverter;
 

--- a/test/IECore/ImageDiffOp.py
+++ b/test/IECore/ImageDiffOp.py
@@ -40,6 +40,43 @@ from IECore import *
 
 class TestImageDiffOp(unittest.TestCase):
 
+	def testOffsetDisplayWindows(self):
+		r = Reader.create( "test/IECore/data/exrFiles/carPark.exr" )
+		imageA = r.read()
+		imageB = r.read()
+
+		op = ImageDiffOp()
+		res = op(
+			imageA = imageA,
+			imageB = imageB,
+			alignDisplayWindows = False
+		)
+		self.assertFalse( res.value )
+	
+		# Offset the display and data windows.
+		offsetDisplayWindow = Box2i( imageA.displayWindow.min + V2i( -261, 172 ), imageA.displayWindow.max + V2i( -261, 172 ) ) 
+		offsetDataWindow = Box2i( imageA.dataWindow.min + V2i( -261, 172 ), imageA.dataWindow.max + V2i( -261, 172 ) ) 
+		imageA.displayWindow = offsetDisplayWindow
+		imageA.dataWindow = offsetDataWindow
+
+		# Compare the images again and they should fail as the display windows are different.
+		op = ImageDiffOp()
+		res = op(
+			imageA = imageA,
+			imageB = imageB,
+			alignDisplayWindows = False
+		)
+		self.assertTrue( res.value )
+		
+		# Compare the images again and they should not fail if "alignDisplayWindows" is turned on.
+		op = ImageDiffOp()
+		res = op(
+			imageA = imageA,
+			imageB = imageB,
+			alignDisplayWindows = True
+		)
+		self.assertFalse( res.value )
+
 	def testSimple(self):
 
 		op = ImageDiffOp()


### PR DESCRIPTION
Added an option to the ImageDiffOp that allows offset display windows of the same size to be aligned before comparison.

This option was added because conceptually, two images that have their display window and data window offset by some arbitrary offset are still the same when the display windows are overlapped.
