### PR TITLE
 Fixing seg fault when attempting to read a non-existant attribute several times

### DIFF
--- a/src/IECore/SceneCache.cpp
+++ b/src/IECore/SceneCache.cpp
@@ -535,6 +535,7 @@ class SceneCache::ReaderImplementation : public SceneCache::Implementation
 			}
 			if ( !it.first->second )
 			{
+				m_attributeSampleTimes.erase( it.first );
 				throw Exception( ( boost::format( "No samples for attribute %s available" ) % name.value() ).str() );
 			}
 			return *(it.first->second);

--- a/test/IECore/SceneCacheThreadingTest.cpp
+++ b/test/IECore/SceneCacheThreadingTest.cpp
@@ -112,6 +112,16 @@ struct SceneCacheThreadingTest
 		parallel_reduce( blocked_range<size_t>( 0, 100 ), task );
  		BOOST_CHECK( task.errors() == 0 );
 	}
+	
+	void testFakeAttributeRead()
+	{
+		task_scheduler_init scheduler( 100 );
+		
+		TestSceneCache task( "fake" );
+		
+		parallel_reduce( blocked_range<size_t>( 0, 100 ), task );
+ 		BOOST_CHECK( task.errors() == 100000 );
+	}
 
 };
 
@@ -123,6 +133,7 @@ struct SceneCacheThreadingTestSuite : public boost::unit_test::test_suite
 		boost::shared_ptr<SceneCacheThreadingTest> instance( new SceneCacheThreadingTest() );
 
 		add( BOOST_CLASS_TEST_CASE( &SceneCacheThreadingTest::testAttributeRead, instance ) );
+		add( BOOST_CLASS_TEST_CASE( &SceneCacheThreadingTest::testFakeAttributeRead, instance ) );
 	}
 };
 


### PR DESCRIPTION
This issue was introduced by 030e7c9. I also re-wrote that original test using parallel_reduce, in order to make task.errors() return a meaningful result, and I verified that the re-written test still exhibited the original issues that 030e7c9 solved.
