### PR TITLE
Changed DespatchedTypedData DataPtr & argument to Data *.

### DIFF
--- a/include/IECore/DespatchTypedData.h
+++ b/include/IECore/DespatchTypedData.h
@@ -34,7 +34,7 @@
 
 //! \file DespatchTypedData.h
 /// Defines useful functions for calling template functions to manipulate
-/// TypedData instances when given only a DataPtr.
+/// TypedData instances when given only a Data *.
 
 
 #ifndef IE_CORE_DESPATCHTYPEDDATA_H
@@ -50,8 +50,8 @@
 namespace IECore
 {
 
-/// Given a DataPtr which points to one a instance of the TypedData classes, call the operator() member function on an
-/// instance of Functor, passing the DataPtr downcast to the correct type. A template parameter, Enabler, allows the
+/// Given a Data * which points to an instance of one of the TypedData classes, call the operator() member function on an
+/// instance of Functor, passing the Data * downcast to the correct type. A template parameter, Enabler, allows the
 /// function to run only on certain subsets of TypedData, for example, only VectorTypeData. The template specified
 /// here should be compatible with boost::mpl - see examples in TypeTraits.h.
 ///
@@ -62,7 +62,7 @@ namespace IECore
 /// struct EH
 /// {
 ///     template<typename DataType, typename Functor>
-///     void operator()( typename DataType::ConstPtr , const Functor& )
+///     void operator()( const DataType *, const Functor & )
 ///     {
 ///         // Handle error here
 ///     }
@@ -77,7 +77,7 @@ namespace IECore
 ///	typedef unspecified-type ReturnType;
 ///
 ///	template<typename T>
-///	ReturnType operator()( typename T::Ptr data )
+///	ReturnType operator()( T *data )
 ///	{
 ///         // Deal with the data and, optionally, return some value
 ///	}
@@ -86,36 +86,36 @@ namespace IECore
 ///
 /// Example uses can be found it the ImageWriter-derived classes
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor, ErrorHandler &errorHandler );
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor, ErrorHandler &errorHandler );
 
 /// Convenience version of despatchTypedData which constructs an ErrorHandler using its default constructor
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor );
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData which constructs the ErrorHandler and Functor using their default constructors
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data );
+typename Functor::ReturnType despatchTypedData( Data *data );
 
 /// Convenience version of despatchTypedData, which throws an InvalidArgumentException when data which doesn't match the Enabler
 /// is encountered
 template< class Functor, template<typename> class Enabler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor );
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData, which throws an InvalidArgumentException when data which doesn't match the Enabler
 /// is encountered.
 template< class Functor, template<typename> class Enabler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data );
+typename Functor::ReturnType despatchTypedData( Data *data );
 
 /// Convenience version of despatchTypedData which operates on all TypedData classes, and constructs an ErrorHandler
 /// using its default constructor
 template< class Functor >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor );
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData which operates on all TypedData classes, constructs the ErrorHandler
 /// and Functor using their default constructors, and throws an InvalidArgumentException when data which isn't TypedData
 /// is encountered.
 template< class Functor >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data );
+typename Functor::ReturnType despatchTypedData( Data *data );
 
 /// Simply returns the result of Trait - this can be used to check TypeTraits at runtime.
 /// e.g. bool isSimple = despatchTraitsTest<TypeTraits::IsSimpleTypedData>( data ).

--- a/include/IECore/DespatchTypedData.inl
+++ b/include/IECore/DespatchTypedData.inl
@@ -60,7 +60,7 @@ struct DespatchTypedData
 	{
 		typedef typename Functor::ReturnType ReturnType;
 
-		ReturnType operator()( typename DataType::Ptr data, Functor &functor, ErrorHandler &errorHandler )
+		ReturnType operator()( DataType *data, Functor &functor, ErrorHandler &errorHandler )
 		{
 			assert( data );
 
@@ -75,7 +75,7 @@ struct DespatchTypedData
 	{
 		typedef typename Functor::ReturnType ReturnType;
 
-		ReturnType operator()( typename DataType::Ptr data, Functor &functor, ErrorHandler & )
+		ReturnType operator()( DataType *data, Functor &functor, ErrorHandler & )
 		{
 			assert( data );
 
@@ -87,7 +87,7 @@ struct DespatchTypedData
 struct DespatchTypedDataExceptionError
 {
 	template<typename T, typename F>
-	void operator()( typename T::ConstPtr data, const F& functor )
+	void operator()( const T *data, const F& functor )
 	{
 		throw InvalidArgumentException( ( boost::format( "Unhandled data of type %s encountered by DespatchTypedData" ) % data->typeName() ).str() );
 	}
@@ -99,13 +99,13 @@ struct DespatchTypedDataExceptionError
 struct DespatchTypedDataIgnoreError
 {
 	template<typename T, typename F>
-	void operator()( typename T::ConstPtr data, const F& functor )
+	void operator()( const T *data, const F& functor )
 	{
 	}
 };
 
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor, ErrorHandler &errorHandler )
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor, ErrorHandler &errorHandler )
 {
 	assert( data );
 
@@ -114,316 +114,316 @@ typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &fu
 		case BoolDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, BoolData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<BoolData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<BoolData *>( data ), functor, errorHandler );
 		case FloatDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, FloatData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<FloatData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<FloatData *>( data ), functor, errorHandler );
 		case DoubleDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, DoubleData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<DoubleData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<DoubleData *>( data ), functor, errorHandler );
 		case IntDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, IntData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<IntData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<IntData *>( data ), functor, errorHandler );
 		case UIntDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UIntData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UIntData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UIntData *>( data ), functor, errorHandler );
 		case CharDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, CharData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<CharData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<CharData *>( data ), functor, errorHandler );
 		case UCharDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UCharData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UCharData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UCharData *>( data ), functor, errorHandler );
 		case ShortDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, ShortData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<ShortData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<ShortData *>( data ), functor, errorHandler );
 		case UShortDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UShortData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UShortData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UShortData *>( data ), functor, errorHandler );
 		case Int64DataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Int64Data, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Int64Data>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Int64Data *>( data ), functor, errorHandler );
 		case UInt64DataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UInt64Data, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UInt64Data>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UInt64Data *>( data ), functor, errorHandler );
 		case StringDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, StringData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<StringData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<StringData *>( data ), functor, errorHandler );
 		case InternedStringDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, InternedStringData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<InternedStringData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<InternedStringData *>( data ), functor, errorHandler );
 		case HalfDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, HalfData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<HalfData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<HalfData *>( data ), functor, errorHandler );
 		case V2iDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2iData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2iData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2iData *>( data ), functor, errorHandler );
 		case V3iDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3iData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3iData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3iData *>( data ), functor, errorHandler );
 		case V2fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2fData *>( data ), functor, errorHandler );
 		case V3fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3fData *>( data ), functor, errorHandler );
 		case V2dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2dData *>( data ), functor, errorHandler );
 		case V3dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3dData *>( data ), functor, errorHandler );
 		case Color3fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color3fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color3fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color3fData *>( data ), functor, errorHandler );
 		case Color4fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color4fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color4fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color4fData *>( data ), functor, errorHandler );
 		case Color3dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color3dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color3dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color3dData *>( data ), functor, errorHandler );
 		case Color4dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color4dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color4dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color4dData *>( data ), functor, errorHandler );
 		case Box2iDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box2iData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box2iData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box2iData *>( data ), functor, errorHandler );
 		case Box2fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box2fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box2fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box2fData *>( data ), functor, errorHandler );
 		case Box3fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box3fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box3fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box3fData *>( data ), functor, errorHandler );
 		case Box2dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box2dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box2dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box2dData *>( data ), functor, errorHandler );
 		case Box3dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box3dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box3dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box3dData *>( data ), functor, errorHandler );
 		case M33fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M33fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M33fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M33fData *>( data ), functor, errorHandler );
 		case M33dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M33dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M33dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M33dData *>( data ), functor, errorHandler );
 		case M44fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M44fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M44fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M44fData *>( data ), functor, errorHandler );
 		case M44dDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M44dData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M44dData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M44dData *>( data ), functor, errorHandler );
 		case TransformationMatrixfDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, TransformationMatrixfData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<TransformationMatrixfData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<TransformationMatrixfData *>( data ), functor, errorHandler );
 		case TransformationMatrixdDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, TransformationMatrixdData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<TransformationMatrixdData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<TransformationMatrixdData *>( data ), functor, errorHandler );
 		case QuatfDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, QuatfData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<QuatfData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<QuatfData *>( data ), functor, errorHandler );
 		case QuatdDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, QuatdData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<QuatdData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<QuatdData *>( data ), functor, errorHandler );
 		case SplineffDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, SplineffData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<SplineffData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<SplineffData *>( data ), functor, errorHandler );
 		case SplineddDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, SplineddData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<SplineddData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<SplineddData *>( data ), functor, errorHandler );
 		case SplinefColor3fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, SplinefColor3fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<SplinefColor3fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<SplinefColor3fData *>( data ), functor, errorHandler );
 		case SplinefColor4fDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, SplinefColor4fData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<SplinefColor4fData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<SplinefColor4fData *>( data ), functor, errorHandler );
 		case CubeColorLookupfDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, CubeColorLookupfData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<CubeColorLookupfData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<CubeColorLookupfData *>( data ), functor, errorHandler );
 		case CubeColorLookupdDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, CubeColorLookupdData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<CubeColorLookupdData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<CubeColorLookupdData *>( data ), functor, errorHandler );
 		case DateTimeDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, DateTimeData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<DateTimeData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<DateTimeData *>( data ), functor, errorHandler );
 		case TimePeriodDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, TimePeriodData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<TimePeriodData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<TimePeriodData *>( data ), functor, errorHandler );
 		case TimeDurationDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, TimeDurationData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<TimeDurationData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<TimeDurationData *>( data ), functor, errorHandler );
 
 		case BoolVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, BoolVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<BoolVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<BoolVectorData *>( data ), functor, errorHandler );
 		case FloatVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, FloatVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<FloatVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<FloatVectorData *>( data ), functor, errorHandler );
 		case DoubleVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, DoubleVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<DoubleVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<DoubleVectorData *>( data ), functor, errorHandler );
 		case HalfVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, HalfVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<HalfVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<HalfVectorData *>( data ), functor, errorHandler );
 		case IntVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, IntVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<IntVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<IntVectorData *>( data ), functor, errorHandler );
 		case UIntVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UIntVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UIntVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UIntVectorData *>( data ), functor, errorHandler );
 		case CharVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, CharVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<CharVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<CharVectorData *>( data ), functor, errorHandler );
 		case UCharVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UCharVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UCharVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UCharVectorData *>( data ), functor, errorHandler );
 		case ShortVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, ShortVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<ShortVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<ShortVectorData *>( data ), functor, errorHandler );
 		case UShortVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UShortVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UShortVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UShortVectorData *>( data ), functor, errorHandler );
 		case Int64VectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Int64VectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Int64VectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Int64VectorData *>( data ), functor, errorHandler );
 		case UInt64VectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, UInt64VectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<UInt64VectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<UInt64VectorData *>( data ), functor, errorHandler );
 		case StringVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, StringVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<StringVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<StringVectorData *>( data ), functor, errorHandler );
 		case InternedStringVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, InternedStringVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<InternedStringVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<InternedStringVectorData *>( data ), functor, errorHandler );
 		case V2iVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2iVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2iVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2iVectorData *>( data ), functor, errorHandler );
 		case V2fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2fVectorData *>( data ), functor, errorHandler );
 		case V2dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V2dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V2dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V2dVectorData *>( data ), functor, errorHandler );
 		case V3iVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3iVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3iVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3iVectorData *>( data ), functor, errorHandler );
 		case V3fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3fVectorData *>( data ), functor, errorHandler );
 		case V3dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, V3dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<V3dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<V3dVectorData *>( data ), functor, errorHandler );
 		case Box3fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box3fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box3fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box3fVectorData *>( data ), functor, errorHandler );
 		case Box3dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Box3dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Box3dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Box3dVectorData *>( data ), functor, errorHandler );
 		case M33fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M33fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M33fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M33fVectorData *>( data ), functor, errorHandler );
 		case M33dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M33dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M33dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M33dVectorData *>( data ), functor, errorHandler );
 		case M44fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M44fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M44fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M44fVectorData *>( data ), functor, errorHandler );
 		case M44dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, M44dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<M44dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<M44dVectorData *>( data ), functor, errorHandler );
 		case QuatfVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, QuatfVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<QuatfVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<QuatfVectorData *>( data ), functor, errorHandler );
 		case QuatdVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, QuatdVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<QuatdVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<QuatdVectorData *>( data ), functor, errorHandler );
 		case Color3fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color3fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color3fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color3fVectorData *>( data ), functor, errorHandler );
 		case Color4fVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color4fVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color4fVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color4fVectorData *>( data ), functor, errorHandler );
 		case Color3dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color3dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color3dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color3dVectorData *>( data ), functor, errorHandler );
 		case Color4dVectorDataTypeId :
 			return
 			typename Detail::DespatchTypedData< Functor, Color4dVectorData, ErrorHandler >
-			::template Func<Enabler>()( staticPointerCast<Color4dVectorData>( data ), functor, errorHandler );
+			::template Func<Enabler>()( static_cast<Color4dVectorData *>( data ), functor, errorHandler );
 
 		default :
 			throw InvalidArgumentException( "Data supplied is not of a known TypedData type." );
@@ -431,7 +431,7 @@ typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &fu
 }
 
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data )
+typename Functor::ReturnType despatchTypedData( Data *data )
 {
 	ErrorHandler e;
 	Functor functor;
@@ -439,33 +439,33 @@ typename Functor::ReturnType despatchTypedData( const DataPtr &data )
 }
 
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor )
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor )
 {
 	ErrorHandler e;
 	return despatchTypedData<Functor, Enabler, ErrorHandler>( data, functor, e );
 }
 
 template< class Functor, template<typename> class Enabler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor )
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor )
 {
 	return despatchTypedData< Functor, Enabler, Detail::DespatchTypedDataExceptionError>( data, functor );
 }
 
 template< class Functor, template<typename> class Enabler >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data )
+typename Functor::ReturnType despatchTypedData( Data *data )
 {
 	Functor functor;
 	return despatchTypedData< Functor, Enabler, Detail::DespatchTypedDataExceptionError>( data, functor );
 }
 
 template< class Functor >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data, Functor &functor )
+typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor )
 {
 	return despatchTypedData< Functor, TypeTraits::IsTypedData, Detail::DespatchTypedDataExceptionError>( data, functor );
 }
 
 template< class Functor >
-typename Functor::ReturnType despatchTypedData( const DataPtr &data )
+typename Functor::ReturnType despatchTypedData( Data *data )
 {
 	Functor functor;
 	return despatchTypedData< Functor, TypeTraits::IsTypedData, Detail::DespatchTypedDataExceptionError>( data, functor );
@@ -478,7 +478,7 @@ struct TypedDataSize
 	template<typename T, typename Enable = void>
 	struct TypedDataSizeHelper
 	{
-		ReturnType operator()( typename T::ConstPtr data ) const
+		ReturnType operator()( const T *data ) const
 		{
 			BOOST_STATIC_ASSERT( sizeof(T) == 0 );
 			return 0;
@@ -486,7 +486,7 @@ struct TypedDataSize
 	};
 
 	template<typename T>
-	ReturnType operator()( typename T::ConstPtr data ) const
+	ReturnType operator()( const T *data ) const
 	{
 		assert( data );
 		return TypedDataSizeHelper<T>()( data );
@@ -496,7 +496,7 @@ struct TypedDataSize
 template<typename T>
 struct TypedDataSize::TypedDataSizeHelper< T, typename boost::enable_if< TypeTraits::IsSimpleTypedData<T> >::type >
 {
-	size_t operator()( typename T::ConstPtr data ) const
+	size_t operator()( const T *data ) const
 	{
 		assert( data );
 		return 1;
@@ -506,7 +506,7 @@ struct TypedDataSize::TypedDataSizeHelper< T, typename boost::enable_if< TypeTra
 template<typename T>
 struct TypedDataSize::TypedDataSizeHelper< T, typename boost::enable_if< TypeTraits::IsVectorTypedData<T> >::type >
 {
-	size_t operator()( typename T::ConstPtr data ) const
+	size_t operator()( const T *data ) const
 	{
 		assert( data );
 		return data->readable().size();
@@ -521,7 +521,7 @@ struct TypedDataAddress
 
 	struct TypedDataAddressHelper
 	{
-		ReturnType operator()( typename T::ConstPtr data ) const
+		ReturnType operator()( const T *data ) const
 		{
 			BOOST_STATIC_ASSERT( sizeof(T) == 0 );
 			return 0;
@@ -529,7 +529,7 @@ struct TypedDataAddress
 	};
  	
 	template<typename T>
-	ReturnType operator()( typename T::ConstPtr data ) const
+	ReturnType operator()( const T *data ) const
 	{
 		assert( data );
 		return TypedDataAddressHelper<T>()( data );
@@ -539,7 +539,7 @@ struct TypedDataAddress
 template<typename T>
 struct TypedDataAddress::TypedDataAddressHelper< T, typename boost::enable_if< TypeTraits::IsSimpleTypedData<T> >::type >
 {
-	const void *operator()( typename T::ConstPtr data ) const
+	const void *operator()( const T *data ) const
 	{
 		assert( data );
 		return &( data->readable() );
@@ -549,7 +549,7 @@ struct TypedDataAddress::TypedDataAddressHelper< T, typename boost::enable_if< T
 template<typename T>
 struct TypedDataAddress::TypedDataAddressHelper< T, typename boost::enable_if< boost::mpl::and_< TypeTraits::IsVectorTypedData<T>, boost::mpl::not_< boost::is_same< typename TypeTraits::VectorValueType<T>::type, bool > > > >::type >
 {
-	const void *operator()( typename T::ConstPtr data ) const
+	const void *operator()( const T *data ) const
 	{
 		assert( data );
 		return &*(data->readable().begin());
@@ -559,7 +559,7 @@ struct TypedDataAddress::TypedDataAddressHelper< T, typename boost::enable_if< b
 template<typename T>
 struct TypedDataAddress::TypedDataAddressHelper< T, typename boost::enable_if< boost::mpl::and_< TypeTraits::IsVectorTypedData<T>, boost::is_same< typename TypeTraits::VectorValueType<T>::type, bool > > >::type >
 {
-	const void *operator()( typename T::ConstPtr data ) const
+	const void *operator()( const T *data ) const
 	{
 		assert( data );
 		return data->baseReadable();
@@ -573,14 +573,14 @@ struct TypedDataInterpolation
 	template< typename T, typename Enable = void >
 	struct TypedDataInterpolationHelper
 	{
-		ReturnType operator()( typename T::ConstPtr d ) const
+		ReturnType operator()( const T *d ) const
 		{
 			return PrimitiveVariable::Invalid;
 		}
 	};
 
 	template< typename T >
-	ReturnType operator()( typename T::ConstPtr d ) const
+	ReturnType operator()( const T *d ) const
 	{
 		return TypedDataInterpolationHelper<T>()( d );
 	}
@@ -589,7 +589,7 @@ struct TypedDataInterpolation
 template< typename T >
 struct TypedDataInterpolation::TypedDataInterpolationHelper<T, typename boost::enable_if< TypeTraits::IsVectorTypedData<T> >::type >
 {
-	ReturnType operator()( typename T::ConstPtr d ) const
+	ReturnType operator()( const T *d ) const
 	{
 		return PrimitiveVariable::Vertex;
 	}
@@ -598,7 +598,7 @@ struct TypedDataInterpolation::TypedDataInterpolationHelper<T, typename boost::e
 template< typename T >
 struct TypedDataInterpolation::TypedDataInterpolationHelper<T, typename boost::enable_if< TypeTraits::IsSimpleTypedData<T> >::type >
 {
-	ReturnType operator()( typename T::ConstPtr d ) const
+	ReturnType operator()( const T *d ) const
 	{
 		return PrimitiveVariable::Constant;
 	}
@@ -615,7 +615,7 @@ struct TraitsTest
 	typedef bool ReturnType;
 
 	template< typename T >
-	ReturnType operator()( typename T::ConstPtr d ) const
+	ReturnType operator()( const T *d ) const
 	{
 		return true;
 	}

--- a/src/IECore/AlexaLogcToLinearOp.cpp
+++ b/src/IECore/AlexaLogcToLinearOp.cpp
@@ -78,6 +78,6 @@ void AlexaLogcToLinearOp::modifyChannels( const Imath::Box2i &displayWindow, con
 	AlexaLogcToLinearOp::Converter converter;
 	for ( ChannelVector::iterator it = channels.begin(); it != channels.end(); it++ )
 	{
-		despatchTypedData<AlexaLogcToLinearOp::Converter, TypeTraits::IsFloatVectorTypedData>( *it, converter );
+		despatchTypedData<AlexaLogcToLinearOp::Converter, TypeTraits::IsFloatVectorTypedData>( it->get(), converter );
 	}
 }

--- a/src/IECore/CurveExtrudeOp.cpp
+++ b/src/IECore/CurveExtrudeOp.cpp
@@ -146,7 +146,7 @@ struct CurveExtrudeOp::VaryingFn
 	}
 
 	template<typename T>
-	DataPtr operator() ( typename T::Ptr data ) const
+	DataPtr operator() ( T *data ) const
 	{
 		assert( data );
 		typedef typename T::ValueType::value_type Value;
@@ -194,12 +194,12 @@ struct CurveExtrudeOp::VaryingFn
 	struct ErrorHandler
 	{
 		template<typename T, typename F>
-		void operator()( typename T::ConstPtr data, const F& functor )
+		void operator()( const T *data, const F& functor )
 		{
 			assert( data );
 			throw InvalidArgumentException( ( boost::format( "CurveExtrudeOp: Invalid data type \"%s\" for primitive variable \"%s\"." ) % Object::typeNameFromTypeId( data->typeId() ) % functor.m_primVarName ).str() );
-                }
-        };
+		}
+	};
 };
 
 struct CurveExtrudeOp::VertexFn
@@ -277,8 +277,8 @@ struct CurveExtrudeOp::VertexFn
 		{
 			assert( data );
 			throw InvalidArgumentException( ( boost::format( "CurveExtrudeOp: Invalid data type \"%s\" for vertex primitive variable \"%s\"." ) % Object::typeNameFromTypeId( data->typeId() ) % functor.m_primVarName ).str() );
-                }
-        };
+		}
+	};
 };
 
 
@@ -295,7 +295,7 @@ struct CurveExtrudeOp::UniformFn
 	}
 
 	template<typename T>
-	DataPtr operator() ( typename T::Ptr data ) const
+	DataPtr operator() ( T *data ) const
 	{
 		assert( data );
 		return new TypedData< typename T::ValueType::value_type >( data->readable()[ m_curveIndex ] );
@@ -304,7 +304,7 @@ struct CurveExtrudeOp::UniformFn
 	struct ErrorHandler
 	{
 		template<typename T, typename F>
-		void operator()( typename T::ConstPtr data, const F& functor )
+		void operator()( const T *data, const F& functor )
 		{
 			assert( data );
 			throw InvalidArgumentException( ( boost::format( "CurveExtrudeOp: Invalid data type \"%s\" for uniform primitive variable \"%s\"." ) % Object::typeNameFromTypeId( data->typeId() ) % functor.m_primVarName ).str() );
@@ -394,7 +394,7 @@ PatchMeshPrimitivePtr CurveExtrudeOp::buildPatchMesh( const CurvesPrimitive * cu
 
 			patchMesh->variables[ it->first ] = PrimitiveVariable(
 				it->second.interpolation,
-				despatchTypedData<VaryingFn, TypeTraits::IsStrictlyInterpolableVectorTypedData>( it->second.data, varyingFn )
+				despatchTypedData<VaryingFn, TypeTraits::IsStrictlyInterpolableVectorTypedData>( it->second.data.get(), varyingFn )
 			);
 
 		}
@@ -405,7 +405,7 @@ PatchMeshPrimitivePtr CurveExtrudeOp::buildPatchMesh( const CurvesPrimitive * cu
 
 			patchMesh->variables[ it->first ] = PrimitiveVariable(
 				it->second.interpolation,
-				despatchTypedData<VertexFn, TypeTraits::IsStrictlyInterpolableVectorTypedData>( it->second.data, vertexFn )
+				despatchTypedData<VertexFn, TypeTraits::IsStrictlyInterpolableVectorTypedData>( it->second.data.get(), vertexFn )
 			);
 
 		}
@@ -418,7 +418,7 @@ PatchMeshPrimitivePtr CurveExtrudeOp::buildPatchMesh( const CurvesPrimitive * cu
 			UniformFn uniformFn( it->first, curves, curveIndex );
 			patchMesh->variables[ it->first ] = PrimitiveVariable(
 				PrimitiveVariable::Constant,
-				despatchTypedData<UniformFn, TypeTraits::IsVectorTypedData>( it->second.data, uniformFn )
+				despatchTypedData<UniformFn, TypeTraits::IsVectorTypedData>( it->second.data.get(), uniformFn )
 			);
 		}
 	}

--- a/src/IECore/ImagePremultiplyOp.cpp
+++ b/src/IECore/ImagePremultiplyOp.cpp
@@ -74,7 +74,7 @@ struct ImagePremultiplyOp::ToFloatVectorData
 	typedef FloatVectorDataPtr ReturnType;
 
 	template<typename T>
-	ReturnType operator()( typename T::ConstPtr dataPtr )
+	ReturnType operator()( const T *dataPtr )
 	{
 		return DataConvert< T, FloatVectorData, ScaledDataConversion< typename T::ValueType::value_type, float > >()( dataPtr );
 	}
@@ -92,7 +92,7 @@ struct ImagePremultiplyOp::PremultFn
 	}
 
 	template<typename T>
-	ReturnType operator()( typename T::Ptr dataPtr )
+	ReturnType operator()( T *dataPtr )
 	{
 		typedef typename T::ValueType Container;
 		typedef typename Container::value_type ValueType;
@@ -133,7 +133,7 @@ void ImagePremultiplyOp::modifyChannels( const Imath::Box2i &displayWindow, cons
 		throw InvalidArgumentException( "ImagePremultiplyOp: Cannot find specified alpha channel" );
 	}
 
-	FloatVectorDataPtr alphaData = despatchTypedData< ToFloatVectorData, TypeTraits::IsNumericVectorTypedData >( it->second.data );
+	FloatVectorDataPtr alphaData = despatchTypedData< ToFloatVectorData, TypeTraits::IsNumericVectorTypedData >( it->second.data.get() );
 
 	ImagePremultiplyOp::PremultFn fn( alphaData );
 	for ( ChannelVector::iterator it = channels.begin(); it != channels.end(); it++ )

--- a/src/IECore/ImagePrimitive.cpp
+++ b/src/IECore/ImagePrimitive.cpp
@@ -382,7 +382,7 @@ bool ImagePrimitive::channelValid( const PrimitiveVariable &pv, std::string *rea
 		return false;
 	}
 
-	size_t size = despatchTypedData<TypedDataSize>( pv.data );
+	size_t size = despatchTypedData<TypedDataSize>( pv.data.get() );
 	size_t numPixels = variableSize( PrimitiveVariable::Vertex );
 	if( size!=numPixels )
 	{

--- a/src/IECore/ImageUnpremultiplyOp.cpp
+++ b/src/IECore/ImageUnpremultiplyOp.cpp
@@ -74,7 +74,7 @@ struct ImageUnpremultiplyOp::ToFloatVectorData
 	typedef FloatVectorDataPtr ReturnType;
 
 	template<typename T>
-	ReturnType operator()( typename T::ConstPtr dataPtr )
+	ReturnType operator()( const T *dataPtr )
 	{
 		return DataConvert< T, FloatVectorData, ScaledDataConversion< typename T::ValueType::value_type, float > >()( dataPtr );
 	}
@@ -92,7 +92,7 @@ struct ImageUnpremultiplyOp::UnpremultFn
 	}
 
 	template<typename T>
-	ReturnType operator()( typename T::Ptr dataPtr )
+	ReturnType operator()( T *dataPtr )
 	{
 		typedef typename T::ValueType Container;
 		typedef typename Container::value_type ValueType;
@@ -136,11 +136,11 @@ void ImageUnpremultiplyOp::modifyChannels( const Imath::Box2i &displayWindow, co
 		throw InvalidArgumentException( "ImageUnpremultiplyOp: Cannot find specified alpha channel" );
 	}
 
-	FloatVectorDataPtr alphaData = despatchTypedData< ToFloatVectorData, TypeTraits::IsNumericVectorTypedData >( it->second.data );
+	FloatVectorDataPtr alphaData = despatchTypedData< ToFloatVectorData, TypeTraits::IsNumericVectorTypedData >( it->second.data.get() );
 
 	ImageUnpremultiplyOp::UnpremultFn fn( alphaData );
 	for ( ChannelVector::iterator it = channels.begin(); it != channels.end(); it++ )
 	{
-		despatchTypedData<ImageUnpremultiplyOp::UnpremultFn, TypeTraits::IsNumericVectorTypedData>( *it, fn );
+		despatchTypedData<ImageUnpremultiplyOp::UnpremultFn, TypeTraits::IsNumericVectorTypedData>( it->get(), fn );
 	}
 }

--- a/src/IECore/LinearToAlexaLogcOp.cpp
+++ b/src/IECore/LinearToAlexaLogcOp.cpp
@@ -79,6 +79,6 @@ void LinearToAlexaLogcOp::modifyChannels( const Imath::Box2i &displayWindow, con
 	LinearToAlexaLogcOp::Converter converter;
 	for ( ChannelVector::iterator it = channels.begin(); it != channels.end(); it++ )
 	{
-		despatchTypedData<LinearToAlexaLogcOp::Converter, TypeTraits::IsFloatVectorTypedData>( *it, converter );
+		despatchTypedData<LinearToAlexaLogcOp::Converter, TypeTraits::IsFloatVectorTypedData>( it->get(), converter );
 	}
 }

--- a/src/IECore/MeshMergeOp.cpp
+++ b/src/IECore/MeshMergeOp.cpp
@@ -115,7 +115,7 @@ struct MeshMergeOp::AppendPrimVars
 	}
 
 	template<typename T>
-	ReturnType operator()( typename T::Ptr data )
+	ReturnType operator()( T *data )
 	{
 		if ( m_visitedData.find( data ) != m_visitedData.end() )
 		{
@@ -164,7 +164,7 @@ struct MeshMergeOp::PrependPrimVars
 	}
 	
 	template<typename T>
-	ReturnType operator()( typename T::ConstPtr data )
+	ReturnType operator()( const T *data )
 	{
 		PrimitiveVariableMap::iterator it = m_mesh->variables.find( m_name );
 		if ( it == m_mesh->variables.end() && !m_remove )
@@ -247,7 +247,7 @@ void MeshMergeOp::modifyTypedPrimitive( MeshPrimitive * mesh, const CompoundObje
 		if ( pvIt2->second.interpolation != PrimitiveVariable::Constant )
 		{
 			PrependPrimVars f( mesh, pvIt2->first, pvIt2->second.interpolation, m_removePrimVarsParameter->getTypedValue(), visitedData2 );
-			despatchTypedData<PrependPrimVars, TypeTraits::IsVectorTypedData, DespatchTypedDataIgnoreError>( pvIt2->second.data, f );
+			despatchTypedData<PrependPrimVars, TypeTraits::IsVectorTypedData, DespatchTypedDataIgnoreError>( pvIt2->second.data.get(), f );
 		}
 	}
 }

--- a/src/IECore/MeshNormalsOp.cpp
+++ b/src/IECore/MeshNormalsOp.cpp
@@ -219,7 +219,7 @@ void MeshNormalsOp::modifyTypedPrimitive( MeshPrimitive * mesh, const CompoundOb
 	const PrimitiveVariable::Interpolation interpolation = static_cast<PrimitiveVariable::Interpolation>( operands->member<IntData>( "interpolation" )->readable() );
 	
 	CalculateNormals f( mesh->verticesPerFace(), mesh->vertexIds(), interpolation );
-	DataPtr n = despatchTypedData<CalculateNormals, TypeTraits::IsVec3VectorTypedData, HandleErrors>( pvIt->second.data, f );
+	DataPtr n = despatchTypedData<CalculateNormals, TypeTraits::IsVec3VectorTypedData, HandleErrors>( pvIt->second.data.get(), f );
 
 	mesh->variables[ nPrimVarNameParameter()->getTypedValue() ] = PrimitiveVariable( interpolation, n );
 }

--- a/src/IECore/MeshPrimitiveShrinkWrapOp.cpp
+++ b/src/IECore/MeshPrimitiveShrinkWrapOp.cpp
@@ -403,5 +403,5 @@ void MeshPrimitiveShrinkWrapOp::modifyTypedPrimitive( MeshPrimitive * mesh, cons
 	}
 
 	ShrinkWrapFn fn( mesh, target, directionVerticesData, direction, method, this->triangulationToleranceParameter()->getNumericValue() );
-	despatchTypedData< ShrinkWrapFn, TypeTraits::IsFloatVec3VectorTypedData, ShrinkWrapFn::ErrorHandler >( verticesData, fn );
+	despatchTypedData< ShrinkWrapFn, TypeTraits::IsFloatVec3VectorTypedData, ShrinkWrapFn::ErrorHandler >( verticesData.get(), fn );
 }

--- a/src/IECore/ParticleWriter.cpp
+++ b/src/IECore/ParticleWriter.cpp
@@ -85,7 +85,7 @@ void ParticleWriter::particleAttributes( std::vector<std::string> &names )
 	{
 		if ( testTypedData<TypeTraits::IsVectorTypedData>( it->second.data ) )
 		{
-			size_t s = despatchTypedData< TypedDataSize, TypeTraits::IsVectorTypedData >( it->second.data );
+			size_t s = despatchTypedData< TypedDataSize, TypeTraits::IsVectorTypedData >( it->second.data.get() );
 			if( s==numParticles )
 			{
 				allNames.push_back( it->first );
@@ -100,7 +100,7 @@ void ParticleWriter::particleAttributes( std::vector<std::string> &names )
 			// it's not data of a vector type but it could be of a simple type
 			// in which case it's suitable for saving as a constant particle attribute
 
-			despatchTypedData< TypedDataAddress, TypeTraits::IsSimpleTypedData >( it->second.data );
+			despatchTypedData< TypedDataAddress, TypeTraits::IsSimpleTypedData >( it->second.data.get() );
 			allNames.push_back( it->first );
 		}
 	}

--- a/src/IECore/PointsMotionOp.cpp
+++ b/src/IECore/PointsMotionOp.cpp
@@ -159,7 +159,7 @@ struct PointsMotionOp::PrimVarBuilder
 	}
 
 	template<typename T>
-	ReturnType operator() ( typename T::Ptr data )
+	ReturnType operator() ( T *data )
 	{
 		typename T::Ptr newData = new T();
 		const typename T::ValueType &dataVec = data->readable();
@@ -329,7 +329,7 @@ ObjectPtr PointsMotionOp::doOperation( const CompoundObject *operands )
 				bool masked = ( maskedPrimvarsSet.find( pIt->first ) != maskedPrimvarsSet.end() );
 				PrimVarBuilder primVarBuilder( pIt->first, masked, snapshot, ids, idMap, objectVector );
 				primitive->variables[ pIt->first ] = PrimitiveVariable( pIt->second.interpolation, 
-						IECore::despatchTypedData< PrimVarBuilder, PrimVarBuilder::CompatibleTypedData >( pIt->second.data, primVarBuilder ) 
+						IECore::despatchTypedData< PrimVarBuilder, PrimVarBuilder::CompatibleTypedData >( pIt->second.data.get(), primVarBuilder ) 
 				);
 			}
 		}

--- a/src/IECore/Primitive.cpp
+++ b/src/IECore/Primitive.cpp
@@ -215,7 +215,7 @@ struct ValidateArraySize
 	}
 
 	template<typename T>
-	bool operator() ( typename T::ConstPtr data )
+	bool operator() ( const T *data )
 	{
 		assert( data );
 
@@ -234,7 +234,7 @@ struct ReturnFalseErrorHandler
 	typedef bool ReturnType;
 
 	template<typename T, typename F>
-	bool operator() ( typename T::ConstPtr data, const F &f )
+	bool operator() ( const T *data, const F &f )
 	{
 		return false;
 	}
@@ -259,7 +259,7 @@ bool Primitive::isPrimitiveVariableValid( const PrimitiveVariable &pv ) const
 	// cases all require arrays so that's what we require.
 	size_t sz = variableSize( pv.interpolation );
 	ValidateArraySize func( sz );
-	return despatchTypedData<ValidateArraySize, TypeTraits::IsVectorTypedData, ReturnFalseErrorHandler>( pv.data, func );
+	return despatchTypedData<ValidateArraySize, TypeTraits::IsVectorTypedData, ReturnFalseErrorHandler>( pv.data.get(), func );
 }
 
 bool Primitive::arePrimitiveVariablesValid() const

--- a/src/IECore/TriangulateOp.cpp
+++ b/src/IECore/TriangulateOp.cpp
@@ -371,10 +371,10 @@ void TriangulateOp::modifyTypedPrimitive( MeshPrimitive * mesh, const CompoundOb
 		TriangulateFn fn( mesh, tolerance, throwExceptions );
 
 		despatchTypedData<
-                        TriangulateFn,
-                        TypeTraits::IsFloatVec3VectorTypedData,
-                        TriangulateFn::ErrorHandler
-                >( verticesData, fn );
+			TriangulateFn,
+			TypeTraits::IsFloatVec3VectorTypedData,
+			TriangulateFn::ErrorHandler
+		>( verticesData.get(), fn );
 	}
 	else
 	{

--- a/src/IECoreGL/MeshPrimitive.cpp
+++ b/src/IECoreGL/MeshPrimitive.cpp
@@ -81,7 +81,7 @@ class MeshPrimitive::MemberData : public IECore::RefCounted
 			}
 
 			template<typename T>
-			IECore::DataPtr operator()( typename T::Ptr inData )
+			IECore::DataPtr operator()( T *inData )
 			{
 				assert( inData );
 
@@ -144,7 +144,7 @@ void MeshPrimitive::addPrimitiveVariable( const std::string &name, const IECore:
 	{
 		MemberData::ToFaceVaryingConverter primVarConverter( m_memberData->vertIds );
 		// convert to facevarying
-		IECore::DataPtr newData = IECore::despatchTypedData< MemberData::ToFaceVaryingConverter, IECore::TypeTraits::IsVectorTypedData >( primVar.data, primVarConverter );
+		IECore::DataPtr newData = IECore::despatchTypedData< MemberData::ToFaceVaryingConverter, IECore::TypeTraits::IsVectorTypedData >( primVar.data.get(), primVarConverter );
 		addVertexAttribute( name, newData );
 	}
 	else if ( primVar.interpolation==IECore::PrimitiveVariable::FaceVarying )

--- a/src/IECoreGL/ToGLCurvesConverter.cpp
+++ b/src/IECoreGL/ToGLCurvesConverter.cpp
@@ -72,7 +72,7 @@ class ToGLCurvesConverter::ToVertexConverter
 		}
 		
 		template<typename T>
-		IECore::DataPtr operator()( typename T::Ptr inData )
+		IECore::DataPtr operator()( const T *inData )
 		{
 			const typename T::Ptr outData = new T();
 			typename T::ValueType &out = outData->writable();
@@ -140,7 +140,7 @@ IECore::RunTimeTypedPtr ToGLCurvesConverter::doConversion( IECore::ConstObjectPt
 		else if( pIt->second.interpolation == IECore::PrimitiveVariable::Uniform )
 		{
 			ToVertexConverter converter( curves->verticesPerCurve()->readable(), curves->variableSize( IECore::PrimitiveVariable::Vertex ), 1 );	
-			IECore::DataPtr newData = IECore::despatchTypedData<ToVertexConverter, IECore::TypeTraits::IsVectorTypedData>( pIt->second.data, converter );
+			IECore::DataPtr newData = IECore::despatchTypedData<ToVertexConverter, IECore::TypeTraits::IsVectorTypedData>( pIt->second.data.get(), converter );
 			if( newData )
 			{
 				result->addPrimitiveVariable( pIt->first, IECore::PrimitiveVariable( IECore::PrimitiveVariable::Vertex, newData ) );


### PR DESCRIPTION
We should only be passing DataPtr & to signify a sharing or ownership, which is not generally the case with DespatchTypedData. This avoids the unnecessary creation and destruction of smart pointers, which in turn make unnecessary addRef() and removeRef() calls, which do have an overhead.

Also replaced some implicit conversions of Ptr to \* with explicit calls to Ptr.get(), in preparation for a move to boost::intrusive_ptr.
