### PR TITLE
Added mip mapping to ColorTexture.

### DIFF
--- a/include/IECoreGL/ColorTexture.h
+++ b/include/IECoreGL/ColorTexture.h
@@ -64,6 +64,9 @@ class IECOREGL_API ColorTexture : public Texture
 		/// Image must have at least RGB channels and all channels
 		/// must be of the same type.
 		ColorTexture( const IECore::ImagePrimitive *image );
+		/// \todo Make all constructors take a mipMap argument with a useful default
+		/// value, then remove this version.
+		ColorTexture( const IECore::ImagePrimitive *image, bool mipMap );
 
 		virtual ~ColorTexture();
 
@@ -72,16 +75,18 @@ class IECOREGL_API ColorTexture : public Texture
 
 	private :
 
+		void construct( const IECore::ImagePrimitive *image, bool mipMap );
+
 		void construct( unsigned int width, unsigned int height, const IECore::Data *r,
-			const IECore::Data *g, const IECore::Data *b, const IECore::Data *a );
+			const IECore::Data *g, const IECore::Data *b, const IECore::Data *a, bool mipMap );
 
 		template<typename T>
 		void castConstruct( unsigned int width, unsigned int height, const IECore::Data *r,
-			const IECore::Data *g, const IECore::Data *b, const IECore::Data *a );
+			const IECore::Data *g, const IECore::Data *b, const IECore::Data *a, bool mipMap );
 
 		template<typename T>
 		void templateConstruct( unsigned int width, unsigned int height, const T *r,
-			const T *g, const T *b, const T *a );
+			const T *g, const T *b, const T *a, bool mipMap );
 
 };
 


### PR DESCRIPTION
The new constructor allows you to specify whether or not you want mipmapping. The old constructors now default to creating mipmaps whereas before they didn't - this does mean a change of behaviour for the automatic creation of textures for GLSL shaders in IECoreGL::Renderer, but hopefully for the better (and matching the existing LuminanceTexture behaviour). If anyone feels strongly that the default should be mipmapping off, then I could jump through some hoops with ToGLTextureConverter and TextureLoader to provide it as an option that can be turned on optionally.

This is necessary because otherwise ImageGadgets in Gaffer look really ropey, and I'm about to start using them.