### PR TITLE
SceneCache ROP marks locations which appear and disappear over time.

### DIFF
--- a/include/IECoreHoudini/ROP_SceneCacheWriter.h
+++ b/include/IECoreHoudini/ROP_SceneCacheWriter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -64,7 +64,7 @@ class ROP_SceneCacheWriter : public ROP_Node
 		
 		static OP_Node *create( OP_Network *net, const char *name, OP_Operator *op );
 		static OP_TemplatePair *buildParameters();
-		
+	
 	protected :
 		
 		virtual int startRender( int nframes, fpreal s, fpreal e );
@@ -79,6 +79,8 @@ class ROP_SceneCacheWriter : public ROP_Node
 	
 	private :
 		
+		static const IECore::SceneInterface::Name &visibleAttribute;
+
 		bool linked( const std::string &file ) const;
 		
 		enum Mode
@@ -93,6 +95,9 @@ class ROP_SceneCacheWriter : public ROP_Node
 		IECore::ConstSceneInterfacePtr m_liveScene;
 		IECore::SceneInterfacePtr m_outScene;
 		UT_StringMMPattern *m_forceFilter;
+		
+		double m_startTime;
+		double m_endTime;
 
 };
 


### PR DESCRIPTION
In Houdini, SceneCache locations can appear and disappear over time when we're working with flattened hierarchies inside a SOP. Previously, this went undocumented in the file on disk, resulting in objects at such locations being visible at times that they should not. We debated off-line for a while about how to best handle this, and decided to postpone any thoughts about modifying SceneInterface to cope with dynamic hierarchy. 

This requests marks such locations with an attribute, with a bool value indicating whether or not it currently exists. While this doesn't help at all for 3d apps which can't handle dynamic hierarchy, it could be used at render time to control visibility of these locations. The attribute name is totally up for debate. I've currently called it "sceneInterface:dynamicHierarchy:exists" just to get something in there. I know David would prefer "visibility" (and to change "gaffer:visibility" to the same).
