### PR TITLE
Made RunTimeTyped::baseTypeIds and derivedTypeIds thread safe

### DIFF
--- a/include/IECore/RunTimeTyped.h
+++ b/include/IECore/RunTimeTyped.h
@@ -44,6 +44,8 @@
 #include <vector>
 #include <set>
 
+#include "tbb/spin_rw_mutex.h"
+
 namespace IECore
 {
 
@@ -302,7 +304,12 @@ class RunTimeTyped : public RefCounted
 		typedef std::map< TypeId, TypeId > BaseTypeRegistryMap;
 		typedef std::map< TypeId, std::vector<TypeId> > BaseTypesRegistryMap;
 		typedef std::map< TypeId, std::set< TypeId > > DerivedTypesRegistryMap;
-
+		
+		typedef tbb::spin_rw_mutex Mutex;
+		
+		static Mutex g_baseTypeIdsMutex;
+		static Mutex g_derivedTypeIdsMutex;
+		
 		static BaseTypeRegistryMap &baseTypeRegistry();
 		static DerivedTypesRegistryMap &derivedTypesRegistry();
 


### PR DESCRIPTION
Previously they were reading/writing to global maps without a mutex, which was causing problems in IECoreGL...
