### PR TITLE
Scene shape component names

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -132,7 +132,8 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 			componentNames = set( componentNames )
 
 		fullPathName = self.fullPathName()
-		allnames = self.componentNames()
+		allNames = self.componentNames()
+		toSelect = []
 		for i, name in enumerate( allNames ):
 			if name in componentNames:
 				toSelect.append( fullPathName + ".f[" + str( i ) + "]" )
@@ -140,8 +141,9 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 		maya.cmds.select( clear=True )
 		maya.cmds.selectMode( component=True )
 		maya.cmds.hilite( fullPathName )
-		for s in toSelect :
-			maya.cmds.select( s, add=True )
+		if toSelect:
+			maya.cmds.select( toSelect, r=True )
+			
 	
 	## Returns the full path name to this node.
 	def fullPathName( self ) :
@@ -157,7 +159,7 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 	def sceneInterface( self ) :
 
 		return _IECoreMaya._sceneShapeSceneInterface( self )
-		
+	
 	def componentNames( self ) :
 
 		return _IECoreMaya._sceneShapeComponentNames( self )

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1384,11 +1384,15 @@ int SceneShapeInterface::selectionIndex( const IECore::InternedString &name )
 
 IECore::InternedString SceneShapeInterface::selectionName( int index )
 {
+	// make sure the gl scene's been built, as this keeps m_indexToNameMap up to date
+	const_cast<SceneShapeInterface*>( this )->glScene();
 	return m_indexToNameMap[index];
 }
 
 const std::vector< InternedString > & SceneShapeInterface::componentNames() const
 {
+	// make sure the gl scene's been built, as this keeps m_indexToNameMap up to date
+	const_cast<SceneShapeInterface*>( this )->glScene();
 	return m_indexToNameMap;
 }
 

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -195,8 +195,21 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		
 		self.assertEqual( maya.cmds.getAttr( "|test|sceneShape_1|sceneShape_SceneShape1.queryPaths[1]" ), "/" )
 		self.assertTrue( maya.cmds.isConnected( "|test|sceneShape_1|sceneShape_SceneShape1.outObjects[1]", "|test|sceneShape_1|sceneShape_Shape1.inMesh" ) )
-
 	
+	def testComponentNames( self ):
+		
+		maya.cmds.file( new=True, f=True )
+		fn = IECoreMaya.FnSceneShape.create( "test" )
+		maya.cmds.setAttr( fn.fullPathName()+'.file', FnSceneShapeTest.__testFile,type='string' )
+		maya.cmds.setAttr( fn.fullPathName()+".drawGeometry", 0 )
+		self.assertEqual( fn.componentNames(), [] )
+		
+		maya.cmds.setAttr( fn.fullPathName()+".drawGeometry", 1 )
+		self.assertEqual( fn.componentNames(), ['/', '/1', '/1/child', '/1/child/3'] )
+		
+		fn.selectComponentNames( ['/', '/1', '/1/child/3'] )
+		self.assertEqual( fn.selectedComponentNames(), set( ['/', '/1', '/1/child/3'] ) )
+		
 	def tearDown( self ) :
 		
 		if os.path.exists( FnSceneShapeTest.__testFile ) :


### PR DESCRIPTION
Added an ensureComponentNames() method to FnSceneShape, for forcing the computation of the component names if the shape hasn't been drawn in the gl viewport. Also added component names unit test.
