### PR TITLE
Fixed numeric TypedData __eq__ and __ne__ bindings.

### DIFF
--- a/src/IECorePython/SimpleTypedDataBinding.cpp
+++ b/src/IECorePython/SimpleTypedDataBinding.cpp
@@ -108,25 +108,27 @@ static typename T::ValueType getValue( T &that )
 }
 
 template<class T>
-static int cmp( T &x, T &y )
+static bool lessThan( const T *x, const T *y )
 {
-	const typename T::ValueType &xData = x.readable();
-	const typename T::ValueType &yData = y.readable();
-	if( xData < yData )
-	{
-		return -1;
-	}
-	if( xData > yData )
-	{
-		return 1;
-	}
-	return 0;
+	return x->readable() < y->readable();
 }
 
-template<>
-int cmp( StringData &x, StringData &y )
+template<class T>
+static bool lessThanOrEqualTo( const T *x, const T *y )
 {
-	return x.readable().compare( y.readable() );
+	return x->readable() <= y->readable();
+}
+
+template<class T>
+static bool greaterThan( const T *x, const T *y )
+{
+	return x->readable() > y->readable();
+}
+
+template<class T>
+static bool greaterThanOrEqualTo( const T *x, const T *y )
+{
+	return x->readable() >= y->readable();
 }
 
 template<>
@@ -321,7 +323,10 @@ static void bindNumericMethods( RunTimeTypedClass<T> &c )
 {
 	c.add_static_property( "minValue", &std::numeric_limits<typename T::ValueType>::min, "Minimum representable value." );
 	c.add_static_property( "maxValue", &std::numeric_limits<typename T::ValueType>::max, "Maximum representable value." );
-	c.def( "__cmp__", &cmp<T>, "Comparison operators ( <, >, >=, <= )" );
+	c.def( "__lt__", &lessThan<T> );
+	c.def( "__le__", &lessThanOrEqualTo<T> );
+	c.def( "__gt__", &greaterThan<T> );
+	c.def( "__ge__", &greaterThanOrEqualTo<T> );
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -331,7 +336,10 @@ static void bindNumericMethods( RunTimeTypedClass<T> &c )
 void bindAllSimpleTypedData()
 {
 	RunTimeTypedClass<StringData> sdc = bindSimpleData<StringData>();
-	sdc.def("__cmp__", &cmp<StringData> );
+	sdc.def( "__lt__", &lessThan<StringData> );
+	sdc.def( "__le__", &lessThanOrEqualTo<StringData> );
+	sdc.def( "__gt__", &greaterThan<StringData> );
+	sdc.def( "__ge__", &greaterThanOrEqualTo<StringData> );
 	
 	bindSimpleData<InternedStringData>();
 

--- a/test/IECore/SimpleTypedData.py
+++ b/test/IECore/SimpleTypedData.py
@@ -336,6 +336,29 @@ class SimpleTypedDataTest(unittest.TestCase):
 			d = IECore.StringData( s )
 			self.assertEqual( eval( repr( d ) ), d )
 
+	def testComparison( self ) :
+	
+		for i in range( 0, 1000 ) :
+		
+			self.assertTrue( IntData( 10 ) < IntData( 20 ) )
+			self.assertFalse( IntData( 20 ) < IntData( 10 ) )
+			
+			self.assertTrue( IntData( 11 ) > IntData( 10 ) )
+			self.assertFalse( IntData( 10 ) > IntData( 10 ) )
+			
+			self.assertTrue( IntData( 11 ) >= IntData( 11 ) )
+			self.assertTrue( IntData( 12 ) >= IntData( 11 ) )
+			self.assertFalse( IntData( 9 ) >= IntData( 10 ) )
+			
+			self.assertTrue( IntData( 11 ) <= IntData( 11 ) )
+			self.assertTrue( IntData( 10 ) <= IntData( 11 ) )
+			self.assertFalse( IntData( 11 ) <= IntData( 10 ) )
+			
+	def testEqualityDoesntThrow( self ) :
+	
+		self.assertFalse( IntData( 100 ) == None )
+		self.assertTrue( IntData( 100 ) != None )
+		
 class BoolDataTest( unittest.TestCase ) :
 
 	def test( self ) :


### PR DESCRIPTION
The nice sensible implementation inherited from the Object base class was being masked by the **cmp** definition, which unhelpfully throws when the second argument is not of the same type as the first. The fix defines **gt**, **ge**, **lt** and **le** individually, leaving the original equality operators as-is. I'm not really sure of the use cases for these operators anyway, and tend to think that `x.value <= y.value` would do the job just as well if not better, but I haven't removed them because there's no way of knowing what Python code uses them in the wild.

In Python 3 **cmp** is totally removed anyway, and defining the operators individually is the only supported form.
