### PR TITLE
iterate active compilers

### DIFF
--- a/config/ie/buildAll
+++ b/config/ie/buildAll
@@ -54,8 +54,9 @@ def installDocs() :
 
 if IEEnv.platform() == "cent6.x86_64" :
 	
-	for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
-		build( [ "COMPILER_VERSION=4.1.2", "DL_VERSION=UNDEFINED", "PYTHON_VERSION="+pythonVersion, "ARNOLD_VERSION=4.0.9.1" ] )
+	for compilerVersion in IEEnv.activeVersions(IEEnv.registry["compilers"]["gcc"]): 
+		for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
+			build( [ "COMPILER_VERSION="+compilerVersion, "DL_VERSION=UNDEFINED", "PYTHON_VERSION="+pythonVersion, "ARNOLD_VERSION=4.0.9.1" ] )
 	
 	for dlVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["3delight"] ):
 		build( [ "COMPILER_VERSION=4.1.2", "DL_VERSION="+dlVersion, "PYTHON_VERSION=2.6", "ARNOLD_VERSION=UNDEFINED" ] )


### PR DESCRIPTION
Adds support for compiling against all our active compiler versions. The IEEnv registry has already been updated, so the finding of active versions returns the expected values. I've been able to build and run scons test (only the few expected issues) and scons testGL (no issues).
