### PR TITLE
Updated IECoreAppleseed for appleseed 1.1.2 API.

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AppleseedUtil.h
@@ -82,6 +82,7 @@ std::string insertEntityWithUniqueName( Container &container, foundation::auto_r
 	}
 }
 
+foundation::auto_release_ptr<renderer::Assembly> createAssembly( const std::string &name );
 std::string createColorEntity( renderer::ColorContainer &colorContainer, const Imath::C3f &color, const std::string &name );
 std::string createTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );
 std::string createAlphaMapTextureEntity( renderer::TextureContainer &textureContainer, renderer::TextureInstanceContainer &textureInstanceContainer, const foundation::SearchPaths &searchPaths, const std::string &textureName, const std::string &fileName );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
@@ -35,6 +35,7 @@
 #include "boost/lexical_cast.hpp"
 
 #include "renderer/api/color.h"
+#include "renderer/api/version.h"
 
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
@@ -194,4 +195,13 @@ string IECoreAppleseed::createAlphaMapTextureEntity( asr::TextureContainer &text
 	asr::ParamArray params;
 	params.insert( "alpha_mode", "detect" );
 	return doCreateTextureEntity( textureContainer, textureInstanceContainer, searchPaths, textureName, fileName, params );
+}
+
+asf::auto_release_ptr<asr::Assembly> IECoreAppleseed::createAssembly( const string &name )
+{
+#if APPLESEED_VERSION > 10101
+	return asr::AssemblyFactory().create( name.c_str(), asr::ParamArray() );
+#else
+	return asr::AssemblyFactory::create( name.c_str(), asr::ParamArray() );
+#endif
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -32,12 +32,12 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "renderer/api/version.h"
 #include "renderer/api/entity.h"
 
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
+#include "IECoreAppleseed/private/AppleseedUtil.h"
 #include "IECoreAppleseed/private/PrimitiveConverter.h"
 
 #include "IECoreAppleseed/ToAppleseedConverter.h"
@@ -101,8 +101,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 		obj->get_parameters().insert( "alpha_map", alphaMapTextureInstanceName.c_str() );
 	}
 
-	string assemblyName = attrState.name();
-	asf::auto_release_ptr<asr::Assembly> ass = asr::AssemblyFactory::create( assemblyName.c_str(), asr::ParamArray() );
+	asf::auto_release_ptr<asr::Assembly> ass = createAssembly( attrState.name() );
 	const asr::Object *objPtr = obj.get();
 	ass->objects().insert( obj );
 	createObjectInstance( *ass, objPtr, objName, materialName );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -271,7 +271,7 @@ void IECoreAppleseed::RendererImplementation::worldBegin()
 	}
 
 	// create the main assembly
-	asf::auto_release_ptr<asr::Assembly> assembly = asr::AssemblyFactory::create( "assembly", asr::ParamArray() );
+	asf::auto_release_ptr<asr::Assembly> assembly = createAssembly( "assembly" );
 	m_mainAssembly = assembly.get();
 	m_project->get_scene()->assemblies().insert( assembly );
 }


### PR DESCRIPTION
The way assemblies are created changed in appleseed 1.1.2. It's now more consistent with the rest of the API and opens the possibility of plugin assemblies, procedurals, ...

This PR updates IECoreAppleseed use the new API if available.
