### PR TITLE
Added screen window modes to CameraController::setResolution.

### DIFF
--- a/include/IECore/CameraController.h
+++ b/include/IECore/CameraController.h
@@ -64,10 +64,22 @@ class CameraController : public boost::noncopyable
 		void setCentreOfInterest( float centreOfInterest );
 		float getCentreOfInterest();
 
-		/// Changes the camera resolution, modifying the screen window
-		/// to preserve the horizontal framing and changing the vertical
-		/// framing to maintain aspect ratio.
+		enum ScreenWindowAdjustment
+		{
+			/// Crop/extend the screen window to accommodate
+			/// the new resolution without scaling the content.
+			CropScreenWindow,
+			/// Preserve the horizontal framing and change the
+			/// vertical framing to maintain aspect ratio.
+			ScaleScreenWindow
+		};
+
+		/// \todo Remove this form, and add a default value for adjustment
+		/// in the form below.
 		void setResolution( const Imath::V2i &resolution );
+		/// Changes the camera resolution, modifying the screen window
+		/// in a manner determined by the adjustment argument.
+		void setResolution( const Imath::V2i &resolution, ScreenWindowAdjustment adjustment );
 		const Imath::V2i &getResolution() const;
 
 		/// Moves the camera to frame the specified box, keeping the

--- a/src/IECorePython/CameraControllerBinding.cpp
+++ b/src/IECorePython/CameraControllerBinding.cpp
@@ -58,12 +58,35 @@ static tuple unproject( CameraController &c, Imath::V2f &p )
 void bindCameraController()
 {
 
-	scope s = class_<CameraController, boost::noncopyable>( "CameraController", init<CameraPtr>() )
-		.def( "setCamera", &CameraController::setCamera )
+	class_<CameraController, boost::noncopyable> cls( "CameraController", init<CameraPtr>() );
+	scope s( cls );
+	
+	// define enums first, because they are needed for default argument definitions
+	
+	enum_<CameraController::ScreenWindowAdjustment>( "ScreenWindowAdjustment" )
+		.value( "CropScreenWindow", CameraController::CropScreenWindow )
+		.value( "ScaleScreenWindow", CameraController::ScaleScreenWindow )
+	;
+	
+	enum_<CameraController::MotionType>( "MotionType" )
+		.value( "None", CameraController::None )
+		.value( "Track", CameraController::Track )
+		.value( "Tumble", CameraController::Tumble )
+		.value( "Dolly", CameraController::Dolly )
+	;
+	
+	cls.def( "setCamera", &CameraController::setCamera )
 		.def( "getCamera", (CameraPtr (CameraController::*)())&CameraController::getCamera )
 		.def( "setCentreOfInterest", &CameraController::setCentreOfInterest )
 		.def( "getCentreOfInterest", &CameraController::getCentreOfInterest )
-		.def( "setResolution", &CameraController::setResolution )
+		.def(
+			"setResolution",
+			(void (CameraController::*)( const Imath::V2i &, CameraController::ScreenWindowAdjustment ))&CameraController::setResolution,
+			(
+				arg_( "resolution" ),
+				arg_( "adjustment" ) = CameraController::ScaleScreenWindow
+			)
+		)
 		.def( "getResolution", &CameraController::getResolution, return_value_policy<copy_const_reference>() )
 		.def( "frame", (void (CameraController::*)( const Imath::Box3f & ))&CameraController::frame )
 		.def( "frame", (void (CameraController::*)( const Imath::Box3f &, const Imath::V3f &, const Imath::V3f & ))&CameraController::frame )
@@ -72,13 +95,6 @@ void bindCameraController()
 		.def( "motionStart", &CameraController::motionStart )
 		.def( "motionUpdate", &CameraController::motionUpdate )
 		.def( "motionEnd", &CameraController::motionEnd )
-	;
-
-	enum_<CameraController::MotionType>( "MotionType" )
-		.value( "None", CameraController::None )
-		.value( "Track", CameraController::Track )
-		.value( "Tumble", CameraController::Tumble )
-		.value( "Dolly", CameraController::Dolly )
 	;
 
 }

--- a/test/IECore/CameraControllerTest.py
+++ b/test/IECore/CameraControllerTest.py
@@ -144,6 +144,34 @@ class CameraControllerTest( unittest.TestCase ) :
 		controller.motionEnd( IECore.V2f( 10 ) )
 		
 		self.assertNotEqual( transform.transform(), originalMatrix )
+	
+	def testSetResolutionScaling( self ) :
+	
+		camera = IECore.Camera()
+		camera.parameters()["resolution"] = IECore.V2i( 200, 100 )
+		camera.parameters()["screenWindow"] = IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) )
+		
+		controller = IECore.CameraController( camera )
+		
+		controller.setResolution( IECore.V2i( 200, 200 ) )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) )
+		
+		controller.setResolution( IECore.V2i( 200, 100 ), controller.ScreenWindowAdjustment.ScaleScreenWindow )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) ) )
+		
+	def testSetResolutionCropping( self ) :
+	
+		camera = IECore.Camera()
+		camera.parameters()["resolution"] = IECore.V2i( 200, 100 )
+		camera.parameters()["screenWindow"] = IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 2, 1 ) )
+		
+		controller = IECore.CameraController( camera )
+		
+		controller.setResolution( IECore.V2i( 100, 100 ), controller.ScreenWindowAdjustment.CropScreenWindow )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		
+		controller.setResolution( IECore.V2i( 100, 200 ), controller.ScreenWindowAdjustment.ScaleScreenWindow )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1, -2 ), IECore.V2f( 1, 2 ) ) )
 		
 if __name__ == "__main__":
         unittest.main()


### PR DESCRIPTION
Prior to this, the horizontal screen window was always preserved, with the vertical being scaled to preserve aspect ratio. The screen window can now optionally be cropped/extended instead.

This is needed for https://github.com/ImageEngine/gaffer/issues/10.
