### PR TITLE
Added support for RiFrame blocks in IECoreRI::Renderer.

### DIFF
--- a/include/IECoreRI/Renderer.h
+++ b/include/IECoreRI/Renderer.h
@@ -84,6 +84,10 @@ class Renderer : public IECore::Renderer
 		/// \li <b>"ri:hider:*" StringData()</b></br>
 		/// Passed to an RiHider call.
 		///
+		/// \li <b>"ri:frame" IntData()</b></br>
+		/// Specifies the frame number for RiFrameBegin. If not specified,
+		/// then no frame block will be output.
+		///
 		/// \li <b>"ri:*:*"</b><br>
 		/// Passed to an RiOption call.
 		virtual void setOption( const std::string &name, IECore::ConstDataPtr value );

--- a/src/IECoreRI/RendererImplementation.cpp
+++ b/src/IECoreRI/RendererImplementation.cpp
@@ -612,10 +612,21 @@ void IECoreRI::RendererImplementation::worldBegin()
 			processed = true;
 		}
 		
-		if( !processed && ( name.find_first_of( ":" )==string::npos || name.compare( 0, 3, "ri:" ) == 0 ) )
+		if(
+			!processed &&
+			( name.find_first_of( ":" )==string::npos || name.compare( 0, 3, "ri:" ) == 0 ) &&
+			name != "ri:frame"
+		)
 		{
 			msg( Msg::Warning, "IECoreRI::RendererImplementation::setOption", format( "Unknown option \"%s\"." ) % name );
 		}
+	}
+	
+	// output a frame block if ri:frame has been specified
+	
+	if( const IntData *frame = m_options->member<IntData>( "ri:frame" ) )
+	{
+		RiFrameBegin( frame->readable() );
 	}
 	
 	// get the world fired up
@@ -653,6 +664,11 @@ void IECoreRI::RendererImplementation::worldEnd()
 	RiContext( m_context );
 	RiWorldEnd();
 	m_inWorld = false;
+	
+	if( m_options->member<IntData>( "ri:frame" ) )
+	{
+		RiFrameEnd();
+	}
 	
 	// get our new context which we can emit edits on. we can no longer make
 	// calls to our original context, and we must call RiEnd() with the new one

--- a/test/IECoreRI/Renderer.py
+++ b/test/IECoreRI/Renderer.py
@@ -597,6 +597,25 @@ class RendererTest( IECoreRI.TestCase ) :
 				
 		self.assertTrue( "+z.exr" in rib )
 	
+	def testFrameBlock( self ) :
+	
+		with CapturingMessageHandler() as mh :
+		
+			r = IECoreRI.Renderer( "test/IECoreRI/output/test.rib" )
+		
+			r.setOption( "ri:frame", 10 )
+		
+			with WorldBlock( r ) :
+				pass
+
+			del r
+
+		self.assertEqual( len( mh.messages ), 0 )
+
+		rib = "".join( file( "test/IECoreRI/output/test.rib" ).readlines() )
+		self.assertTrue( "FrameBegin 10" in rib )
+		self.assertTrue( "FrameEnd" in rib )
+	
 	def tearDown( self ) :
 
 		IECoreRI.TestCase.tearDown( self )


### PR DESCRIPTION
If the "ri:frame" option is specified, then it will be used to provide the frame number for the frame block.

This is necessary for ImageEngine/gaffer#358.
