### PR TITLE
Fixed bug in IECoreRI::Renderer camera editing.

### DIFF
--- a/include/IECoreRI/private/RendererImplementation.h
+++ b/include/IECoreRI/private/RendererImplementation.h
@@ -195,6 +195,7 @@ class RendererImplementation : public IECore::Renderer
 		size_t m_numDisplays;
 		std::string m_lastCamera;
 		bool m_inWorld;
+		bool m_inEdit;
 
 		struct AttributeState
 		{


### PR DESCRIPTION
It was incorrectly storing m_lastCamera (the primary camera) even during edits, meaning that if cameras other than the primary camera were edited, it would lose track of the primary camera. For common sequences of edits (all cameras in order, primary last), this meant the main world camera would never be updated.
