### PR TITLE
Reduced overhead of calling memoryUsage() on SimpleTypedData.

### DIFF
--- a/src/IECore/SimpleTypedData.cpp
+++ b/src/IECore/SimpleTypedData.cpp
@@ -145,7 +145,7 @@ template<>
 void StringData::memoryUsage( Object::MemoryAccumulator &accumulator ) const
 {
 	Data::memoryUsage( accumulator );
-	accumulator.accumulate( &readable(), readable().capacity() );
+	accumulator.accumulate( readable().capacity() );
 }
 
 template<>


### PR DESCRIPTION
The new implementation is approximately 2x faster than the previous one.
