### PR TITLE
Improved precision of Imath Vec and Color repr() and str().

### DIFF
--- a/src/IECorePython/ImathColorBinding.cpp
+++ b/src/IECorePython/ImathColorBinding.cpp
@@ -94,7 +94,7 @@ std::string repr<COL>( COL &x )							\
 	s << "IECore." << #COL << "( ";						\
 	for( unsigned i=0; i<COL::dimensions(); i++ )		\
 	{													\
-		s << x[i];										\
+		s << boost::lexical_cast<std::string>( x[i] );	\
 		if( i!=COL::dimensions()-1 )					\
 		{												\
 			s << ", ";									\
@@ -110,7 +110,7 @@ std::string str<COL>( COL &x )							\
 	std::stringstream s;								\
 	for( unsigned i=0; i<COL::dimensions(); i++ )		\
 	{													\
-		s << x[i];										\
+		s << boost::lexical_cast<std::string>( x[i] );	\
 		if( i!=COL::dimensions()-1 )					\
 		{												\
 			s << " ";									\

--- a/src/IECorePython/ImathVecBinding.cpp
+++ b/src/IECorePython/ImathVecBinding.cpp
@@ -159,7 +159,7 @@ std::string repr<VEC>( VEC &x )\
 	s << "IECore." << typeName<VEC>() << "( ";\
 	for( unsigned i=0; i<VEC::dimensions(); i++ )\
 	{\
-		s << x[i];\
+		s << boost::lexical_cast<string>( x[i] );\
 		if( i!=VEC::dimensions()-1 )\
 		{\
 			s << ", ";\
@@ -175,7 +175,7 @@ std::string str<VEC>( VEC &x )\
 	std::stringstream s;\
 	for( unsigned i=0; i<VEC::dimensions(); i++ )\
 	{\
-		s << x[i];\
+		s << boost::lexical_cast<string>( x[i] );\
 		if( i!=VEC::dimensions()-1 )\
 		{\
 			s << " ";\

--- a/test/IECore/Imath.py
+++ b/test/IECore/Imath.py
@@ -37,6 +37,8 @@
 import math
 import unittest
 import random
+
+import IECore
 from IECore import *
 
 class ImathV2f(unittest.TestCase):
@@ -493,6 +495,12 @@ class ImathV3f(unittest.TestCase):
 
 		v1.normalize()
 		self.assertEqual( v1, V3f(1.0, 0.0, 0.0) )
+		
+	def testRepr( self ) :
+	
+		v1 = IECore.V3f( 0.091242323423 )
+		v2 = eval( repr( v1 ) )
+		self.assertEqual( v1, v2 )
 
 class ImathBox3f(unittest.TestCase):
 	def testConstructors(self):
@@ -1106,6 +1114,12 @@ class ImathColor3Test( unittest.TestCase ) :
 		crgb = chsv.hsvToRGB()
 		self.failUnless( chsv.equalWithAbsError( Color3f( 0.5833, 0.6667, 0.3 ), 0.001 ) )
 		self.failUnless( crgb.equalWithAbsError( c, 0.001 ) )
+
+	def testRepr( self ) :
+	
+		c1 = IECore.Color3f( 0.091242323423 )
+		c2 = eval( repr( c1 ) )
+		self.assertEqual( c1, c2 )
 
 class ImathColor4Test( unittest.TestCase ) :
 


### PR DESCRIPTION
This works because boost::lexical_cast contains magic to figure out an appropriate precision for each numeric type. There is a slight speed hit (~10%) for using this call, but these methods shouldn't be performance critical.

With this merged and installed, we should be good to merge https://github.com/ImageEngine/gaffer/pull/765.
