### PR TITLE
Fixed argument passing for RiProcDynamicLoad.

### DIFF
--- a/src/IECoreRI/RendererImplementation.cpp
+++ b/src/IECoreRI/RendererImplementation.cpp
@@ -1996,6 +1996,14 @@ struct Serialiser
 
 };
 
+void dynamicLoadFree( void *voidData )
+{
+	char **data = (char **)voidData;
+	free( data[0] );
+	free( data[1] );
+	free( data );
+};
+
 } // namespace
 
 void IECoreRI::RendererImplementation::externalProcedural( ExternalProcedural *proc )
@@ -2039,9 +2047,9 @@ void IECoreRI::RendererImplementation::externalProcedural( ExternalProcedural *p
 		const std::string dataString = dataStringStream.str();
 
 		const char **data = (const char **)malloc( sizeof( char * ) * 2 );
-		data[0] = proc->fileName().c_str();
-		data[1] = dataString.c_str();
-		RiProcedural( data, riBound, RiProcDynamicLoad, RiProcFree );
+		data[0] = strdup( proc->fileName().c_str() );
+		data[1] = strdup( dataString.c_str() );
+		RiProcedural( data, riBound, RiProcDynamicLoad, dynamicLoadFree );
 	}
 }
 


### PR DESCRIPTION
We were passing pointers from string::c_str(), where that string might have been destroyed before the procedural subdivide function was invoked. This wasn't caught by the unit tests because when outputting direct to RIB, the strings are used immediately, before returning from the RiProcedural call. We now copy all strings, and use our own free function to ensure that they are cleaned up appropriately.

It's worth noting that the RI Spec is a little misleading on this matter. It says that all three built in procedural types may use the built in RiProcFree, providing this example :

```
RtString args[] = { ”mydso.so”, ”” };
RtBound mybound = { -1, 1, -1, 1, 0, 6 };
RiProcedural ((RtPointer)args, mybound, RiProcDynamicLoad, RiProcFree);
```

This crashes, because args hasn't been malloc'd, so can't be passed to RiProcFree. Even when using malloc, RiProcFree is only of use when passing static strings for `args[0]` and `args[1]`, because it doesn't free the strings referred to within args.
