### PR TITLE
Fixed bug with SceneCache animated object topology.

### DIFF
--- a/src/IECore/SceneCache.cpp
+++ b/src/IECore/SceneCache.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -1228,13 +1228,14 @@ class SceneCache::WriterImplementation : public SceneCache::Implementation
 					MurmurHash topologyHash;
 					primitive->topologyHash( topologyHash );
 					topologyHash.append( primitive->typeId() );
-					if ( !m_objectSamples.empty() && topologyHash != m_animatedObjectTopology.first )
-					{
-						m_animatedObjectTopology.second = true;
-					}
-					else
+					if ( m_objectSamples.empty() )
 					{
 						m_animatedObjectTopology = AnimatedHashTest( topologyHash, false );
+					}
+					
+					if ( topologyHash != m_animatedObjectTopology.first )
+					{
+						m_animatedObjectTopology.second = true;
 					}
 					
 					for ( PrimitiveVariableMap::const_iterator it = primitive->variables.begin(); it != primitive->variables.end(); ++it )

--- a/test/IECore/SceneCacheTest.py
+++ b/test/IECore/SceneCacheTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -516,6 +516,7 @@ class SceneCacheTest( unittest.TestCase ) :
 		# animated topology
 		d.writeObject( box, 0 )
 		d.writeObject( plane, 1 )
+		d.writeObject( box, 2 )
 		
 		del s, a, b, c, d
 		


### PR DESCRIPTION
Previously, if the first topology hash matched the last topology hash, the animatedObjectTopology attribute would not be written, even if the hashes on the intermediate frames differed.
