### PR TITLE
Deleting normals on subdiv meshes converted from Houdini.

### DIFF
--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -125,7 +125,8 @@ ObjectPtr FromHoudiniPolygonsConverter::doDetailConversion( const GU_Detail *geo
 	if ( attrHandle.isAttributeValid() )
 	{
 		modifiedOperands = operands->copy();
-		modifiedOperands->member<StringData>( "attributeFilter" )->writable() += " ^ieMeshInterpolation";
+		std::string &attributeFilter = modifiedOperands->member<StringData>( "attributeFilter" )->writable();
+		attributeFilter += " ^ieMeshInterpolation";
 		
 		GA_Range primRange = geo->getPrimitiveRange();
 		const GA_ROAttributeRef attrRef( attrHandle.getAttribute() );
@@ -137,6 +138,9 @@ ObjectPtr FromHoudiniPolygonsConverter::doDetailConversion( const GU_Detail *geo
 				if ( !strcmp( value, "subdiv" ) )
 				{
 					interpolation = "catmullClark";
+					// subdivision meshes should not have normals. we assume this occurred because the geo contained
+					// both subdiv and linear meshes, inadvertantly extending the normals attribute to both.
+					attributeFilter += " ^N";
 					break;
 				}
 				else if ( !strcmp( value, "poly" ) )

--- a/test/IECoreHoudini/FromHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/FromHoudiniPolygonsConverter.py
@@ -788,11 +788,14 @@ class TestFromHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 	def testInterpolation( self ) :
 		
 		torus = self.createTorus()
-		result = IECoreHoudini.FromHoudiniPolygonsConverter( torus ).convert()
+		normals = torus.createOutputNode( "facet" )
+		normals.parm( "postnml" ).set( True )
+		result = IECoreHoudini.FromHoudiniPolygonsConverter( normals ).convert()
 		self.assertTrue( "ieMeshInterpolation" not in result.keys() )
 		self.assertEqual( result.interpolation, "linear" )
+		self.assertTrue( "N" in result.keys() )
 		
-		attr = torus.createOutputNode( "attribcreate", node_name = "interpolation", exact_type_name=True )
+		attr = normals.createOutputNode( "attribcreate", node_name = "interpolation", exact_type_name=True )
 		attr.parm( "name" ).set( "ieMeshInterpolation" )
 		attr.parm( "class" ).set( 1 ) # prim
 		attr.parm( "type" ).set( 3 ) # string
@@ -800,11 +803,13 @@ class TestFromHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 		result = IECoreHoudini.FromHoudiniPolygonsConverter( attr ).convert()
 		self.assertTrue( "ieMeshInterpolation" not in result.keys() )
 		self.assertEqual( result.interpolation, "catmullClark" )
+		self.assertTrue( "N" not in result.keys() )
 		
 		attr.parm( "string") .set( "poly" )
 		result = IECoreHoudini.FromHoudiniPolygonsConverter( attr ).convert()
 		self.assertTrue( "ieMeshInterpolation" not in result.keys() )
 		self.assertEqual( result.interpolation, "linear" )
+		self.assertTrue( "N" in result.keys() )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Subdivision meshes should not have normals, but they tend to get added accidentally when dealing with many meshes in a single SOP, as that would extend the normals attribute to all meshes. We force N to be excluded when converting subdiv (catmullClark) meshes directly in the FromHoudiniPolygonsConverter. I considered making an optional parameter to keep normals in this case, but since most uses of the converters take default parameter values, I thought it wasn't necessarily worth while. I can add the option of there are strong opinions otherwise though.
