### PR TITLE
IECoreAppleseed improvements and refactors.

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/Renderer.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/Renderer.h
@@ -83,7 +83,7 @@ class Renderer : public IECore::Renderer
 		/// True if the environment is visible in the background.
 		///
 		/// \li <b>"as:cfg:*"</b><br>
-		/// Passed to appleseed Configuration.
+		/// Passed to appleseed configuration (render settings).
 		virtual void setOption( const std::string &name, IECore::ConstDataPtr value );
 		virtual IECore::ConstDataPtr getOption( const std::string &name ) const;
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/bindings/RendererBinding.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/bindings/RendererBinding.h
@@ -40,6 +40,6 @@ namespace IECoreAppleseed
 
 void bindRenderer();
 
-} // namespace IECoreArnold
+} // namespace IECoreAppleseed
 
 #endif // IECOREAPPLESEED_RENDERERBINDING_H

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
@@ -84,6 +84,7 @@ std::string insertEntityWithUniqueName( Container &container, foundation::auto_r
 
 std::string createColorEntity( renderer::ColorContainer &colorContainer, const Imath::C3f &color, const std::string &name );
 std::string createTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );
+std::string createAlphaMapTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );
 
 } // namespace IECoreAppleseed
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/BatchPrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/BatchPrimitiveConverter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2014, Esteban Tovagliari. All rights reserved.
+//  Copyright (c) 2015, Esteban Tovagliari. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -32,56 +32,36 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef IECOREAPPLESEED_ATTRIBUTESTATE_H
-#define IECOREAPPLESEED_ATTRIBUTESTATE_H
+#ifndef IECOREAPPLESEED_BATCHPRIMITIVECONVERTER_H
+#define IECOREAPPLESEED_BATCHPRIMITIVECONVERTER_H
 
-#include "renderer/api/utility.h"
+#include "boost/filesystem/path.hpp"
 
-#include "IECore/CompoundData.h"
-
-#include "IECoreAppleseed/private/ShadingState.h"
+#include "IECoreAppleseed/private/PrimitiveConverter.h"
 
 namespace IECoreAppleseed
 {
 
-class AttributeState
+/// A PrimitiveConverter subclass that writes primitives to geometry files.
+class BatchPrimitiveConverter : public PrimitiveConverter
 {
-
 	public :
 
-		AttributeState();
-		AttributeState( const AttributeState &other );
+		BatchPrimitiveConverter( const boost::filesystem::path &projectPath, const foundation::SearchPaths &searchPaths );
 
-		IECore::ConstDataPtr getAttribute( const std::string &name ) const;
-		void setAttribute( const std::string &name, IECore::ConstDataPtr value );
-
-		const std::string &name() const;
-
-		const foundation::Dictionary &visibilityDictionary() const;
-
-		const std::string &alphaMap() const;
-
-		void addOSLShader( IECore::ConstShaderPtr shader );
-		void setOSLSurface( IECore::ConstShaderPtr surface );
-
-		bool shadingStateValid() const;
-
-		const IECore::MurmurHash &shaderGroupHash() const;
-		const IECore::MurmurHash &materialHash() const;
-
-		std::string createShaderGroup( renderer::Assembly &assembly );
-		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName );
+		virtual void setOption( const std::string &name, IECore::ConstDataPtr value );
 
 	private :
 
-		IECore::CompoundDataPtr m_attributes;
-		ShadingState m_shadingState;
-		std::string m_name;
-		std::string m_alphaMap;
-		foundation::Dictionary m_visibilityDictionary;
+		boost::filesystem::path m_projectPath;
+		std::string m_meshGeomExtension;
+
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash );
+
+		foundation::auto_release_ptr<renderer::Object> convertAndWriteMeshPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &meshHash );
 
 };
 
 } // namespace IECoreAppleseed
 
-#endif // IECOREAPPLESEED_ATTRIBUTESTATE_H
+#endif // IECOREAPPLESEED_BATCHPRIMITIVECONVERTER_H

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/InteractivePrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/InteractivePrimitiveConverter.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2014, Esteban Tovagliari. All rights reserved.
+//  Copyright (c) 2015, Esteban Tovagliari. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -32,56 +32,26 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef IECOREAPPLESEED_ATTRIBUTESTATE_H
-#define IECOREAPPLESEED_ATTRIBUTESTATE_H
+#ifndef IECOREAPPLESEED_INTERACTIVEPRIMITIVECONVERTER_H
+#define IECOREAPPLESEED_INTERACTIVEPRIMITIVECONVERTER_H
 
-#include "renderer/api/utility.h"
-
-#include "IECore/CompoundData.h"
-
-#include "IECoreAppleseed/private/ShadingState.h"
+#include "IECoreAppleseed/private/PrimitiveConverter.h"
 
 namespace IECoreAppleseed
 {
 
-class AttributeState
+/// A PrimitiveConverter subclass that converts primitives to appleseed entities.
+class InteractivePrimitiveConverter : public PrimitiveConverter
 {
-
 	public :
 
-		AttributeState();
-		AttributeState( const AttributeState &other );
-
-		IECore::ConstDataPtr getAttribute( const std::string &name ) const;
-		void setAttribute( const std::string &name, IECore::ConstDataPtr value );
-
-		const std::string &name() const;
-
-		const foundation::Dictionary &visibilityDictionary() const;
-
-		const std::string &alphaMap() const;
-
-		void addOSLShader( IECore::ConstShaderPtr shader );
-		void setOSLSurface( IECore::ConstShaderPtr surface );
-
-		bool shadingStateValid() const;
-
-		const IECore::MurmurHash &shaderGroupHash() const;
-		const IECore::MurmurHash &materialHash() const;
-
-		std::string createShaderGroup( renderer::Assembly &assembly );
-		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName );
+		explicit InteractivePrimitiveConverter( const foundation::SearchPaths &searchPaths );
 
 	private :
 
-		IECore::CompoundDataPtr m_attributes;
-		ShadingState m_shadingState;
-		std::string m_name;
-		std::string m_alphaMap;
-		foundation::Dictionary m_visibilityDictionary;
-
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash );
 };
 
 } // namespace IECoreAppleseed
 
-#endif // IECOREAPPLESEED_ATTRIBUTESTATE_H
+#endif // IECOREAPPLESEED_INTERACTIVEPRIMITIVECONVERTER_H

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -36,10 +36,8 @@
 #define IECOREAPPLESEED_PRIMITIVECONVERTER_H
 
 #include <map>
-#include <set>
 
 #include "boost/noncopyable.hpp"
-#include "boost/filesystem/path.hpp"
 
 #include "renderer/api/scene.h"
 #include "renderer/api/object.h"
@@ -47,13 +45,12 @@
 #include "IECore/MurmurHash.h"
 #include "IECore/Primitive.h"
 
-#include "IECoreAppleseed/private/PrimitiveConverter.h"
 #include "IECoreAppleseed/private/AttributeState.h"
 
 namespace IECoreAppleseed
 {
 
-/// A class for managing the conversion of a series of IECore::Primitives to
+/// An abstract base class for managing the conversion of a series of IECore::Primitives to
 /// appleseed entities, automatically creating instances when a previously
 /// converted primitive is processed again.
 class PrimitiveConverter : boost::noncopyable
@@ -61,27 +58,25 @@ class PrimitiveConverter : boost::noncopyable
 
 	public :
 
-		typedef enum
-		{
-			BinaryMeshFormat,
-			ObjFormat
-		} MeshFileFormat;
+		explicit PrimitiveConverter( const foundation::SearchPaths &searchPaths );
 
-		explicit PrimitiveConverter( const boost::filesystem::path &projectPath );
+		virtual ~PrimitiveConverter();
 
-		void setMeshFileFormat( MeshFileFormat format );
+		virtual void setOption( const std::string &name, IECore::ConstDataPtr value );
 
 		const renderer::Assembly *convertPrimitive( IECore::PrimitivePtr primitive, const AttributeState &attrState, const std::string &materialName, renderer::Assembly &parentAssembly );
 
 	private :
 
-		foundation::auto_release_ptr<renderer::Object> convertAndWriteMeshPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &meshHash );
-
 		void createObjectInstance( renderer::Assembly &assembly, const renderer::Object *obj, const std::string &objSourceName, const std::string &materialName );
 
-		boost::filesystem::path m_projectPath;
-		std::string m_meshGeomExtension;
-		bool m_interactive;
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash ) = 0;
+
+		typedef std::map<IECore::MurmurHash, const renderer::Assembly*> InstanceMapType;
+
+		const foundation::SearchPaths &m_searchPaths;
+		InstanceMapType m_instanceMap;
+		bool m_autoInstancing;
 
 };
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/RendererImplementation.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/RendererImplementation.h
@@ -39,10 +39,11 @@
 #include <stack>
 
 #include "boost/filesystem/path.hpp"
-#include "boost/shared_ptr.hpp"
 
 #include "renderer/modeling/project/project.h"
 #include "renderer/modeling/scene/assembly.h"
+
+#include "IECore/Camera.h"
 
 #include "IECoreAppleseed/Renderer.h"
 #include "IECoreAppleseed/private/AttributeState.h"
@@ -122,17 +123,9 @@ class RendererImplementation : public IECore::Renderer
 
 	private :
 
-		enum Mode
-		{
-			GenerateProject,
-			Render
-		};
+		void constructCommon();
 
-		// this class is non-copyable for now as
-		// appleseed does not have support for procedurals yet...
-		RendererImplementation( const RendererImplementation &other );
-
-		void constructCommon( Mode mode );
+		void setCamera( IECore::CameraPtr cortexCamera, foundation::auto_release_ptr<renderer::Camera> &camera );
 
 		std::string currentShaderGroupName();
 		std::string currentMaterialName();
@@ -155,7 +148,7 @@ class RendererImplementation : public IECore::Renderer
 			return 0;
 		}
 
-		Mode m_mode;
+		bool m_interactive;
 		std::string m_fileName;
 		boost::filesystem::path m_projectPath;
 
@@ -180,7 +173,7 @@ class RendererImplementation : public IECore::Renderer
 		// project related
 		foundation::auto_release_ptr<renderer::Project> m_project;
 		renderer::Assembly *m_mainAssembly;
-		boost::shared_ptr<PrimitiveConverter> m_primitiveConverter;
+		std::auto_ptr<PrimitiveConverter> m_primitiveConverter;
 
 		friend class IECoreAppleseed::Renderer;
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
@@ -53,7 +53,6 @@ class ShadingState
 		ShadingState();
 
 		void setShadingSamples( int samples );
-		void setAlphaMap( const std::string &alphaMap );
 
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
@@ -62,7 +61,7 @@ class ShadingState
 		std::string createShaderGroup( renderer::Assembly &assembly );
 
 		const IECore::MurmurHash &materialHash() const;
-		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName, const foundation::SearchPaths &searchPaths );
+		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName );
 
 		bool valid() const;
 
@@ -76,7 +75,6 @@ class ShadingState
 		std::vector<IECore::ConstShaderPtr> m_shaders;
 		IECore::ConstShaderPtr m_surfaceShader;
 		int m_shadingSamples;
-		std::string m_alphaMap;
 		IECore::MurmurHash m_shaderGroupHash;
 		IECore::MurmurHash m_materialHash;
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
@@ -107,34 +107,34 @@ void IECoreAppleseed::setParam( const string &name, const Data *value, asr::Para
 	{
 		case IntDataTypeId :
 			{
-				int x = static_cast<const IntData*>( value)->readable();
+				int x = static_cast<const IntData*>( value )->readable();
 				params.insert( name, x );
 			}
 			break;
 
 		case FloatDataTypeId :
 			{
-				float x = static_cast<const FloatData*>( value)->readable();
+				float x = static_cast<const FloatData*>( value )->readable();
 				params.insert( name, x );
 			}
 			break;
 
 		case StringDataTypeId :
 			{
-				const string &x = static_cast<const StringData*>( value)->readable();
+				const string &x = static_cast<const StringData*>( value )->readable();
 				params.insert( name, x.c_str() );
 			}
 			break;
 
 		case BoolDataTypeId :
 			{
-				bool x = static_cast<const BoolData*>( value)->readable();
-				params.insert( name, x);
+				bool x = static_cast<const BoolData*>( value )->readable();
+				params.insert( name, x );
 			}
 			break;
 
 		default:
-			// some kind of warning would be nice here...
+			// TODO: some kind of warning would be nice here...
 			break;
 	}
 }
@@ -165,16 +165,33 @@ string IECoreAppleseed::createColorEntity( asr::ColorContainer &colorContainer, 
 	return insertEntityWithUniqueName( colorContainer, c, name.c_str() );
 }
 
-string IECoreAppleseed::createTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+namespace
+{
+
+string doCreateTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName, const asr::ParamArray &txInstanceParams )
 {
 	asr::ParamArray params;
 	params.insert( "filename", fileName.c_str() );
 	params.insert( "color_space", "linear_rgb" );
 
 	asf::auto_release_ptr<asr::Texture> texture( asr::DiskTexture2dFactory().create( textureName.c_str(), params, searchPaths ) );
-	string txName = insertEntityWithUniqueName( textureContainer, texture, textureName );
+	string txName = IECoreAppleseed::insertEntityWithUniqueName( textureContainer, texture, textureName );
 
 	string textureInstanceName = txName + "_instance";
-	asf::auto_release_ptr<asr::TextureInstance> textureInstance( asr::TextureInstanceFactory().create( textureInstanceName.c_str(), asr::ParamArray(), txName.c_str() ) );
-	return insertEntityWithUniqueName( textureInstanceContainer, textureInstance, textureInstanceName.c_str() );
+	asf::auto_release_ptr<asr::TextureInstance> textureInstance( asr::TextureInstanceFactory().create( textureInstanceName.c_str(), txInstanceParams, txName.c_str() ) );
+	return IECoreAppleseed::insertEntityWithUniqueName( textureInstanceContainer, textureInstance, textureInstanceName.c_str() );
+}
+
+}
+
+string IECoreAppleseed::createTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+{
+	return doCreateTextureEntity( textureContainer, textureInstanceContainer, searchPaths, textureName, fileName, asr::ParamArray() );
+}
+
+string IECoreAppleseed::createAlphaMapTextureEntity( asr::TextureContainer &textureContainer, asr::TextureInstanceContainer &textureInstanceContainer, const asf::SearchPaths &searchPaths, const string &textureName, const string &fileName )
+{
+	asr::ParamArray params;
+	params.insert( "alpha_mode", "detect" );
+	return doCreateTextureEntity( textureContainer, textureInstanceContainer, searchPaths, textureName, fileName, params );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -34,6 +34,8 @@
 
 #include "foundation/math/scalar.h"
 
+#include "renderer/api/version.h"
+
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
@@ -55,6 +57,7 @@ IECoreAppleseed::AttributeState::AttributeState( const AttributeState &other )
 	m_attributes = other.m_attributes->copy();
 	m_shadingState = other.m_shadingState;
 	m_visibilityDictionary = other.m_visibilityDictionary;
+	m_alphaMap = other.m_alphaMap;
 }
 
 void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDataPtr value )
@@ -76,7 +79,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	{
 		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
 		{
-			m_shadingState.setAlphaMap( f->readable() );
+			m_alphaMap = f->readable();
 		}
 		else
 		{
@@ -137,6 +140,11 @@ const asf::Dictionary &IECoreAppleseed::AttributeState::visibilityDictionary() c
 	return m_visibilityDictionary;
 }
 
+const std::string &IECoreAppleseed::AttributeState::alphaMap() const
+{
+	return m_alphaMap;
+}
+
 void IECoreAppleseed::AttributeState::addOSLShader( ConstShaderPtr shader )
 {
 	m_shadingState.addOSLShader( shader );
@@ -152,12 +160,12 @@ bool IECoreAppleseed::AttributeState::shadingStateValid() const
 	return m_shadingState.valid();
 }
 
-const MurmurHash&IECoreAppleseed::AttributeState::shaderGroupHash() const
+const MurmurHash &IECoreAppleseed::AttributeState::shaderGroupHash() const
 {
 	return m_shadingState.shaderGroupHash();
 }
 
-const MurmurHash&IECoreAppleseed::AttributeState::materialHash() const
+const MurmurHash &IECoreAppleseed::AttributeState::materialHash() const
 {
 	return m_shadingState.materialHash();
 }
@@ -167,7 +175,7 @@ string IECoreAppleseed::AttributeState::createShaderGroup( asr::Assembly &assemb
 	return m_shadingState.createShaderGroup( assembly );
 }
 
-string IECoreAppleseed::AttributeState::createMaterial( asr::Assembly &assembly, const string &shaderGroupName, const asf::SearchPaths &searchPaths )
+string IECoreAppleseed::AttributeState::createMaterial( asr::Assembly &assembly, const string &shaderGroupName )
 {
-	return m_shadingState.createMaterial( assembly, shaderGroupName, searchPaths );
+	return m_shadingState.createMaterial( assembly, shaderGroupName );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
@@ -1,0 +1,130 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2015, Esteban Tovagliari. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/filesystem/convenience.hpp"
+
+#include "renderer/api/entity.h"
+
+#include "IECore/MessageHandler.h"
+#include "IECore/SimpleTypedData.h"
+
+#include "IECoreAppleseed/private/BatchPrimitiveConverter.h"
+
+#include "IECoreAppleseed/ToAppleseedConverter.h"
+
+using namespace std;
+using namespace boost;
+using namespace IECore;
+
+namespace asf = foundation;
+namespace asr = renderer;
+
+IECoreAppleseed::BatchPrimitiveConverter::BatchPrimitiveConverter( const filesystem::path &projectPath, const asf::SearchPaths &searchPaths ) : PrimitiveConverter( searchPaths )
+{
+	m_projectPath = projectPath;
+	m_meshGeomExtension = ".binarymesh";
+}
+
+void IECoreAppleseed::BatchPrimitiveConverter::setOption( const string &name, IECore::ConstDataPtr value )
+{
+	if( name == "as:mesh_file_format" )
+	{
+		const string &str = static_cast<const StringData *>( value.get() )->readable();
+
+		if( str == "binarymesh" )
+		{
+			m_meshGeomExtension = ".binarymesh";
+		}
+		else if( str == "obj" )
+		{
+			m_meshGeomExtension = ".obj";
+		}
+		else
+		{
+			msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::setOption", format( "Unknown mesh file format \"%s\"." ) % str );
+		}
+	}
+	else
+		PrimitiveConverter::setOption( name, value );
+}
+
+asf::auto_release_ptr<asr::Object> IECoreAppleseed::BatchPrimitiveConverter::doConvertPrimitive( PrimitivePtr primitive, const MurmurHash &primitiveHash )
+{
+	if( primitive->typeId() == MeshPrimitiveTypeId )
+	{
+		return convertAndWriteMeshPrimitive( primitive, primitiveHash );
+	}
+
+	return asf::auto_release_ptr<asr::Object>();
+}
+
+asf::auto_release_ptr<asr::Object> IECoreAppleseed::BatchPrimitiveConverter::convertAndWriteMeshPrimitive( PrimitivePtr primitive, const MurmurHash &meshHash )
+{
+	string objectName = meshHash.toString();
+
+	// Check if we already have a mesh saved for this object.
+	string fileName = string( "_geometry/" ) + objectName + m_meshGeomExtension;
+	filesystem::path p = m_projectPath / fileName;
+
+	if( !filesystem::exists( p ) )
+	{
+		ToAppleseedConverterPtr converter = ToAppleseedConverter::create( primitive.get() );
+
+		if( !converter )
+		{
+			msg( Msg::Warning, "IECoreAppleseed::BatchPrimitiveConverter", "Couldn't convert primitive." );
+			return asf::auto_release_ptr<asr::Object>();
+		}
+
+		asf::auto_release_ptr<asr::Object> entity;
+		entity.reset( static_cast<asr::Object*>( converter->convert() ) );
+
+		if( entity.get() == 0 )
+		{
+			msg( Msg::Warning, "IECoreAppleseed::BatchPrimitiveConverter", "Couldn't convert primitive." );
+			return asf::auto_release_ptr<asr::Object>();
+		}
+
+		// Write the mesh to a file.
+		p = m_projectPath / fileName;
+		if( !asr::MeshObjectWriter::write( static_cast<const asr::MeshObject&>( *entity ), objectName.c_str(), p.string().c_str() ) )
+		{
+			msg( Msg::Warning, "IECoreAppleseed::BatchPrimitiveConverter", "Couldn't save mesh primitive." );
+			return asf::auto_release_ptr<asr::Object>();
+		}
+	}
+
+	asf::auto_release_ptr<asr::MeshObject> meshObj( asr::MeshObjectFactory().create( objectName.c_str(), asr::ParamArray().insert( "filename", fileName.c_str() ) ) );
+	return asf::auto_release_ptr<asr::Object>( meshObj.release() );
+}

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
@@ -66,12 +66,6 @@ void IECoreAppleseed::ShadingState::setShadingSamples(int samples)
 	updateHashes();
 }
 
-void IECoreAppleseed::ShadingState::setAlphaMap( const string& alphaMap )
-{
-	m_alphaMap = alphaMap;
-	updateHashes();
-}
-
 void IECoreAppleseed::ShadingState::addOSLShader( ConstShaderPtr shader )
 {
 	if( m_surfaceShader )
@@ -136,7 +130,7 @@ const MurmurHash&IECoreAppleseed::ShadingState::materialHash() const
 	return m_materialHash;
 }
 
-string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, const std::string &shaderGroupName, const asf::SearchPaths &searchPaths )
+string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, const std::string &shaderGroupName )
 {
 	asr::ParamArray params;
 
@@ -149,12 +143,6 @@ string IECoreAppleseed::ShadingState::createMaterial( asr::Assembly &assembly, c
 	params.insert( "surface_shader", surfaceShaderName.c_str() );
 	params.insert( "osl_surface", shaderGroupName.c_str() );
 	asf::auto_release_ptr<asr::Material> mat( asr::OSLMaterialFactory().create( "material", params ) );
-
-	if( !m_alphaMap.empty() )
-	{
-		string alphaMapTextureInstanceName = createTextureEntity( assembly.textures(), assembly.texture_instances(), searchPaths, m_surfaceShader->getName() + "_alpha_map", m_alphaMap );
-		mat->get_parameters().insert( "alpha_map", alphaMapTextureInstanceName.c_str() );
-	}
 
 	string materialName = insertEntityWithUniqueName( assembly.materials(), mat, m_surfaceShader->getName() + "_material" );
 	return materialName;
@@ -176,7 +164,6 @@ void IECoreAppleseed::ShadingState::updateHashes()
 
 	m_materialHash = m_shaderGroupHash;
 	m_materialHash.append( m_shadingSamples );
-	m_materialHash.append( m_alphaMap );
 }
 
 asr::ParamArray IECoreAppleseed::ShadingState::convertParameters( const CompoundDataMap &parameters )

--- a/test/IECoreRI/Renderer.py
+++ b/test/IECoreRI/Renderer.py
@@ -152,19 +152,28 @@ class RendererTest( IECoreRI.TestCase ) :
 			l = " ".join( l.split() )
 			self.assert_( t[2] in l )
 	
-	def testM44dAttribute( self ) :
+	def testDoublePrecisionAttributes( self ) :
 		
 		# separate test case for M44d attributes, as they get converted to M44f before being 
 		# written into the rib:
 		
-		r = IECoreRI.Renderer( "test/IECoreRI/output/testM44dAttribute.rib" )
+		r = IECoreRI.Renderer( "test/IECoreRI/output/testDoublePrecisionAttributes.rib" )
 		with WorldBlock( r ) :
 			r.setAttribute( "user:Mref", M44dData( M44d( 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 ) ) )
 			self.assertEqual( r.getAttribute( "user:Mref" ), M44fData( M44f( 0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15 ) ) )
+			r.setAttribute( "user:v", V3dData( V3d( 3,4,5 ) ) )
+			self.assertEqual( r.getAttribute( "user:v" ), V3fData( V3f( 3,4,5 ) ) )
+			r.setAttribute( "user:c", Color3dData( Color3d( 0,1,2 ) ) )
+			self.assertEqual( r.getAttribute( "user:c" ), Color3fData( Color3f( 0,1,2 ) ) )
+			r.setAttribute( "user:number", DoubleData( 10 ) )
+			self.assertEqual( r.getAttribute( "user:number" ), FloatData( 10 ) )
 
-		l = "".join( file( "test/IECoreRI/output/testM44dAttribute.rib" ).readlines() )
+		l = "".join( file( "test/IECoreRI/output/testDoublePrecisionAttributes.rib" ).readlines() )
 		l = " ".join( l.split() )
 		self.assert_( "Attribute \"user\" \"matrix Mref\" [ 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 ]" in l )
+		self.assert_( "Attribute \"user\" \"vector v\" [ 3 4 5 ]" in l )
+		self.assert_( "Attribute \"user\" \"color c\" [ 0 1 2 ]" in l )
+		self.assert_( "Attribute \"user\" \"float number\" [ 10 ]" in l )
 	
 	def testCompoundDataAttributes( self ) :
 	


### PR DESCRIPTION
- Refactored IECore primitive to appleseed entities conversions code.
- Simplified IECoreAppleseed::RendererImplementation.
- Use appleseed object alpha maps instead of material alpha maps.
- Fixed a bug when trying to render a scene without cameras.
- Use the names set with setAttribute to name the appleseed entities in generated appleseed scene files.
- Highlight regions being rendered in the interactive display driver. Useful when doing multipass rendering.
- Small refactors in the display driver code.
- Removed some unused headers and other formatting changes.

All changes are internal to IECoreAppleseed.
