### PR TITLE
Preventing double cooking in HoudiniScene::scene( path )

### DIFF
--- a/src/IECoreHoudini/HoudiniScene.cpp
+++ b/src/IECoreHoudini/HoudiniScene.cpp
@@ -923,6 +923,7 @@ SceneInterfacePtr HoudiniScene::retrieveScene( const Path &path, MissingBehaviou
 	std::copy( m_path.begin(), m_path.begin() + m_rootIndex, rootPath.begin() );
 	
 	HoudiniScenePtr rootScene = new HoudiniScene();
+	rootScene->setDefaultTime( m_defaultTime );
 	for ( Path::const_iterator it = rootPath.begin(); it != rootPath.end(); ++it )
 	{
 		rootScene = IECore::runTimeCast<HoudiniScene>( rootScene->child( *it ) );

--- a/test/IECoreHoudini/HoudiniSceneTest.py
+++ b/test/IECoreHoudini/HoudiniSceneTest.py
@@ -699,6 +699,12 @@ class HoudiniSceneTest( IECoreHoudini.TestCase ) :
 		self.assertEqual( deformer.cookCount(), 2 )
 		self.assertEqual( len(mesh0["P"].data), 8 )
 		self.assertEqual( mesh0["P"].data[0].x, -0.5 )
+		
+		scene.setDefaultTime( 0.5 )
+		self.assertTrue( scene.hasObject() )
+		self.assertEqual( deformer.cookCount(), 3 )
+		gap = scene.scene( scene.path() + [ "gap" ] )
+		self.assertEqual( deformer.cookCount(), 3 )
 	
 	def testNode( self ) :
 		


### PR DESCRIPTION
Previously the scene method was not using the default cook time for a portion of its calculations, resulting in double cooking of SOPs which contain a flattened hierarchy. Note that the additional test doesn't actually demonstrate the issue, as it is only apparent in an interactive session, because the viewport forces extra cooks as well. I've verified the cook count is appropriate in interactive mode, and added the test just to be sure no other extra cooks are being caused by the scene method.
