### PR TITLE
Selector

### DIFF
--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "OpenEXR/ImathBox.h"
+#include "OpenEXR/ImathMatrix.h"
 
 #include "IECore/RefCounted.h"
 
@@ -94,6 +95,13 @@ class Selector : boost::noncopyable
 		
 		/// Returns the mode this Selector is operating in.
 		Mode mode() const;
+		
+		/// The post-projection matrix being used to perform
+		/// the selection. This is applied automatically by
+		/// the constructor, but if the projection matrix is
+		/// changed after construction, then this matrix must
+		/// be multiplied with it.
+		const Imath::M44d &postProjectionMatrix();
 		
 		/// Call this to set the name attached to subsequently rendered objects.
 		/// If rendering a Scene, this will be called automatically

--- a/src/IECoreGL/Selector.cpp
+++ b/src/IECoreGL/Selector.cpp
@@ -98,6 +98,7 @@ class Selector::Implementation : public IECore::RefCounted
 			glMatrixMode( GL_PROJECTION );
 			glLoadIdentity();
 			gluPickMatrix( regionCenter.x, regionCenter.y, regionSize.x, regionSize.y, viewport );
+			glGetDoublev( GL_PROJECTION_MATRIX, m_postProjectionMatrix.getValue() );
 			glMultMatrixd( projectionMatrix );
 			glMatrixMode( GL_MODELVIEW );
 
@@ -162,6 +163,11 @@ class Selector::Implementation : public IECore::RefCounted
 		Mode mode() const
 		{
 			return m_mode;
+		}
+
+		const Imath::M44d &postProjectionMatrix()
+		{
+			return m_postProjectionMatrix;
 		}
 
 		void loadName( GLuint name )
@@ -246,6 +252,7 @@ class Selector::Implementation : public IECore::RefCounted
 		}
 		
 		Mode m_mode;
+		Imath::M44d m_postProjectionMatrix;
 		std::vector<HitRecord> &m_hits;
 		StatePtr m_baseState;
 		GLuint m_currentName;
@@ -482,6 +489,11 @@ Selector::~Selector()
 Selector::Mode Selector::mode() const
 {
 	return m_implementation->mode();
+}
+
+const Imath::M44d &Selector::postProjectionMatrix()
+{
+	return m_implementation->postProjectionMatrix();
 }
 
 void Selector::loadName( GLuint name )


### PR DESCRIPTION
This removes a deprecated method from IECoreGL::Selector, and adds a method to allow the Selector to be used with mixed projections - I need the latter for some work I'm doing with overlays in the Gaffer viewer.
