### PR TITLE
Fixed GILReleasePtr crash.

### DIFF
--- a/src/IECorePython/ScopedGILRelease.cpp
+++ b/src/IECorePython/ScopedGILRelease.cpp
@@ -37,7 +37,7 @@
 using namespace IECorePython;
 
 ScopedGILRelease::ScopedGILRelease()
-	:	m_threadsInitialised( PyEval_ThreadsInitialized() )
+	:	m_threadsInitialised( Py_IsInitialized() && PyEval_ThreadsInitialized() )
 {
 	if( m_threadsInitialised )
 	{


### PR DESCRIPTION
The crashes were observed at shutdown when running the GafferUI test cases. It seemed that some python objects were being destroyed _after_ python had shutdown, and the GILReleasePtr was therefore doing a ScopedGILRelease when python was finalized (or thought it was, despite there still being objects alive) - this lead to errors about NULL thread states. The Py_IsInitialized() call is used to detect this case, and prevents the crash.
