### PR TITLE
IECoreGL Selection Fixes

### DIFF
--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -193,7 +193,15 @@ void Primitive::render( State *state ) const
 		return;
 	}
 	
+	// get a constant shader suitable for drawing wireframes, points etc.
 	const Shader *constantShader = Shader::constant();
+	if( currentSelector && currentSelector->mode() == Selector::IDRender )
+	{
+		// if we're in IDRender mode, then the constant shader is unsuitable,
+		// and we should instead use the ID shader we've been given.
+		constantShader = state->get<ShaderStateComponent>()->shaderSetup()->shader();
+	}
+	
 	const Shader::Setup *constantSetup = shaderSetup( constantShader, state );
 	Shader::Setup::ScopedBinding constantBinding( *constantSetup );
 	GLint csIndex = -1;
@@ -252,8 +260,9 @@ void Primitive::render( State *state ) const
 	
 	// bound
 	
-	if( drawBound )
+	if( drawBound && ( !currentSelector || currentSelector->mode() != Selector::IDRender ) )
 	{
+		/// \todo Support IDRender selection mode.
 		Shader::Setup::ScopedBinding boundSetupBinding( *boundSetup() );
 		glLineWidth( 1 );
 		if( csIndex >= 0 )

--- a/src/IECoreGL/Selector.cpp
+++ b/src/IECoreGL/Selector.cpp
@@ -332,10 +332,6 @@ class Selector::Implementation : public IECore::RefCounted
 					"", "", idShaderFragmentSource(),
 					new IECore::CompoundObject()
 				) );
-				s.push_back( new Primitive::DrawBound( false ) );
-				s.push_back( new Primitive::DrawWireframe( false ) );
-				s.push_back( new Primitive::DrawOutline( false ) );
-				s.push_back( new Primitive::DrawPoints( false ) );
 			}
 			return s;
 		}

--- a/test/IECoreGL/Selection.py
+++ b/test/IECoreGL/Selection.py
@@ -283,6 +283,109 @@ class TestSelection( unittest.TestCase ) :
 			self.assertEqual( len( names ), 1 )
 			self.assertEqual( names[0], "pointsNeedSelectingToo" )
 	
+	def testCurvesPrimitiveSelect( self ) :
+	
+		r = IECoreGL.Renderer()
+		r.setOption( "gl:mode", IECore.StringData( "deferred" ) )
+		r.setOption( "gl:searchPath:shader", IECore.StringData( os.path.dirname( __file__ ) + "/shaders" ) )
+			
+		with IECore.WorldBlock( r ) :
+
+			r.concatTransform( IECore.M44f.createTranslated( IECore.V3f( 0, 0, -5 ) ) )
+
+			r.setAttribute( "name", IECore.StringData( "curvesNeedSelectingToo" ) )           
+
+			r.curves(
+				IECore.CubicBasisf.linear(),
+				False,
+				IECore.IntVectorData( [ 2 ] ),
+				{
+					"P" : IECore.PrimitiveVariable(
+						IECore.PrimitiveVariable.Interpolation.Vertex,
+						IECore.V3fVectorData( [ IECore.V3f( -1, -1, 0, ), IECore.V3f( 1, 1, 0 ) ] )
+					)
+				}
+			)
+			
+		s = r.scene()
+		s.setCamera( IECoreGL.PerspectiveCamera() )
+
+		for mode in ( IECoreGL.Selector.Mode.GLSelect, IECoreGL.Selector.Mode.OcclusionQuery, IECoreGL.Selector.Mode.IDRender ) :
+			ss = s.select( mode, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ) )
+			names = [ x.name.value() for x in ss ]
+			self.assertEqual( len( names ), 1 )
+			self.assertEqual( names[0], "curvesNeedSelectingToo" )
+			
+	def testCurvesPrimitiveSelectUsingLines( self ) :
+	
+		r = IECoreGL.Renderer()
+		r.setOption( "gl:mode", IECore.StringData( "deferred" ) )
+		r.setOption( "gl:searchPath:shader", IECore.StringData( os.path.dirname( __file__ ) + "/shaders" ) )
+			
+		with IECore.WorldBlock( r ) :
+
+			r.concatTransform( IECore.M44f.createTranslated( IECore.V3f( 0, 0, -5 ) ) )
+
+			r.setAttribute( "name", IECore.StringData( "curvesNeedSelectingToo" ) )           
+			r.setAttribute( "gl:curvesPrimitive:useGLLines", IECore.BoolData( True ) )
+
+			r.curves(
+				IECore.CubicBasisf.linear(),
+				False,
+				IECore.IntVectorData( [ 2 ] ),
+				{
+					"P" : IECore.PrimitiveVariable(
+						IECore.PrimitiveVariable.Interpolation.Vertex,
+						IECore.V3fVectorData( [ IECore.V3f( -1, -1, 0, ), IECore.V3f( 1, 1, 0 ) ] )
+					)
+				}
+			)
+			
+		s = r.scene()
+		s.setCamera( IECoreGL.PerspectiveCamera() )
+
+		for mode in ( IECoreGL.Selector.Mode.GLSelect, IECoreGL.Selector.Mode.OcclusionQuery, IECoreGL.Selector.Mode.IDRender ) :
+			ss = s.select( mode, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ) )
+			names = [ x.name.value() for x in ss ]
+			self.assertEqual( len( names ), 1 )
+			self.assertEqual( names[0], "curvesNeedSelectingToo" )			
+
+	def testCurvesPrimitiveSelectUsingWireframeLines( self ) :
+	
+		r = IECoreGL.Renderer()
+		r.setOption( "gl:mode", IECore.StringData( "deferred" ) )
+		r.setOption( "gl:searchPath:shader", IECore.StringData( os.path.dirname( __file__ ) + "/shaders" ) )
+			
+		with IECore.WorldBlock( r ) :
+
+			r.concatTransform( IECore.M44f.createTranslated( IECore.V3f( 0, 0, -5 ) ) )
+
+			r.setAttribute( "name", IECore.StringData( "curvesNeedSelectingToo" ) )           
+			r.setAttribute( "gl:curvesPrimitive:useGLLines", IECore.BoolData( True ) )
+			r.setAttribute( "gl:primitive:wireframe", IECore.BoolData( True ) )
+			r.setAttribute( "gl:primitive:solid", IECore.BoolData( False ) )
+
+			r.curves(
+				IECore.CubicBasisf.linear(),
+				False,
+				IECore.IntVectorData( [ 2 ] ),
+				{
+					"P" : IECore.PrimitiveVariable(
+						IECore.PrimitiveVariable.Interpolation.Vertex,
+						IECore.V3fVectorData( [ IECore.V3f( -1, -1, 0, ), IECore.V3f( 1, 1, 0 ) ] )
+					)
+				}
+			)
+			
+		s = r.scene()
+		s.setCamera( IECoreGL.PerspectiveCamera() )
+
+		for mode in ( IECoreGL.Selector.Mode.GLSelect, IECoreGL.Selector.Mode.OcclusionQuery, IECoreGL.Selector.Mode.IDRender ) :
+			ss = s.select( mode, IECore.Box2f( IECore.V2f( 0 ), IECore.V2f( 1 ) ) )
+			names = [ x.name.value() for x in ss ]
+			self.assertEqual( len( names ), 1 )
+			self.assertEqual( names[0], "curvesNeedSelectingToo" )			
+	
 	def testContextManager( self ) :
 	
 		r = IECoreGL.Renderer()


### PR DESCRIPTION
This makes a couple of fixes to IECoreGL's selection code, addressing https://github.com/ImageEngine/gaffer/issues/53 and https://github.com/ImageEngine/gaffer/issues/160. The problems don't show themselves at all on my Mac, because it falls back to GL_SELECT mode for selection, so I've been testing on my workstation over VNC. The unit tests all pass there and I've also manually verified the problem as fixed in Gaffer, but the latency is too great to do much more testing - it might be a good idea to have a couple of developers run this for a few days before it gets pushed to production.

I'm also a little curious as to how the "primitive:selectable" attribute was working at all before - it kindof implies that we were using GL_SELECT selection mode everywhere where it was needed. That mode is very slow on the workstations so it might be worth a little bit of investigating...
