### PR TITLE
Maya tags and attributes

### DIFF
--- a/src/IECore/LinkedScene.cpp
+++ b/src/IECore/LinkedScene.cpp
@@ -774,6 +774,10 @@ void LinkedScene::readTags( NameList &tags, int filter ) const
 			m_mainScene->readTags( mainTags, mainFilter );
 			tags.insert( tags.end(), mainTags.begin(), mainTags.end() );
 		}
+		
+		// remove duplicates:
+		std::sort( tags.begin(), tags.end() );
+		tags.erase( std::unique( tags.begin(), tags.end() ), tags.end() );
 	}
 	else
 	{

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -381,8 +381,9 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 {
 	OP_Node *node = retrieveNode();
 	
+	// iterate attribute readers in reverse order so the ones registered later take precedence:
 	const std::vector<CustomAttributeReader> &attributeReaders = customAttributeReaders();
-	for ( std::vector<CustomAttributeReader>::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
+	for ( std::vector<CustomAttributeReader>::const_reverse_iterator it = attributeReaders.rbegin(); it != attributeReaders.rend(); ++it )
 	{
 		if ( IECore::ConstObjectPtr object = it->m_read( node, name, time ) )
 		{

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -296,6 +296,10 @@ void LiveScene::attributeNames( NameList &attrs ) const
 	{
 		it->m_names( m_dagPath, attrs );
 	}
+
+	// remove duplicates:
+	std::sort( attrs.begin(), attrs.end() );
+	attrs.erase( std::unique( attrs.begin(), attrs.end() ), attrs.end() );
 }
 
 ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
@@ -383,6 +387,17 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 		return new BoolData( true );
 	}
 
+	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
+	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
+	{
+		ConstObjectPtr attr = it->m_read( m_dagPath, name );
+		if( !attr )
+		{
+			continue;
+		}
+		return attr;
+	}
+
 	if( strstr( name.c_str(), "user:" ) == name.c_str() )
 	{
 
@@ -399,17 +414,7 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 			return plugConverter->convert();
 		}
 	}
-	
-	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
-	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
-	{
-		ConstObjectPtr attr = it->m_read( m_dagPath, name );
-		if( !attr )
-		{
-			continue;
-		}
-		return attr;
-	}
+
 	return IECore::NullObject::defaultNullObject();
 }
 

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -388,7 +388,7 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 	}
 
 	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
-	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
+	for ( std::vector< CustomAttributeReader >::const_reverse_iterator it = attributeReaders.rbegin(); it != attributeReaders.rend(); ++it )
 	{
 		ConstObjectPtr attr = it->m_read( m_dagPath, name );
 		if( !attr )

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -40,6 +40,7 @@
 #include "IECore/NullObject.h"
 
 #include "IECoreMaya/LiveScene.h"
+#include "IECoreMaya/FromMayaPlugConverter.h"
 #include "IECoreMaya/FromMayaTransformConverter.h"
 #include "IECoreMaya/FromMayaShapeConverter.h"
 #include "IECoreMaya/FromMayaDagNodeConverter.h"
@@ -54,6 +55,7 @@
 #include "maya/MFnCamera.h"
 #include "maya/MFnMatrixData.h"
 #include "maya/MFnNumericData.h"
+#include "maya/MFnAttribute.h"
 #include "maya/MSelectionList.h"
 #include "maya/MAnimControl.h"
 #include "maya/MString.h"
@@ -270,10 +272,26 @@ void LiveScene::attributeNames( NameList &attrs ) const
 	{
 		throw Exception( "IECoreMaya::LiveScene::attributeNames: Dag path no longer exists!" );
 	}
-	
+
 	tbb::mutex::scoped_lock l( s_mutex );
 	attrs.clear();
 	attrs.push_back( SceneInterface::visibilityName );
+
+	// translate attributes with names starting with "ieAttr_":
+	MFnDependencyNode fnNode( m_dagPath.node() );
+	unsigned int n = fnNode.attributeCount();
+	for( unsigned int i=0; i<n; i++ )
+	{
+		MObject attr = fnNode.attribute( i );
+		MFnAttribute fnAttr( attr );
+		MString attrName = fnAttr.name();
+		if( attrName.length() > 7 && ( strstr( attrName.asChar(),"ieAttr_" ) == attrName.asChar() ) )
+		{
+			attrs.push_back( ( "user:" + attrName.substring( 7, attrName.length()-1 ) ).asChar() );
+		}
+	}
+
+	// add attributes from custom readers:
 	for ( std::vector< CustomAttributeReader >::const_iterator it = customAttributeReaders().begin(); it != customAttributeReaders().end(); it++ )
 	{
 		it->m_names( m_dagPath, attrs );
@@ -364,6 +382,23 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 	{
 		return new BoolData( true );
 	}
+
+	if( strstr( name.c_str(), "user:" ) == name.c_str() )
+	{
+
+		MStatus st;
+		MFnDependencyNode fnNode( m_dagPath.node() );
+		MPlug attrPlug = fnNode.findPlug( ( "ieAttr_" + name.string().substr(5) ).c_str(), false, &st );
+		if( st )
+		{
+			FromMayaConverterPtr plugConverter = FromMayaPlugConverter::create( attrPlug );
+			if( !plugConverter )
+			{
+				return IECore::NullObject::defaultNullObject();
+			}
+			return plugConverter->convert();
+		}
+	}
 	
 	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
 	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
@@ -422,6 +457,26 @@ void LiveScene::readTags( NameList &tags, int filter ) const
 	}
 	
 	std::set<Name> uniqueTags;
+
+	// read tags from ieTags attribute:
+	MStatus st;
+	MFnDependencyNode fnNode( m_dagPath.node() );
+	MPlug tagsPlug = fnNode.findPlug( "ieTags", false, &st );
+	if( st )
+	{
+		std::string tagsStr( tagsPlug.asString().asChar() );
+		boost::tokenizer<boost::char_separator<char> > t( tagsStr, boost::char_separator<char>( " " ) );
+		for (
+			boost::tokenizer<boost::char_separator<char> >::iterator it = t.begin();
+			it != t.end();
+			++it
+		)
+		{
+			uniqueTags.insert( Name( *it ) );
+		}
+	}
+
+	// read tags from custom readers:
 	std::vector<CustomTagReader> &tagReaders = customTagReaders();
 	for ( std::vector<CustomTagReader>::const_iterator it = tagReaders.begin(); it != tagReaders.end(); ++it )
 	{

--- a/test/IECore/LinkedSceneTest.py
+++ b/test/IECore/LinkedSceneTest.py
@@ -505,11 +505,12 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testTags( self ) :
 
-		def testSet( values ):
-			return set( map( lambda s: IECore.InternedString(s), values ) )
+		def testList( values ):
+			return sorted( map( lambda s: str(s), values ) )
 
 		# create a base scene
 		l = IECore.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l.writeTags( ['top'] )
 		a = l.createChild('a')
 		a.writeTags( [ "testA" ] )
 		b = l.createChild('b')
@@ -522,13 +523,13 @@ class LinkedSceneTest( unittest.TestCase ) :
 		a = l.child('a')
 		b = l.child('b')
 
-		self.assertEqual( set(l.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["testA", "testB", "tags"]) )
-		self.assertEqual( set(l.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["tags"]) )
-		self.assertEqual( set(a.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), testSet(["tags"]) )
-		self.assertEqual( set(a.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), set() )
-		self.assertEqual( set(a.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["testA"]) )
-		self.assertEqual( set(b.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["testB"]) )
-		self.assertEqual( set(b.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["testB"]) )
+		self.assertEqual( testList(l.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["tags", "testA", "testB", "top"] )
+		self.assertEqual( testList(l.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["tags", "top"] )
+		self.assertEqual( testList(a.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), ["tags", "top"] )
+		self.assertEqual( testList(a.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), [] )
+		self.assertEqual( testList(a.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["testA"] )
+		self.assertEqual( testList(b.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["testB"] )
+		self.assertEqual( testList(b.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["testB"] )
 		self.assertTrue( l.hasTag("testA", IECore.SceneInterface.TagFilter.EveryTag) )
 		self.assertTrue( l.hasTag("testB", IECore.SceneInterface.TagFilter.EveryTag) )
 		self.assertFalse( l.hasTag("testA", IECore.SceneInterface.TagFilter.LocalTag) )
@@ -542,7 +543,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		A = l2.createChild('A')
 		A.writeLink( l )
-		A.writeTags( ['linkedA'] )	# creating tag after link
+		A.writeTags( ['linkedA', 'top'] )	# creating tag after link
 
 		B = l2.createChild('B')
 
@@ -582,34 +583,34 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertTrue( l2.hasTag("testB", IECore.SceneInterface.TagFilter.EveryTag) )
 		self.assertFalse( l2.hasTag("t", IECore.SceneInterface.TagFilter.EveryTag) )
 
-		self.assertEqual( set(l2.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet([]) )
-		self.assertEqual( set(l2.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), testSet(["testA", "testB","tags", "C", "D","linkedA"]) )
-		self.assertEqual( set(l2.readTags(IECore.SceneInterface.TagFilter.LocalTag|IECore.SceneInterface.TagFilter.DescendantTag)), testSet(["testA", "testB","tags", "C", "D","linkedA"]) )
-		self.assertEqual( set(l2.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), testSet([]) )
-		self.assertEqual( set(A.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["testA","testB", "tags","linkedA"]) )
+		self.assertEqual( testList(l2.readTags(IECore.SceneInterface.TagFilter.LocalTag)), [] )
+		self.assertEqual( testList(l2.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), ["C", "D", "linkedA","tags","testA", "testB", "top"] )
+		self.assertEqual( testList(l2.readTags(IECore.SceneInterface.TagFilter.LocalTag|IECore.SceneInterface.TagFilter.DescendantTag)), ["C", "D", "linkedA","tags","testA", "testB", "top"] )
+		self.assertEqual( testList(l2.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), [] )
+		self.assertEqual( testList(A.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["linkedA", "tags", "testA","testB", "top"] )
 		self.assertTrue( A.hasTag( "linkedA", IECore.SceneInterface.TagFilter.EveryTag ) )
 		self.assertTrue( A.hasTag( "tags", IECore.SceneInterface.TagFilter.EveryTag ) )
 		self.assertTrue( A.hasTag( "testA", IECore.SceneInterface.TagFilter.EveryTag ) )
 		self.assertTrue( A.hasTag( "testB", IECore.SceneInterface.TagFilter.EveryTag ) )
 		self.assertFalse( A.hasTag("C", IECore.SceneInterface.TagFilter.EveryTag) )
-		self.assertEqual( set(A.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["tags","linkedA"]) )
-		self.assertEqual( set(Aa.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["tags","testA", "linkedA"]) )
-		self.assertEqual( set(Aa.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), testSet(["tags", "linkedA"]) )
-		self.assertEqual( set(Aa.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["testA"]) )
+		self.assertEqual( testList(A.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["linkedA","tags","top"] )
+		self.assertEqual( testList(Aa.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["linkedA","tags","testA","top"] )
+		self.assertEqual( testList(Aa.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), ["linkedA","tags","top"] )
+		self.assertEqual( testList(Aa.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["testA"] )
 		self.assertTrue( Aa.hasTag("testA", IECore.SceneInterface.TagFilter.EveryTag) )
 		self.assertFalse( Aa.hasTag("testB", IECore.SceneInterface.TagFilter.EveryTag) )
-		self.assertEqual( set(B.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["testA", "tags"]) )	# should not list "linkedA" as the link pointed to a child location.
-		self.assertEqual( set(C.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["testA","testB","tags","C"]) )
-		self.assertEqual( set(C.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["C"]) )
-		self.assertEqual( set(c.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["C", "testA", "testB","tags"]) )
-		self.assertEqual( set(c.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["tags"]) )
-		self.assertEqual( set(c.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), testSet([ "testA", "testB" ]) )
-		self.assertEqual( set(ca.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["testA"]) )
-		self.assertEqual( set(ca.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), testSet(["C", "tags"]) )
+		self.assertEqual( testList(B.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["tags","testA","top"] )	# should not list "linkedA" as the link pointed to a child location.
+		self.assertEqual( testList(C.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["C","tags","testA","testB","top"] )
+		self.assertEqual( testList(C.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["C"] )
+		self.assertEqual( testList(c.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["C", "tags","testA", "testB","top"] )
+		self.assertEqual( testList(c.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["tags","top"] )
+		self.assertEqual( testList(c.readTags(IECore.SceneInterface.TagFilter.DescendantTag)), [ "testA", "testB" ] )
+		self.assertEqual( testList(ca.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["testA"] )
+		self.assertEqual( testList(ca.readTags(IECore.SceneInterface.TagFilter.AncestorTag)), ["C", "tags", "top"] )
 		self.assertTrue( ca.hasTag("testA", IECore.SceneInterface.TagFilter.EveryTag) )
 		self.assertFalse( ca.hasTag("testB", IECore.SceneInterface.TagFilter.EveryTag) )
-		self.assertEqual( set(C.readTags(IECore.SceneInterface.TagFilter.LocalTag)), testSet(["C"]) )
-		self.assertEqual( set(D.readTags(IECore.SceneInterface.TagFilter.EveryTag)), testSet(["tags", "D", "testA"]) )
+		self.assertEqual( testList(C.readTags(IECore.SceneInterface.TagFilter.LocalTag)), ["C"] )
+		self.assertEqual( testList(D.readTags(IECore.SceneInterface.TagFilter.EveryTag)), ["D", "tags", "testA", "top"] )
 	
 	def testMissingLinkedScene( self ) :
 		

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -824,6 +824,48 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		finally:
 			doDuplicateNameTest = False
 
+	def testCustomAttributePrecedence( self ) :
+		
+		doCustomAttributePrecedenceTest = True
+		
+		t = maya.cmds.createNode( "transform" )
+		maya.cmds.currentTime( "0sec" )
+		
+		def myAttributeNames1( node ):
+			if not doCustomAttributePrecedenceTest:
+				return []
+			return["test"]
+
+		def readMyAttribute1( node, attr ):
+			if not doCustomAttributePrecedenceTest:
+				return None
+			if attr == "test":
+				return IECore.IntData( 1 )
+
+		def myAttributeNames2( node ):
+			if not doCustomAttributePrecedenceTest:
+				return []
+			return["test"]
+
+		def readMyAttribute2( node, attr ):
+			if not doCustomAttributePrecedenceTest:
+				return None
+			if attr == "test":
+				return IECore.IntData( 2 )
+
+		IECoreMaya.LiveScene.registerCustomAttributes( myAttributeNames1, readMyAttribute1 )
+		IECoreMaya.LiveScene.registerCustomAttributes( myAttributeNames2, readMyAttribute2 )
+		
+		try:
+			scene = IECoreMaya.LiveScene()
+			transformScene = scene.child(str(t))
+
+			# The second custom reader we registered should have taken precedence:
+			self.assertEqual( transformScene.readAttribute( "test", 0 ), IECore.IntData(2) )
+		finally:
+			doCustomAttributePrecedenceTest = False
+		
+	
 	def testSceneVisible( self ) :
 		
 		maya.cmds.createNode( "transform", name = "t1" )

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -586,6 +586,17 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		# tests a bug where calling attributeNames at the root raised an exception
 		scene.attributeNames()
 	
+	def testTags( self ) :
+		
+		t = maya.cmds.createNode( "transform" )
+		maya.cmds.addAttr( t, ln="ieTags", dt="string" )
+		maya.cmds.setAttr( t + ".ieTags", "pizza burger", type="string" )
+		
+		scene = IECoreMaya.LiveScene()
+		transformScene = scene.child(str(t))
+		
+		self.assertEqual( set( transformScene.readTags() ), set( [IECore.InternedString("pizza"), IECore.InternedString("burger") ] ) )
+
 	def testCustomTags( self ) :
 
 		t = maya.cmds.createNode( "transform" )
@@ -659,7 +670,49 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		# Disable custom tag functions so they don't mess with other tests
 		doTest = False
 	
-	
+	def testAttributes( self ) :
+		
+		maya.cmds.currentTime( "0sec" )
+		t = maya.cmds.createNode( "transform", name="t1" )
+		
+		maya.cmds.addAttr( t, ln="ieAttr_bool", at="bool" )
+		maya.cmds.addAttr( t, ln="ieAttr_float", at="float" )
+		maya.cmds.addAttr( t, ln="ieAttr_double", at="double" )
+		maya.cmds.addAttr( t, ln="ieAttr_doubleAngle", at="doubleAngle" )
+		maya.cmds.addAttr( t, ln="ieAttr_doubleLinear", at="doubleLinear" )
+		maya.cmds.addAttr( t, ln="ieAttr_message", at="message" )
+		maya.cmds.addAttr( t, ln="ieAttr_time", at="time" )
+		maya.cmds.addAttr( t, ln="ieAttr_fltMatrix", at="fltMatrix" )
+		maya.cmds.addAttr( t, ln="ieAttr_string", dt="string" )
+		
+		scene = IECoreMaya.LiveScene()
+		transformScene = scene.child(str(t))
+		
+		self.assertEqual( set( transformScene.attributeNames()),
+			set( [
+				"scene:visible",
+				"user:bool",
+				"user:float",
+				"user:double",
+				"user:doubleAngle",
+				"user:doubleLinear",
+				"user:message",
+				"user:time",
+				"user:fltMatrix",
+				"user:string"
+			] )
+		)
+		
+		self.failUnless( isinstance( transformScene.readAttribute("user:bool",0), IECore.BoolData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:float",0), IECore.FloatData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:double",0), IECore.DoubleData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:doubleAngle",0), IECore.DoubleData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:doubleLinear",0), IECore.DoubleData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:message",0), IECore.NullObject ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:time",0), IECore.DoubleData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:fltMatrix",0), IECore.M44dData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:string",0), IECore.StringData ) )
+
 	def testCustomAttributes( self ) :
 	
 		t = maya.cmds.createNode( "transform" )


### PR DESCRIPTION
Attributes on maya transforms with names beginning with "ieAttr_" are now translated into attributes prefixed by "user:" in the IECoreMaya::LiveScene. Also, if a transform has a string attribute called called ieTags, the attributes contents are interpreted as a space separated list of tags for that location by the LiveScene.

I'm also removing duplicate tag names in the IECoreMaya.LiveScene and the LinkedScene, and removing duplicate attribute names in the IECoreMaya.LiveScene. Also, the most recently registered custom attribute reader now takes precedence in the IECoreMaya.LiveScene (it used to be the first)