### PR TITLE
Appleseed options improvements

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -66,7 +66,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 
 	if( name == "name" )
 	{
-		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
+		if( const StringData *f = runTimeCast<const StringData>( value.get() ) )
 		{
 			m_name = f->readable();
 		}
@@ -77,7 +77,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	}
 	else if( name == "as:alpha_map" )
 	{
-		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
+		if( const StringData *f = runTimeCast<const StringData>( value.get() ) )
 		{
 			m_alphaMap = f->readable();
 		}
@@ -88,7 +88,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	}
 	else if( name == "as:shading_samples" )
 	{
-		if( ConstIntDataPtr f = runTimeCast<const IntData>( value ) )
+		if( const IntData *f = runTimeCast<const IntData>( value.get() ) )
 		{
 			m_shadingState.setShadingSamples( f->readable() );
 		}
@@ -99,7 +99,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	}
 	else if( name == "gaffer:deformationBlurSegments" )
 	{
-		if( ConstIntDataPtr f = runTimeCast<const IntData>( value ) )
+		if( const IntData *f = runTimeCast<const IntData>( value.get() ) )
 		{
 			// round samples to the next power of 2 as
 			// appleseed only supports power of 2 number of deformation segments.
@@ -113,7 +113,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	}
 	else if( 0 == name.compare( 0, 14, "as:visibility:" ) )
 	{
-		if( ConstBoolDataPtr f = runTimeCast<const BoolData>( value ) )
+		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )
 		{
 			string flag_name( name, 14, string::npos );
 			m_visibilityDictionary.insert( flag_name.c_str(), f->readable() ? "true" : "false" );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
@@ -60,19 +60,24 @@ void IECoreAppleseed::BatchPrimitiveConverter::setOption( const string &name, IE
 {
 	if( name == "as:mesh_file_format" )
 	{
-		const string &str = static_cast<const StringData *>( value.get() )->readable();
-
-		if( str == "binarymesh" )
+		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
 		{
-			m_meshGeomExtension = ".binarymesh";
-		}
-		else if( str == "obj" )
-		{
-			m_meshGeomExtension = ".obj";
+			if( f->readable() == "binarymesh" )
+			{
+				m_meshGeomExtension = ".binarymesh";
+			}
+			else if( f->readable() == "obj" )
+			{
+				m_meshGeomExtension = ".obj";
+			}
+			else
+			{
+				msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::setOption", format( "as:mesh_file_format, unknown mesh file format \"%s\"." ) % f->readable() );
+			}
 		}
 		else
 		{
-			msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::setOption", format( "Unknown mesh file format \"%s\"." ) % str );
+			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setOption", "as:mesh_file_format option expects a StringData value." );
 		}
 	}
 	else

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/BatchPrimitiveConverter.cpp
@@ -60,7 +60,7 @@ void IECoreAppleseed::BatchPrimitiveConverter::setOption( const string &name, IE
 {
 	if( name == "as:mesh_file_format" )
 	{
-		if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
+		if( const StringData *f = runTimeCast<const StringData>( value.get() ) )
 		{
 			if( f->readable() == "binarymesh" )
 			{

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -61,6 +61,17 @@ IECoreAppleseed::PrimitiveConverter::~PrimitiveConverter()
 
 void IECoreAppleseed::PrimitiveConverter::setOption( const string &name, ConstDataPtr value )
 {
+	if( name == "as:automatic_instancing" )
+	{
+		if( ConstBoolDataPtr f = runTimeCast<const BoolData>( value ) )
+		{
+			m_autoInstancing = f->readable();
+		}
+		else
+		{
+			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setOption", "as:automatic_instancing option expects a BoolData value." );
+		}
+	}
 }
 
 const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( PrimitivePtr primitive, const AttributeState &attrState, const string &materialName, asr::Assembly &parentAssembly )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -63,7 +63,7 @@ void IECoreAppleseed::PrimitiveConverter::setOption( const string &name, ConstDa
 {
 	if( name == "as:automatic_instancing" )
 	{
-		if( ConstBoolDataPtr f = runTimeCast<const BoolData>( value ) )
+		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )
 		{
 			m_autoInstancing = f->readable();
 		}

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -173,7 +173,7 @@ void IECoreAppleseed::RendererImplementation::setOption( const string &name, IEC
 
 		if( optName == "searchpath" )
 		{
-			if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
+			if( const StringData *f = runTimeCast<const StringData>( value.get() ) )
 			{
 				m_project->search_paths().push_back( f->readable().c_str() );
 			}

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -173,10 +173,20 @@ void IECoreAppleseed::RendererImplementation::setOption( const string &name, IEC
 
 		if( optName == "searchpath" )
 		{
-			const string &str = static_cast<const StringData *>( value.get() )->readable();
-			m_project->search_paths().push_back( str.c_str() );
+			if( ConstStringDataPtr f = runTimeCast<const StringData>( value ) )
+			{
+				m_project->search_paths().push_back( f->readable().c_str() );
+			}
+			else
+			{
+				msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setOption", "as:searchpath option expects a StringData value." );
+			}
 		}
 		else if( optName == "mesh_file_format" )
+		{
+			m_primitiveConverter->setOption( name, value );
+		}
+		else if( optName == "automatic_instancing" )
 		{
 			m_primitiveConverter->setOption( name, value );
 		}

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
@@ -83,7 +83,7 @@ class PrimitiveConverterTest( unittest.TestCase ):
 		self.failUnless( self.__countAssemblies( r ) == 3 )
 		self.failUnless( self.__countAssemblyInstances( r ) == 3 )
 
-	def __testNoAutoInstancing( self ) :
+	def testNoAutoInstancing( self ) :
 
 		r = IECoreAppleseed.Renderer()
 		r.setOption( "as:automatic_instancing", False )

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
@@ -83,6 +83,25 @@ class PrimitiveConverterTest( unittest.TestCase ):
 		self.failUnless( self.__countAssemblies( r ) == 3 )
 		self.failUnless( self.__countAssemblyInstances( r ) == 3 )
 
+	def __testNoAutoInstancing( self ) :
+
+		r = IECoreAppleseed.Renderer()
+		r.setOption( "as:automatic_instancing", False )
+		r.worldBegin()
+
+		self.__createDefaultShader( r )
+
+		m1 = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		m2 = m1.copy()
+		m3 = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -2 ), IECore.V2f( 2 ) ) )
+
+		m1.render( r )
+		m2.render( r )
+		m3.render( r )
+		m2.render( r )
+
+		self.failUnless( self.__countAssemblies( r ) == 4 )
+		self.failUnless( self.__countAssemblyInstances( r ) == 4 )
 
 	def __createDefaultShader( self, r ) :
 


### PR DESCRIPTION
Small changes related to IECoreAppleseed::Renderer::setOption:

- Check the types of the options passed to setOption and report an error if they are not correct.
- Added as:auto_instancing option, to enable / disable auto-instancing.
- Fixed some typos in the error / warning messages reported by setOption.

All changes local to IECoreAppleseed.
