### PR TITLE
IECoreAppleseed improvements

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
@@ -84,6 +84,7 @@ std::string insertEntityWithUniqueName( Container &container, foundation::auto_r
 
 std::string createColorEntity( renderer::ColorContainer &colorContainer, const Imath::C3f &color, const std::string &name );
 std::string createTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );
+std::string createAlphaMapTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );
 
 } // namespace IECoreAppleseed
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
@@ -59,13 +59,15 @@ class AttributeState
 
 		const foundation::Dictionary &visibilityDictionary() const;
 
+		const std::string &alphaMap() const;
+
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
 
 		bool shadingStateValid() const;
 
 		const IECore::MurmurHash &shaderGroupHash() const;
-		const IECore::MurmurHash &materialHash() const;
+		const IECore::MurmurHash materialHash() const;
 
 		std::string createShaderGroup( renderer::Assembly &assembly );
 		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName, const foundation::SearchPaths &searchPaths );
@@ -75,6 +77,7 @@ class AttributeState
 		IECore::CompoundDataPtr m_attributes;
 		ShadingState m_shadingState;
 		std::string m_name;
+		std::string m_alphaMap;
 		foundation::Dictionary m_visibilityDictionary;
 
 };

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -36,7 +36,6 @@
 #define IECOREAPPLESEED_PRIMITIVECONVERTER_H
 
 #include <map>
-#include <set>
 
 #include "boost/noncopyable.hpp"
 #include "boost/filesystem/path.hpp"
@@ -71,7 +70,7 @@ class PrimitiveConverter : boost::noncopyable
 
 		void setMeshFileFormat( MeshFileFormat format );
 
-		const renderer::Assembly *convertPrimitive( IECore::PrimitivePtr primitive, const AttributeState &attrState, const std::string &materialName, renderer::Assembly &parentAssembly );
+		const renderer::Assembly *convertPrimitive( IECore::PrimitivePtr primitive, const AttributeState &attrState, const std::string &materialName, renderer::Assembly &parentAssembly, const foundation::SearchPaths &searchPaths );
 
 	private :
 
@@ -81,6 +80,7 @@ class PrimitiveConverter : boost::noncopyable
 
 		boost::filesystem::path m_projectPath;
 		std::string m_meshGeomExtension;
+		std::map<std::string, const renderer::Assembly*> m_instanceMap;
 		bool m_interactive;
 
 };

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -78,9 +78,11 @@ class PrimitiveConverter : boost::noncopyable
 
 		void createObjectInstance( renderer::Assembly &assembly, const renderer::Object *obj, const std::string &objSourceName, const std::string &materialName );
 
+		typedef std::map<IECore::MurmurHash, const renderer::Assembly*> InstanceMapType;
+
 		boost::filesystem::path m_projectPath;
 		std::string m_meshGeomExtension;
-		std::map<std::string, const renderer::Assembly*> m_instanceMap;
+		InstanceMapType m_instanceMap;
 		bool m_interactive;
 
 };

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
@@ -53,7 +53,6 @@ class ShadingState
 		ShadingState();
 
 		void setShadingSamples( int samples );
-		void setAlphaMap( const std::string &alphaMap );
 
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
@@ -62,7 +61,7 @@ class ShadingState
 		std::string createShaderGroup( renderer::Assembly &assembly );
 
 		const IECore::MurmurHash &materialHash() const;
-		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName, const foundation::SearchPaths &searchPaths );
+		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName, const foundation::SearchPaths &searchPaths, const std::string &alphaMap );
 
 		bool valid() const;
 
@@ -76,7 +75,6 @@ class ShadingState
 		std::vector<IECore::ConstShaderPtr> m_shaders;
 		IECore::ConstShaderPtr m_surfaceShader;
 		int m_shadingSamples;
-		std::string m_alphaMap;
 		IECore::MurmurHash m_shaderGroupHash;
 		IECore::MurmurHash m_materialHash;
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
@@ -165,16 +165,33 @@ string IECoreAppleseed::createColorEntity( asr::ColorContainer &colorContainer, 
 	return insertEntityWithUniqueName( colorContainer, c, name.c_str() );
 }
 
-string IECoreAppleseed::createTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+namespace
+{
+
+string doCreateTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName, const asr::ParamArray &txInstanceParams )
 {
 	asr::ParamArray params;
 	params.insert( "filename", fileName.c_str() );
 	params.insert( "color_space", "linear_rgb" );
 
 	asf::auto_release_ptr<asr::Texture> texture( asr::DiskTexture2dFactory().create( textureName.c_str(), params, searchPaths ) );
-	string txName = insertEntityWithUniqueName( textureContainer, texture, textureName );
+	string txName = IECoreAppleseed::insertEntityWithUniqueName( textureContainer, texture, textureName );
 
 	string textureInstanceName = txName + "_instance";
-	asf::auto_release_ptr<asr::TextureInstance> textureInstance( asr::TextureInstanceFactory().create( textureInstanceName.c_str(), asr::ParamArray(), txName.c_str() ) );
-	return insertEntityWithUniqueName( textureInstanceContainer, textureInstance, textureInstanceName.c_str() );
+	asf::auto_release_ptr<asr::TextureInstance> textureInstance( asr::TextureInstanceFactory().create( textureInstanceName.c_str(), txInstanceParams, txName.c_str() ) );
+	return IECoreAppleseed::insertEntityWithUniqueName( textureInstanceContainer, textureInstance, textureInstanceName.c_str() );
+}
+
+}
+
+string IECoreAppleseed::createTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+{
+	return doCreateTextureEntity( textureContainer, textureInstanceContainer, searchPaths, textureName, fileName, asr::ParamArray() );
+}
+
+string IECoreAppleseed::createAlphaMapTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+{
+	asr::ParamArray params;
+	params.insert( "alpha_mode", "detect" );
+	return doCreateTextureEntity( textureContainer, textureInstanceContainer, searchPaths, textureName, fileName, params );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -34,6 +34,8 @@
 
 #include "foundation/math/scalar.h"
 
+#include "renderer/api/version.h"
+
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
@@ -55,6 +57,7 @@ IECoreAppleseed::AttributeState::AttributeState( const AttributeState &other )
 	m_attributes = other.m_attributes->copy();
 	m_shadingState = other.m_shadingState;
 	m_visibilityDictionary = other.m_visibilityDictionary;
+	m_alphaMap = other.m_alphaMap;
 }
 
 void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDataPtr value )
@@ -76,7 +79,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	{
 		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
 		{
-			m_shadingState.setAlphaMap( f->readable() );
+			m_alphaMap = f->readable();
 		}
 		else
 		{
@@ -137,6 +140,11 @@ const asf::Dictionary &IECoreAppleseed::AttributeState::visibilityDictionary() c
 	return m_visibilityDictionary;
 }
 
+const std::string &IECoreAppleseed::AttributeState::alphaMap() const
+{
+	return m_alphaMap;
+}
+
 void IECoreAppleseed::AttributeState::addOSLShader( ConstShaderPtr shader )
 {
 	m_shadingState.addOSLShader( shader );
@@ -152,14 +160,20 @@ bool IECoreAppleseed::AttributeState::shadingStateValid() const
 	return m_shadingState.valid();
 }
 
-const MurmurHash&IECoreAppleseed::AttributeState::shaderGroupHash() const
+const MurmurHash &IECoreAppleseed::AttributeState::shaderGroupHash() const
 {
 	return m_shadingState.shaderGroupHash();
 }
 
-const MurmurHash&IECoreAppleseed::AttributeState::materialHash() const
+const MurmurHash IECoreAppleseed::AttributeState::materialHash() const
 {
+#if APPLESEED_VERSION > 10100
 	return m_shadingState.materialHash();
+#else
+	MurmurHash h( m_shadingState.materialHash() );
+	h.append( m_alphaMap );
+	return h;
+#endif
 }
 
 string IECoreAppleseed::AttributeState::createShaderGroup( asr::Assembly &assembly )
@@ -169,5 +183,9 @@ string IECoreAppleseed::AttributeState::createShaderGroup( asr::Assembly &assemb
 
 string IECoreAppleseed::AttributeState::createMaterial( asr::Assembly &assembly, const string &shaderGroupName, const asf::SearchPaths &searchPaths )
 {
-	return m_shadingState.createMaterial( assembly, shaderGroupName, searchPaths );
+#if APPLESEED_VERSION > 10100
+	return m_shadingState.createMaterial( assembly, shaderGroupName, searchPaths, "" );
+#else
+	return m_shadingState.createMaterial( assembly, shaderGroupName, searchPaths, alphaMap() );
+#endif
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -85,8 +85,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 	geomAndShadingHash.append( attrState.materialHash() );
 
 	// Check if we already processed this primitive.
-	string assemblyKey = geomAndShadingHash.toString() + "_assembly";
-	std::map<string, const asr::Assembly*>::const_iterator it = m_instanceMap.find( assemblyKey );
+	InstanceMapType::const_iterator it = m_instanceMap.find( geomAndShadingHash );
 	if( it != m_instanceMap.end() )
 	{
 		return it->second;
@@ -151,7 +150,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 	createObjectInstance( *ass, objPtr, objName, materialName );
 	const asr::Assembly *p = ass.get();
 	parentAssembly.assemblies().insert( ass );
-	m_instanceMap[assemblyKey] = p;
+	m_instanceMap[geomAndShadingHash] = p;
 	return p;
 }
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -79,7 +79,9 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 	// the shading / material state in the hash so that objects with
 	// the same geometry but different materials are not instances.
 	MurmurHash geomAndShadingHash( geometryHash );
+#if APPLESEED_VERSION > 10100
 	geomAndShadingHash.append( attrState.alphaMap() );
+#endif
 	geomAndShadingHash.append( attrState.materialHash() );
 
 	// Check if we already processed this primitive.

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -589,7 +589,7 @@ void IECoreAppleseed::RendererImplementation::mesh( IECore::ConstIntVectorDataPt
 		msg( Msg::Warning, "IECoreAppleseed::RendererImplementation", "Geometry without materials (it will render pink)" );
 	}
 
-	const asr::Assembly *assembly = m_primitiveConverter->convertPrimitive( mesh, m_attributeStack.top(), materialName, *m_mainAssembly );
+	const asr::Assembly *assembly = m_primitiveConverter->convertPrimitive( mesh, m_attributeStack.top(), materialName, *m_mainAssembly, m_project->search_paths() );
 	if( !assembly )
 	{
 		msg( MessageHandler::Warning, "IECoreAppleseed::RendererImplementation::Mesh", "Error converting mesh" );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
@@ -66,12 +66,6 @@ void IECoreAppleseed::ShadingState::setShadingSamples(int samples)
 	updateHashes();
 }
 
-void IECoreAppleseed::ShadingState::setAlphaMap( const string& alphaMap )
-{
-	m_alphaMap = alphaMap;
-	updateHashes();
-}
-
 void IECoreAppleseed::ShadingState::addOSLShader( ConstShaderPtr shader )
 {
 	if( m_surfaceShader )
@@ -136,7 +130,7 @@ const MurmurHash&IECoreAppleseed::ShadingState::materialHash() const
 	return m_materialHash;
 }
 
-string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, const std::string &shaderGroupName, const asf::SearchPaths &searchPaths )
+string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, const std::string &shaderGroupName, const asf::SearchPaths &searchPaths, const string &alphaMap )
 {
 	asr::ParamArray params;
 
@@ -150,9 +144,9 @@ string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, c
 	params.insert( "osl_surface", shaderGroupName.c_str() );
 	asf::auto_release_ptr<asr::Material> mat( asr::OSLMaterialFactory().create( "material", params ) );
 
-	if( !m_alphaMap.empty() )
+	if( !alphaMap.empty() )
 	{
-		string alphaMapTextureInstanceName = createTextureEntity( assembly.textures(), assembly.texture_instances(), searchPaths, m_surfaceShader->getName() + "_alpha_map", m_alphaMap );
+		string alphaMapTextureInstanceName = createAlphaMapTextureEntity( assembly.textures(), assembly.texture_instances(), searchPaths, m_surfaceShader->getName() + "_alpha_map", alphaMap );
 		mat->get_parameters().insert( "alpha_map", alphaMapTextureInstanceName.c_str() );
 	}
 
@@ -176,7 +170,6 @@ void IECoreAppleseed::ShadingState::updateHashes()
 
 	m_materialHash = m_shaderGroupHash;
 	m_materialHash.append( m_shadingSamples );
-	m_materialHash.append( m_alphaMap );
 }
 
 asr::ParamArray IECoreAppleseed::ShadingState::convertParameters( const CompoundDataMap &parameters )


### PR DESCRIPTION
A collection of small changes and refactors:

- Highlight regions being rendered in the interactive display driver. Useful when doing multipass rendering.
- Small refactors in the display driver code.
- Use appleseed's newer object alpha maps instead of material alpha maps when possible.
- Use the names set with setAttribute to name the appleseed entities in generated appleseed scene files.
- Removed some unused headers and other formatting changes.

All changes are internal to IECoreAppleseed.
