### PR TITLE
Removed unnecessary overhead from Object::copy().

### DIFF
--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -312,8 +312,8 @@ size_t Object::MemoryAccumulator::total() const
 
 ObjectPtr Object::copy() const
 {
-	boost::shared_ptr<CopyContext> c( new CopyContext );
-	ObjectPtr result = c->copy( this );
+	CopyContext c;
+	ObjectPtr result = c.copy( this );
 	return result;
 }
 


### PR DESCRIPTION
This one baffled me for a while. I'm working on the Gaffer::Context implementation both in an attempt to optimise it (in particular, copying them is quite slow) and also to generalise it to allow any RunTimeTyped object as a member (currently it holds only Data). The original Context implementation just uses a CompoundData object internally for storing its members, and I was replacing that with a boost::flat_map which I believed I'd be able to copy construct much more quickly. But no matter what I did, it was always slower. Then I tried just using a std::map, the exact same data structure used internally in CompoundData - slower again. Something didn't make sense until I realised the overhead involved in calling Object::copy()…

In the case where I was using CompoundData internally, I could copy all the entries at once using CompoundData::copy(), but when managing my own map, I had to iterate and call copy() on each member individually. And each call to copy() creates a CopyContext (nothing to do with Gaffer::Context) internally, and it turned out that the CopyContext construction was the major overhead (because I was actually only copying very simple objects). Fortunately most of that overhead was unnecessary, and is removed by this commit.

In my scenario, I believe we could get better performance still by providing a public Object::copy() method which takes a CopyContext explicitly, but for now I think I'd rather not complicate the API with extra stuff - it might be that I can just stop copying stuff in the Gaffer::Context at all...
