### PR TITLE
Added memory object deduplication for SceneCache.

### DIFF
--- a/include/IECore/StreamIndexedIO.h
+++ b/include/IECore/StreamIndexedIO.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -42,6 +42,7 @@
 #include "boost/optional.hpp"
 #include "boost/iostreams/filtering_stream.hpp"
 
+#include "MurmurHash.h"
 #include "IndexedIO.h"
 #include "Exception.h"
 #include "VectorTypedData.h"
@@ -91,6 +92,8 @@ class StreamIndexedIO : public IndexedIO
 		IndexedIOPtr directory( const IndexedIO::EntryIDList &path, IndexedIO::MissingBehaviour missingBehaviour = IndexedIO::ThrowIfMissing );
 
 		ConstIndexedIOPtr directory( const IndexedIO::EntryIDList &path, IndexedIO::MissingBehaviour missingBehaviour = IndexedIO::ThrowIfMissing ) const;
+
+		MurmurHash entryHash( const IndexedIO::EntryID &name ) const;
 
 		void commit();
 


### PR DESCRIPTION
NOT TO BE MERGED UNTIL MORE TESTS ARE DONE 

Added a non-virtual function entryHash() to StreamIndexedIO (TODO: we should consider adding to IndexedIO in next major version). This function is supposed to return a unique hash for a child entry.

Using this hash in the cache objects in SceneCache, so repetitive Objects will return very quickly. It falls back to the previous hash if the IndexedIO is not derived from StreamIndexedIO (see TODO above)
