### PR TITLE
Added GIL release for DisplayDriver imageData and imageClose bindings.

### DIFF
--- a/src/IECorePython/DisplayDriverBinding.cpp
+++ b/src/IECorePython/DisplayDriverBinding.cpp
@@ -39,8 +39,6 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 #include "IECorePython/RunTimeTypedBinding.h"
-#include "IECorePython/Wrapper.h"
-#include "IECorePython/ScopedGILLock.h"
 #include "IECorePython/ScopedGILRelease.h"
 
 using namespace boost;
@@ -66,11 +64,13 @@ static boost::python::list channelNames( DisplayDriverPtr dd )
 
 static void displayDriverImageData( DisplayDriverPtr dd, const Imath::Box2i &box, FloatVectorDataPtr data )
 {
+	ScopedGILRelease gilRelease;
 	dd->imageData( box, &(data->readable()[0]), data->readable().size() );
 }
 
 static void displayDriverImageClose( DisplayDriverPtr dd )
 {
+	ScopedGILRelease gilRelease;
 	dd->imageClose();
 }
 


### PR DESCRIPTION
This is necessary for some unit tests I'm currently adding to Gaffer for the Display node. The Gaffer display driver node emits signals (with connected Python slots) on the server thread, so the GIL must be released on the client thread so that those signals can be processed.

Also removed a couple of unnecessary includes.
