### PR TITLE
Changes for appleseed 1.1.2 API changes.

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -102,7 +102,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 	}
 
 	string assemblyName = attrState.name();
-	asf::auto_release_ptr<asr::Assembly> ass = asr::AssemblyFactory::create( assemblyName.c_str(), asr::ParamArray() );
+	asf::auto_release_ptr<asr::Assembly> ass = asr::AssemblyFactory().create( assemblyName.c_str(), asr::ParamArray() );
 	const asr::Object *objPtr = obj.get();
 	ass->objects().insert( obj );
 	createObjectInstance( *ass, objPtr, objName, materialName );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -273,7 +273,7 @@ void IECoreAppleseed::RendererImplementation::worldBegin()
 	}
 
 	// create the main assembly
-	asf::auto_release_ptr<asr::Assembly> assembly = asr::AssemblyFactory::create( "assembly", asr::ParamArray() );
+	asf::auto_release_ptr<asr::Assembly> assembly = asr::AssemblyFactory().create( "assembly", asr::ParamArray() );
 	m_mainAssembly = assembly.get();
 	m_project->get_scene()->assemblies().insert( assembly );
 }


### PR DESCRIPTION
In appleseed 1.1.2 (current master) AssemblyFactory's create changed. It is now a virtual method. 
The idea is that there will be more types of Assemblies in the future, including a procedural assembly.

I made the changes for IECoreAppleseed to build against 1.1.2. 
I removed compatibility with older versions of appleseed to keep the code clean, 
but it would be quite easy to add if needed.
