### PR TITLE
SceneShape readSceneShapeAttribute fix in case attribute name is not found

### DIFF
--- a/src/IECoreMaya/SceneShape.cpp
+++ b/src/IECoreMaya/SceneShape.cpp
@@ -320,7 +320,14 @@ ConstObjectPtr SceneShape::readSceneShapeAttribute( const MDagPath &p, SceneInte
 	MPlug timePlug = fnChildDag.findPlug( aTime );
 	MTime time;
 	timePlug.getValue( time );
-	return scene->readAttribute( attributeName, time.as( MTime::kSeconds ) );
+	try
+	{
+		return scene->readAttribute( attributeName, time.as( MTime::kSeconds ) );
+	}
+	catch( ... )
+	{
+		return 0;
+	}
 }
 
 bool SceneShape::hasSceneShapeObject( const MDagPath &p )


### PR DESCRIPTION
Return 0 if attributeName is not found in the scene instead of erroring at readAttribute.
