### PR TITLE
Added implicit conversion from python datetime to DateTimeData.

### DIFF
--- a/src/IECorePython/DateTimeDataBinding.cpp
+++ b/src/IECorePython/DateTimeDataBinding.cpp
@@ -42,6 +42,7 @@
 #include "IECore/DateTimeData.h"
 #include "IECorePython/DateTimeDataBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"
+#include "IECorePython/SimpleTypedDataBinding.h"
 #include "IECorePython/IECoreBinding.h"
 
 #include <sstream>
@@ -184,6 +185,8 @@ void bindDateTimeData()
 
 	ptime_from_python_datetime();
 	to_python_converter<posix_time::ptime, ptime_to_python > ();
+
+	TypedDataFromType<DateTimeData>();
 
 	RunTimeTypedClass<DateTimeData>()
 		.def( init<>() )

--- a/test/IECore/DateTimeDataTest.py
+++ b/test/IECore/DateTimeDataTest.py
@@ -104,6 +104,12 @@ class DateTimeDataTest( unittest.TestCase ) :
 	
 		self.failIf( IECore.DateTimeData.hasBase() )
 
+	def testImplicitConversion( self ) :
+
+		c = IECore.CompoundData()
+		c["d"] = datetime.datetime.now()
+		self.assertTrue( isinstance( c["d"], IECore.DateTimeData ) )
+
 	def setUp(self):
 
 		if os.path.isfile( "test/IECore/DateTimeData.cob" ) :


### PR DESCRIPTION
This is to help with the C++ification of the `Gaffer.Path` class. We already support the same type of conversion for all the SimpleTypedData types, so this is in keeping with what we do generally.