### PR TITLE
Allowing MurmurHash objects in python sets and dictionaries

### DIFF
--- a/src/IECorePython/MurmurHashBinding.cpp
+++ b/src/IECorePython/MurmurHashBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2011-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2011-2014, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -68,6 +68,11 @@ static void appendInt( MurmurHash &hash, int64_t v )
 	{
 		hash.append( v );
 	}
+}
+
+static size_t hash( MurmurHash &hash )
+{
+	return tbb_hasher( hash );
 }
 
 void bindMurmurHash()
@@ -146,6 +151,7 @@ void bindMurmurHash()
 		.def( "copyFrom", &MurmurHash::operator=, return_self<>() )
 		.def( "__repr__", &repr )
 		.def( "__str__", &MurmurHash::toString )
+		.def( "__hash__", &hash )
 		.def( "toString", &MurmurHash::toString )
 	;
 

--- a/test/IECore/MurmurHashTest.py
+++ b/test/IECore/MurmurHashTest.py
@@ -215,6 +215,28 @@ class MurmurHashTest( unittest.TestCase ) :
 		h2.append( IECore.StringVectorData( [ "", "" ] ) )
 		
 		self.assertNotEqual( h1, h2 )
+
+	def testHashInSets( self ) :
+
+		h1 = IECore.MurmurHash()		
+		h2 = IECore.MurmurHash()
+		h3 = IECore.MurmurHash()
+		h3.append( 1 )
+		h4 = IECore.MurmurHash()
+		h4.append( "lala" )
+
+		uniqueHashes = set()
+		uniqueHashes.add( h1 )
+		self.assertEqual( len(uniqueHashes), 1 )
+		uniqueHashes.add( h1 )
+		self.assertEqual( len(uniqueHashes), 1 )
+		uniqueHashes.add( h2 )
+		self.assertEqual( len(uniqueHashes), 1 )
+		uniqueHashes.add( h3 )
+		self.assertEqual( len(uniqueHashes), 2 )
+		uniqueHashes.add( h4 )
+		self.assertEqual( len(uniqueHashes), 3 )
+		self.assertEqual( uniqueHashes, set( [ h4, h3, h2, h1 ] ) )
 		
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Just added an implementation for **hash** function using the tbb_hasher.
