### PR TITLE
Fixing infinite instantiation of SceneCacheReader Ops

### DIFF
--- a/include/IECoreNuke/SceneCacheReader.h
+++ b/include/IECoreNuke/SceneCacheReader.h
@@ -104,6 +104,7 @@ class SceneCacheReader : public DD::Image::SourceGeo
 		/// taken from the SceneCache, filter and select them. They are called
 		/// from the knob_changed() method to synchronize the SceneView_knob and
 		/// the internal lists of selected and filtered items.
+		/// These methods should only be called from the firstReader() returned instance.
 		//////////////////////////////////////////////////////////////
 		//@{
 		/// Loads the internal data structures from the knobs and set up the
@@ -130,8 +131,6 @@ class SceneCacheReader : public DD::Image::SourceGeo
 		void rebuildSelection();
 		/// Clear any selected geometry from the SceneView_knob.
 		void clearSceneViewSelection();
-		/// Clears the current filters applied to the scene.
-		void clearSceneViewFilter();
 		//@}
 
 		/// Updates the Enumeration_knob of available tags from the internal list of tags
@@ -145,6 +144,9 @@ class SceneCacheReader : public DD::Image::SourceGeo
 		std::string filePath() const;
 		
 		Imath::M44d worldTransform( IECore::ConstSceneInterfacePtr scene, IECore::SceneInterface::Path root, double time );
+
+		// uses firstOp to return the Op that has the up-to-date private data
+		SceneCacheReader *firstReader();
 	
 		/// Returns an InternedString with the name of the geometry tag.	
 		static const IECore::InternedString &geometryTag();

--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -121,12 +121,17 @@ SceneCacheReader::~SceneCacheReader()
 {
 }
 
+SceneCacheReader *SceneCacheReader::firstReader()
+{
+	return dynamic_cast<SceneCacheReader*>(firstOp());
+}
+
 void SceneCacheReader::_validate( bool forReal )
 {
 	m_evaluatedFilePath	= filePath();
 
 	m_scriptFinishedLoading = true;
-	if( m_isFirstRun )
+	if( firstReader()->m_isFirstRun )
 	{
 		Knob *k = knob("loadAll");
 		if( k != NULL )
@@ -134,12 +139,12 @@ void SceneCacheReader::_validate( bool forReal )
 			k->set_value( true );
 		}
 
-		m_isFirstRun = false;
-		loadAllFromKnobs();
+		firstReader()->m_isFirstRun = false;
+		firstReader()->loadAllFromKnobs();
 	}
 
-	filterScene( m_filterText, m_filterTagText );
-	rebuildSelection();
+	firstReader()->filterScene( m_filterText, m_filterTagText );
+	firstReader()->rebuildSelection();
 
 	SourceGeo::_validate( forReal );
 }
@@ -225,6 +230,11 @@ std::string SceneCacheReader::filePath() const
 
 int SceneCacheReader::knob_changed(Knob* k)
 {
+	if ( firstReader() != this )
+	{
+		return SourceGeo::knob_changed(k);
+	}
+
 	if ( k != NULL ) 
 	{
 		if ( knob("selectable") == k ) 


### PR DESCRIPTION
The previous code was changing the SceneView knob for instances of the Op triggered by Nuke during the validation, which would trigger more instantiations.

The solution was to use the Op::firstOp() method which returns the pointer to the main instance, and make sure we call the knob-updating methods only from that instance.
