### PR TITLE
Fixed linking of IECoreNuke for Nuke 8.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2169,6 +2169,10 @@ nukeEnvAppends = {
 		pythonEnv["PYTHON_INCLUDE_FLAGS"],
 	],
 	
+	"LINKFLAGS" : [
+		"-Wl,-rpath-link=$NUKE_ROOT",
+	],
+
 	"LIBPATH" : [
 		"$NUKE_ROOT",
 	],


### PR DESCRIPTION
The libDDImage in Nuke 8 links against libRIPFramework, so that library must be available at build time in order for the configure tests to pass. The -L flag isn't used when searching for the dependencies of a library, so we use the -rpath-link flag to specify where libRIPFramework is to be found.

Unlike the -rpath flag, -rpath-link only has effect at compile time, and doesn't affect linking at runtime.

This pull request is an alternative to Lucio's #251.
