### PR TITLE
set __file__ when loading configs

### DIFF
--- a/python/IECore/ConfigLoader.py
+++ b/python/IECore/ConfigLoader.py
@@ -59,6 +59,7 @@ def loadConfig( searchPaths, contextDict, raiseExceptions = False, subdirectory 
 				fullFileName = os.path.abspath( os.path.join( dirPath, fileName ) )
 
 				contextDict["__file__"] = fullFileName
+				IECore.msg( IECore.Msg.Level.Debug, "IECore.loadConfig", "Loading file \"%s\"" % fullFileName )
 
 				if raiseExceptions:
 					execfile( fullFileName, contextDict, contextDict )

--- a/python/IECore/Log.py
+++ b/python/IECore/Log.py
@@ -73,12 +73,15 @@ def setLogLevel( level ):
 	
 	debug("setLogLevel(", level, ")")
 
+def __getCallStr(frame):
+	return frame.f_globals.get("__name__", frame.f_globals.get("__file__", "N/A"))
+
 def __getCallContext(frame = None, withLineNumber = False):
 	if frame is None:
 		f = inspect.currentframe().f_back.f_back
 	else:
 		f = frame
-	callStr = f.f_globals["__name__"]
+	callStr = __getCallStr(f)
 	if withLineNumber:
 		callStr += " #" + str(f.f_lineno)
 	return callStr
@@ -92,7 +95,7 @@ def showCallStack():
 	index = 0
 	callstack = "Callstack:\n"
 	while not f is None:
-		callstack += "> " + str(index) + ": " + f.f_globals["__name__"] + " #" + str(f.f_lineno) + "\n"
+		callstack += "> " + str(index) + ": " + __getCallStr(f) + " #" + str(f.f_lineno) + "\n"
 		f = f.f_back
 		index += 1
 	Msg.output(Msg.Level.Debug, __getCallContext( withLineNumber = True ), callstack )

--- a/test/IECore/ConfigLoaderTest.py
+++ b/test/IECore/ConfigLoaderTest.py
@@ -88,9 +88,10 @@ class ConfigLoaderTest( unittest.TestCase ) :
 				
 			)
 
-		self.assertEqual( len( m.messages ), 1 )
-		self.assertEqual( m.messages[0].level, IECore.Msg.Level.Error )
-		self.failUnless( "I am a very naughty boy" in m.messages[0].message )
+		errors = [ msg for msg in m.messages if msg.level == IECore.Msg.Level.Error ]
+		self.assertEqual( len( errors ), 1 )
+		self.assertEqual( errors[0].level, IECore.Msg.Level.Error )
+		self.failUnless( "I am a very naughty boy" in errors[0].message )
 
 		self.assertEqual( contextDict["a"], 1 )
 		

--- a/test/IECore/ConfigLoaderTest.py
+++ b/test/IECore/ConfigLoaderTest.py
@@ -201,6 +201,20 @@ class ConfigLoaderTest( unittest.TestCase ) :
 		
 		self.assertEqual( contextDict["a"], 2 )
 		
+	def testFile( self ) :
+
+		contextDict = {}
+		path = os.path.dirname( __file__ ) + "/config/getFile"
+		IECore.loadConfig(
+		
+			IECore.SearchPath( path, ":" ),
+			contextDict,
+			
+		)
+		
+		expectedFile = os.path.abspath( os.path.join( path, "config.py" ) )
+		self.assertEqual( contextDict["myFile"], expectedFile )
+		
 if __name__ == "__main__":
 	unittest.main()
 

--- a/test/IECore/config/getFile/config.py
+++ b/test/IECore/config/getFile/config.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2007-2011, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2011, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -32,43 +32,4 @@
 #
 ##########################################################################
 
-import re
-import os
-import os.path
-import sys
-import traceback
-import IECore
-
-## This function provides an easy means of providing a flexible configuration
-# mechanism for any software. It works by executing all .py files found on
-# a series of searchpaths. It is expected that these files will then make appropriate
-# calls to objects passed in via the specified contextDict.
-# \ingroup python
-def loadConfig( searchPaths, contextDict, raiseExceptions = False, subdirectory = "" ) :
-
-	if isinstance( searchPaths, basestring ) :
-		searchPaths = IECore.SearchPath( os.environ.get( searchPaths, "" ), ":" )
-
-	paths = searchPaths.paths
-	paths.reverse()
-
-	for path in paths :
-		pyExtTest = re.compile( "^[^~].*\.py$" )
-		for dirPath, dirNames, fileNames in os.walk( os.path.join( path, subdirectory ) ) :
-			for fileName in filter( pyExtTest.search, sorted( fileNames ) ) :
-				fullFileName = os.path.abspath( os.path.join( dirPath, fileName ) )
-
-				contextDict["__file__"] = fullFileName
-
-				if raiseExceptions:
-					execfile( fullFileName, contextDict, contextDict )
-				else:
-					try :
-						execfile( fullFileName, contextDict, contextDict )
-					except Exception, m :
-						stacktrace = traceback.format_exc()
-						IECore.msg( IECore.Msg.Level.Error, "IECore.loadConfig", "Error executing file \"%s\" - \"%s\".\n %s" % ( fullFileName, m, stacktrace ) )
-
-				del( contextDict["__file__"] )
-
-loadConfig( "IECORE_CONFIG_PATHS", { "IECore" : IECore } )
+myFile = __file__


### PR DESCRIPTION
Setting a ~~module~~ file name on load allows to more easily use IECore logging
in the configs, an example log would look like:
~~INFO : /home/me/config/myTool/testconfig_py : Hello World!~~

~~NOTE: "." characters are replaced with underscores so the name is not
interpreted as a python namespace in the module.~~

INFO : /home/me/config/myTool/testconfig.py : Hello World!

EDIT: using __file__ rather than __name__ makes more sense, see comments for details