### PR TITLE
Fixing default ObjectPool for larger sizes.

### DIFF
--- a/src/IECore/ObjectPool.cpp
+++ b/src/IECore/ObjectPool.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -141,7 +141,7 @@ ObjectPoolPtr ObjectPool::defaultObjectPool()
 	if( !c )
 	{
 		const char *m = getenv( "IECORE_OBJECTPOOL_MEMORY" );
-		int mi = m ? boost::lexical_cast<int>( m ) : 500;
+		size_t mi = m ? boost::lexical_cast<size_t>( m ) : 500;
 		c = new ObjectPool(1024 * 1024 * mi);
 	}
 	return c;


### PR DESCRIPTION
Previously, setting IECORE_OBJECTPOOL_MEMORY = 2048 or larger would overflow the lexical cast, and you'd end up with 18446744071562067968
