### PR TITLE
Added IECoreGL::Selector::push/popIDShader()

### DIFF
--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -110,6 +110,12 @@ class Selector : boost::noncopyable
 		/// Typically one is set up automatically in baseState(), but
 		/// if rendering must be performed with an alternative shader
 		/// then it may be passed via this function.
+		void pushIDShader( const IECoreGL::Shader *idShader );
+		
+		/// Revert to previous ID shader:
+		void popIDShader();
+		
+		/// Deprecated: calls pushIDShader
 		void loadIDShader( const IECoreGL::Shader *idShader );
 		
 		/// Returns the currently active Selector - this may be used

--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -880,7 +880,7 @@ Shader::Setup::ScopedBinding::ScopedBinding( const Setup &setup )
 	{
 		if( currentSelector->mode() == Selector::IDRender )
 		{
-			currentSelector->loadIDShader( m_setup.shader() );
+			currentSelector->pushIDShader( m_setup.shader() );
 		}	
 	}
 }
@@ -894,6 +894,13 @@ Shader::Setup::ScopedBinding::~ScopedBinding()
 	}
 	
 	glUseProgram( m_previousProgram );
+	if( Selector *currentSelector = Selector::currentSelector() )
+	{
+		if( currentSelector->mode() == Selector::IDRender )
+		{
+			currentSelector->popIDShader();
+		}	
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
ID shaders weren't being reverted correctly in certain situations involving ribbon curves, so Selector::loadIDShader() has been deprecated and replaced by Selector::pushIDShader(), which can be reverted using Selector::popIDShader()
