### PR TITLE
Added boost::hash compatibility for MurmurHash.

### DIFF
--- a/include/IECore/MurmurHash.h
+++ b/include/IECore/MurmurHash.h
@@ -159,6 +159,7 @@ class MurmurHash
 		uint64_t m_h2;
 		
 		friend size_t tbb_hasher( const MurmurHash &h );
+		friend size_t hash_value( const MurmurHash &h );
 
 };
 

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -506,6 +506,13 @@ inline size_t tbb_hasher( const MurmurHash &h )
 	return h.m_h1 ^ h.m_h2;
 }
 
+/// Implementation of hash_value for MurmurHash, allowing it to be used with boost::hash,
+/// and therefore as a key in boost::unordered_map.
+inline size_t hash_value( const MurmurHash &h )
+{
+	return h.m_h1 ^ h.m_h2;
+}
+
 } // namespace IECore
 
 #endif // IECORE_MURMURHASH_INL


### PR DESCRIPTION
This means we can use MurmurHash as the key in containers like boost::unordered_map.
