### PR TITLE
fixed maya sceneshape component selection bug

### DIFF
--- a/src/IECoreMaya/SceneShapeUI.cpp
+++ b/src/IECoreMaya/SceneShapeUI.cpp
@@ -450,7 +450,7 @@ bool SceneShapeUI::snap( MSelectInfo &snapInfo ) const
 	sceneInterface->path( objPath );
 	IECore::SceneInterface::pathToString( objPath, objPathStr );
 	
-	objPathStr += hits[depthMinIndex].name;
+	objPathStr += IECoreGL::NameStateComponent::nameFromGLName( hits[depthMinIndex].name );
 	IECore::SceneInterface::stringToPath( objPathStr, objPath );
 
 	// Validate the hit selection.
@@ -637,7 +637,7 @@ bool SceneShapeUI::select( MSelectInfo &selectInfo, MSelectionList &selectionLis
 			depthMin = hits[i].depthMin;
 			depthMinIndex = componentIndices.length();
 		}
-		int index = sceneShape->selectionIndex( hits[i].name );
+		int index = sceneShape->selectionIndex( IECoreGL::NameStateComponent::nameFromGLName( hits[i].name ) );
 		componentIndices.append( index );
 	}
 	


### PR DESCRIPTION
IECoreGL::HitRecord::name is now storing a GLuint rather than an interned string - I've just updated the scene shape ui code to reflect this
