### PR TITLE
Preventing crashes when OBJ networks contain non-OBJ nodes.

### DIFF
--- a/src/IECoreHoudini/HoudiniScene.cpp
+++ b/src/IECoreHoudini/HoudiniScene.cpp
@@ -675,11 +675,11 @@ void HoudiniScene::childNames( NameList &childNames ) const
 	{
 		for ( int i=0; i < node->getNchildren(); ++i )
 		{
-			OP_Node *child = node->getChild( i );
+			OBJ_Node *child = node->getChild( i )->castToOBJNode();
 			
 			// ignore children that have incoming connections, as those are actually grandchildren
 			// also ignore the contentNode, which is actually an extension of ourself
-			if ( child != contentNode && !hasInput( child ) )
+			if ( child && child != contentNode && !hasInput( child ) )
 			{
 				childNames.push_back( Name( child->getName() ) );
 			}
@@ -845,14 +845,14 @@ OP_Node *HoudiniScene::retrieveChild( const Name &name, Path &contentPath, Missi
 	{
 		for ( int i=0; i < node->getNchildren(); ++i )
 		{
-			OP_Node *child = node->getChild( i );
+			OBJ_Node *child = node->getChild( i )->castToOBJNode();
 			// the contentNode is actually an extension of ourself
 			if ( child == contentNode )
 			{
 				continue;
 			}
 			
-			if ( child->getName().equal( name.c_str() ) && !hasInput( child ) )
+			if ( child && child->getName().equal( name.c_str() ) && !hasInput( child ) )
 			{
 				return child;
 			}

--- a/test/IECoreHoudini/HoudiniSceneTest.py
+++ b/test/IECoreHoudini/HoudiniSceneTest.py
@@ -996,5 +996,17 @@ class HoudiniSceneTest( IECoreHoudini.TestCase ) :
 		sub3Transform = sub3Sc.readTransform( 0 ).value
 		self.assertEqual( sub3Transform.translate, IECore.V3d( 0.0, 0.0, 0.0 ) )
 
+	def testIgnoreNonOBJNodes( self ) :
+		
+		scene = self.buildScene()
+		rop = hou.node( "/obj" ).createNode( "ropnet" )
+		self.assertTrue( isinstance( rop, hou.RopNode ) )
+		# it is a child as far as Houdini is concerned
+		self.assertTrue( rop in scene.node().children() )
+		# but since its not an OBJ, we silently ignore it's existence
+		self.assertTrue( rop.name() not in scene.childNames() )
+		self.assertRaises( RuntimeError, scene.child, "ropnet" )
+		self.assertEqual( scene.child( "ropnet", IECore.SceneInterface.MissingBehaviour.NullIfMissing ), None )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This is possible because Houdini allows embded networks from alternate contexts (rop, chop, etc)
