### PR TITLE
Fixed cropping bug in CameraController::setResolution.

### DIFF
--- a/src/IECore/CameraController.cpp
+++ b/src/IECore/CameraController.cpp
@@ -156,8 +156,8 @@ void CameraController::setResolution( const Imath::V2i &resolution, ScreenWindow
 	{
 		const V2f screenWindowCenter = oldScreenWindow.center();
 		const V2f scale = V2f( resolution ) / V2f( oldResolution );
-		newScreenWindow.min = (oldScreenWindow.min - screenWindowCenter) * scale;
-		newScreenWindow.max = (oldScreenWindow.max - screenWindowCenter) * scale;
+		newScreenWindow.min = screenWindowCenter + (oldScreenWindow.min - screenWindowCenter) * scale;
+		newScreenWindow.max = screenWindowCenter + (oldScreenWindow.max - screenWindowCenter) * scale;
 	}
 	
 	m_data->screenWindow->writable() = newScreenWindow;

--- a/test/IECore/CameraControllerTest.py
+++ b/test/IECore/CameraControllerTest.py
@@ -170,8 +170,22 @@ class CameraControllerTest( unittest.TestCase ) :
 		controller.setResolution( IECore.V2i( 100, 100 ), controller.ScreenWindowAdjustment.CropScreenWindow )
 		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
 		
-		controller.setResolution( IECore.V2i( 100, 200 ), controller.ScreenWindowAdjustment.ScaleScreenWindow )
+		controller.setResolution( IECore.V2i( 100, 200 ), controller.ScreenWindowAdjustment.CropScreenWindow )
 		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1, -2 ), IECore.V2f( 1, 2 ) ) )
+
+	def testSetResolutionCroppingWithOffsetCenter( self ) :
+	
+		camera = IECore.Camera()
+		camera.parameters()["resolution"] = IECore.V2i( 200, 100 )
+		camera.parameters()["screenWindow"] = IECore.Box2f( IECore.V2f( -2, -1 ), IECore.V2f( 0, 0 ) )
+		
+		controller = IECore.CameraController( camera )
+		
+		controller.setResolution( IECore.V2i( 100, 100 ), controller.ScreenWindowAdjustment.CropScreenWindow )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1.5, -1 ), IECore.V2f( -0.5, 0  ) ) )
+		
+		controller.setResolution( IECore.V2i( 100, 200 ), controller.ScreenWindowAdjustment.CropScreenWindow )
+		self.assertEqual( camera.parameters()["screenWindow"].value, IECore.Box2f( IECore.V2f( -1.5, -1.5 ), IECore.V2f( -0.5, 0.5 ) ) )
 		
 if __name__ == "__main__":
         unittest.main()


### PR DESCRIPTION
It was performing the scale-about-centre incorrectly for off-centre screen windows.
