### PR TITLE
SceneCache::hash() uses file name where available

### DIFF
--- a/src/IECore/SceneCache.cpp
+++ b/src/IECore/SceneCache.cpp
@@ -100,7 +100,12 @@ class SceneCache::Implementation : public RefCounted
 			}
 			throw Exception( "File name not available in scene cache!" );
 		}
-
+		
+		bool isFile() const
+		{
+			return m_indexedIO->typeId() == FileIndexedIOTypeId;
+		}
+		
 		bool hasObject() const
 		{
 			return m_indexedIO->hasEntry( objectEntry );
@@ -1020,8 +1025,14 @@ class SceneCache::ReaderImplementation : public SceneCache::Implementation
 
 		static void sceneHash( const ReaderImplementation *scene, MurmurHash &h )
 		{
-			// \todo Currently there's a chance of hash collision if the file is closed and others opened, if the shared data object happens to be allocated in the same address. Replace it by a more reliable mechanism for uniquely identifying the file. 
-			h.append( (uint64_t)scene->m_sharedData );
+			if( scene->isFile() )
+			{
+				h.append( scene->fileName() );
+			}
+			else
+			{
+				h.append( (uint64_t)scene->m_sharedData );
+			}
 			const ReaderImplementation *currScene = scene;
 			while( currScene->m_parent )
 			{


### PR DESCRIPTION
SceneCache::hash() used to use a memory address. Ideally you'd want this method to give a stable result across different processes, so now we use the file name if we're reading a scene cache from a file, and fall back to a memory address if we're using something like a MemoryIndexedIO.
