### PR TITLE
Added support for the Ogawa backend into IECoreAlembic.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3062,6 +3062,16 @@ if doConfigure :
 		
 	else :
 	
+		if c.CheckLibWithHeader( alembicEnv.subst( "AlembicOgawa" + env["ALEMBIC_LIB_SUFFIX"] ), "Alembic/AbcCoreOgawa/ReadWrite.h", "CXX" ) :
+			alembicEnv.Append(
+				CPPFLAGS = "-DIECOREALEMBIC_WITH_OGAWA",
+				LIBS = [
+					"AlembicAbcCoreOgawa$ALEMBIC_LIB_SUFFIX",
+					"AlembicAbcCoreFactory$ALEMBIC_LIB_SUFFIX",
+					"AlembicOgawa$ALEMBIC_LIB_SUFFIX",
+				]
+			)
+			
 		c.Finish()	
 		
 		alembicSources = sorted( glob.glob( "contrib/IECoreAlembic/src/IECoreAlembic/*.cpp" ) )

--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicInput.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicInput.cpp
@@ -42,6 +42,10 @@
 #include "Alembic/AbcGeom/IXform.h"
 #include "Alembic/AbcGeom/ICamera.h"
 
+#ifdef IECOREALEMBIC_WITH_OGAWA
+#include "Alembic/AbcCoreFactory/IFactory.h"
+#endif
+
 #include "IECoreAlembic/AlembicInput.h"
 #include "IECoreAlembic/FromAlembicConverter.h"
 
@@ -70,7 +74,20 @@ struct AlembicInput::DataMembers
 AlembicInput::AlembicInput( const std::string &fileName )
 {
 	m_data = boost::shared_ptr<DataMembers>( new DataMembers );
+	
+#ifdef IECOREALEMBIC_WITH_OGAWA
+	Alembic::AbcCoreFactory::IFactory factory;
+	m_data->archive = boost::shared_ptr<IArchive>( new IArchive( factory.getArchive( fileName ) ) );
+	if( !m_data->archive->valid() )
+	{
+		// even though the default policy for IFactory is kThrowPolicy, this appears not to
+		// be applied when it fails to load an archive - instead it returns an invalid archive.
+		throw IECore::Exception( boost::str( boost::format( "Unable to open file \"%s\"" ) % fileName ) );
+	}
+#else
 	m_data->archive = boost::shared_ptr<IArchive>( new IArchive( ::Alembic::AbcCoreHDF5::ReadArchive(), fileName ) );
+#endif
+	
 	m_data->object = m_data->archive->getTop();
 }
 


### PR DESCRIPTION
The availability of the backend is checked in the SConstruct (it's only available for Alembic 1.5 and above), and we fall back to the old code path if its not available.
