### PR TITLE
return results of config loading

### DIFF
--- a/python/IECore/ConfigLoader.py
+++ b/python/IECore/ConfigLoader.py
@@ -46,6 +46,7 @@ import IECore
 # \ingroup python
 def loadConfig( searchPaths, contextDict, raiseExceptions = False ) :
 
+	configsLoaded = []
 	paths = searchPaths.paths
 	paths.reverse()
 	for path in paths :
@@ -63,5 +64,7 @@ def loadConfig( searchPaths, contextDict, raiseExceptions = False ) :
 					except Exception, m :
 						stacktrace = traceback.format_exc()
 						IECore.msg( IECore.Msg.Level.Error, "IECore.loadConfig", "Error executing file \"%s\" - \"%s\".\n %s" % ( fullFileName, m, stacktrace ) )
+				configsLoaded.append( fullFileName )
+	return configsLoaded
 
 loadConfig( IECore.SearchPath( os.environ.get( "IECORE_CONFIG_PATHS", "" ), ":" ), { "IECore" : IECore } )


### PR DESCRIPTION
Currently, when calling IECore.loadConfig there is no feedback about the results of the call, i.e. the caller has no idea how many and which configs may have been executed. This can make things trickier in situations where it would be useful to verify that an expected number of (or at least some) configs were executed.

For example, this pull request would make it possible to do something such as:

<pre>
configsLoaded = IECore.loadConfig( configPath, { "op": self }, raiseExceptions = True )
if not configsLoaded:
    raise Exception("Configuration required but no config files were loaded!")
</pre>
