### PR TITLE
Fixed scene shape curve primitive GL preview

### DIFF
--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1121,7 +1121,8 @@ void SceneShapeInterface::recurseBuildScene( IECoreGL::Renderer * renderer, cons
 	subSceneInterface->path( pathName );
 	std::string pathStr = relativePathName( pathName );
 	renderer->setAttribute( "name", new StringData( pathStr ) );
-
+	renderer->setAttribute( "gl:curvesPrimitive:useGLLines", new BoolData( true ) );
+	
 	if(pathStr != "/")
 	{
 		// Path space
@@ -1162,9 +1163,6 @@ void SceneShapeInterface::recurseBuildScene( IECoreGL::Renderer * renderer, cons
 
 	if( drawBounds && pathStr != "/" )
 	{
-		AttributeBlock aBox(renderer);
-		renderer->setAttribute( "gl:curvesPrimitive:useGLLines", new BoolData( true ) );
-
 		Box3d b = subSceneInterface->readBound( time );
 		Box3f bbox( b.min, b.max );
 		if( !bbox.isEmpty() )


### PR DESCRIPTION
Attribute gl:curvesPrimitive:useGLLines was set only for drawing bounds. Setting it before rendering objects so curve primitives are previewed correctly.
