### PR TITLE
Optimised Object::memoryUsage()

### DIFF
--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -285,9 +285,19 @@ void Object::MemoryAccumulator::accumulate( size_t bytes )
 
 void Object::MemoryAccumulator::accumulate( const Object *object )
 {
-	if( m_accumulated.find( object )==m_accumulated.end() )
+	if( object->refCount() > 1 )
 	{
-		m_accumulated.insert( object );
+		// object may occur multiple times in the data structure
+		// being counted - ensure that we don't count it twice.
+		if( m_accumulated.insert( object ).second )
+		{
+			object->memoryUsage( *this );
+		}
+	}
+	else
+	{
+		// object can only occur once in the data structure being
+		// counted - avoid unnecessary bookkeeping overhead.
 		object->memoryUsage( *this );
 	}
 }

--- a/test/IECore/MemoryUsage.py
+++ b/test/IECore/MemoryUsage.py
@@ -53,6 +53,19 @@ class TestMemoryUsage( unittest.TestCase ) :
 		c["b"] = d
 		self.assert_( c.memoryUsage() < m + dm )
 
+	def testMultipleReferencesToStringData( self ) :
+
+		c = CompoundObject()
+		d = StringData( " " * 10000 )
+
+		c["a"] = d
+
+		m = c.memoryUsage()
+		dm = d.memoryUsage()
+
+		c["b"] = d
+		self.assert_( c.memoryUsage() < m + dm )
+
 	def testCopiedDataReferences( self ) :
 
 		"""Copied data shouldn't use additional memory unless the copies have


### PR DESCRIPTION
- Reduced number of set lookups by performing find/insert in one
- Removed bookkeeping for objects with only one owner - they should never be counted twice anyway

This knocks 20% off the total runtime of a certain Gaffer benchmark.
