### PR TITLE
Adding link flag in order to build for Nuke 8

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2168,6 +2168,10 @@ nukeEnvAppends = {
 	"CPPFLAGS" : [
 		pythonEnv["PYTHON_INCLUDE_FLAGS"],
 	],
+
+	"LINKFLAGS" : [
+		"-Wl,-rpath=$NUKE_ROOT",
+	],
 	
 	"LIBPATH" : [
 		"$NUKE_ROOT",


### PR DESCRIPTION
This change uses the -rpath flag to the Nuke root location. Nuke 8 has this new library RIPFramework which DDImage depends on. 

In order to build or even to pass the config phase with CheckLibWithHeader( DDImage ), I found two options:
1) add the -rpath flag so it will find any extra library that DDImage requires.
2) include the RIPFramework as a library to direct link against IECoreNuke (using flag -lRIPFramework).

I favored option 1 because SConstruct doesn't need to know much about internal libraries for each Nuke version.

I'm not aware of undesired effects from using rpath. But I believe John had some more in depth experience with that in the past and could help here.
