### PR TITLE
Fixed bug in CortexConverter SOP todo with multiple CortexObject primitives with the same name

### DIFF
--- a/src/IECoreHoudini/DetailSplitter.cpp
+++ b/src/IECoreHoudini/DetailSplitter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -115,6 +115,7 @@ bool DetailSplitter::validate()
 		GU_Detail *newGeo = new GU_Detail();
 		GA_Range matchPrims( geo->getPrimitiveMap(), oIt->second );
 		newGeo->mergePrimitives( *geo, matchPrims );
+		newGeo->incrementMetaCacheCount();
 		
 		GU_DetailHandle handle;
 		handle.allocateAndSet( newGeo, true );

--- a/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2010-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2010-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -343,6 +343,7 @@ void FromHoudiniGroupConverter::doUnnamedConversion( const GU_Detail *geo, Group
 			GU_Detail *newGeo = new GU_Detail();
 			GA_Range thisPrim( geo->getPrimitiveMap(), offsets );
 			newGeo->mergePrimitives( *geo, thisPrim );
+			newGeo->incrementMetaCacheCount();
 			ObjectPtr object = doDetailConversion( newGeo, operands );
 			if ( VisibleRenderablePtr renderable = IECore::runTimeCast<VisibleRenderable>( object ) )
 			{


### PR DESCRIPTION
This was actually a bug in the DetailSplitter caching mechanism, which was failing to increment the MetaCount on GU_Details that it authored during validation.
