### PR TITLE
Added a GIL lock to python object creator wrapper.

### DIFF
--- a/src/IECorePython/ObjectBinding.cpp
+++ b/src/IECorePython/ObjectBinding.cpp
@@ -38,8 +38,10 @@
 
 #include "IECore/Object.h"
 #include "IECore/MurmurHash.h"
+
 #include "IECorePython/ObjectBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"
+#include "IECorePython/ScopedGILLock.h"
 
 using namespace boost::python;
 using namespace IECore;
@@ -49,6 +51,7 @@ namespace IECorePython
 
 static ObjectPtr creator( void *data )
 {
+	IECorePython::ScopedGILLock gilLock;
 	assert( data );
 	PyObject *d = (PyObject *)(data );
 


### PR DESCRIPTION
Without this, we get crashes if we try to create a Python object via Object::create() from C++, when the calling Python wrapper released the GIL before entering C++. We don't encounter this situation in Cortex so I've been unable to create a test case here, but this is necessary to fix a test case in Gaffer.
