### PR TITLE
IECoreAppleseed work

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
@@ -63,13 +63,15 @@ class AttributeState
 
 		bool photonTarget() const;
 
+		void attributesHash( IECore::MurmurHash &hash ) const;
+
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
 
 		bool shadingStateValid() const;
 
-		const IECore::MurmurHash &shaderGroupHash() const;
-		const IECore::MurmurHash &materialHash() const;
+		void shaderGroupHash( IECore::MurmurHash &hash ) const;
+		void materialHash( IECore::MurmurHash &hash ) const;
 
 		std::string createShaderGroup( renderer::Assembly &assembly );
 		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName );

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
@@ -61,6 +61,8 @@ class AttributeState
 
 		const std::string &alphaMap() const;
 
+		bool photonTarget() const;
+
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
 
@@ -78,6 +80,7 @@ class AttributeState
 		ShadingState m_shadingState;
 		std::string m_name;
 		std::string m_alphaMap;
+		bool m_photonTarget;
 		foundation::Dictionary m_visibilityDictionary;
 
 };

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/BatchPrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/BatchPrimitiveConverter.h
@@ -56,9 +56,8 @@ class BatchPrimitiveConverter : public PrimitiveConverter
 		boost::filesystem::path m_projectPath;
 		std::string m_meshGeomExtension;
 
-		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash );
-
-		foundation::auto_release_ptr<renderer::Object> convertAndWriteMeshPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &meshHash );
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive,
+			const std::string &name );
 
 };
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/InteractivePrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/InteractivePrimitiveConverter.h
@@ -49,7 +49,9 @@ class InteractivePrimitiveConverter : public PrimitiveConverter
 
 	private :
 
-		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash );
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive,
+			const std::string &name );
+
 };
 
 } // namespace IECoreAppleseed

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -76,7 +76,7 @@ class PrimitiveConverter : boost::noncopyable
 		void createObjectInstance( renderer::Assembly &assembly, const renderer::Object *obj,
 			const std::string &objSourceName, const AttributeState &attrState, const std::string &materialName );
 
-		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash ) = 0;
+		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const std::string &name ) = 0;
 
 		typedef std::map<IECore::MurmurHash, const renderer::Assembly*> InstanceMapType;
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -73,7 +73,8 @@ class PrimitiveConverter : boost::noncopyable
 
 	private :
 
-		void createObjectInstance( renderer::Assembly &assembly, const renderer::Object *obj, const std::string &objSourceName, const std::string &materialName );
+		void createObjectInstance( renderer::Assembly &assembly, const renderer::Object *obj,
+			const std::string &objSourceName, const AttributeState &attrState, const std::string &materialName );
 
 		virtual foundation::auto_release_ptr<renderer::Object> doConvertPrimitive( IECore::PrimitivePtr primitive, const IECore::MurmurHash &primitiveHash ) = 0;
 

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/ShadingState.h
@@ -57,17 +57,15 @@ class ShadingState
 		void addOSLShader( IECore::ConstShaderPtr shader );
 		void setOSLSurface( IECore::ConstShaderPtr surface );
 
-		const IECore::MurmurHash &shaderGroupHash() const;
+		void shaderGroupHash( IECore::MurmurHash &hash ) const;
 		std::string createShaderGroup( renderer::Assembly &assembly );
 
-		const IECore::MurmurHash &materialHash() const;
+		void materialHash( IECore::MurmurHash &hash ) const;
 		std::string createMaterial( renderer::Assembly &assembly, const std::string &shaderGroupName );
 
 		bool valid() const;
 
 	private :
-
-		void updateHashes();
 
 		renderer::ParamArray convertParameters( const IECore::CompoundDataMap &parameters );
 		void addConnections( const std::string &shaderHandle, const IECore::CompoundDataMap &parameters, renderer::ShaderGroup *shaderGroup );
@@ -75,8 +73,6 @@ class ShadingState
 		std::vector<IECore::ConstShaderPtr> m_shaders;
 		IECore::ConstShaderPtr m_surfaceShader;
 		int m_shadingSamples;
-		IECore::MurmurHash m_shaderGroupHash;
-		IECore::MurmurHash m_materialHash;
 
 };
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -50,14 +50,16 @@ namespace asr = renderer;
 IECoreAppleseed::AttributeState::AttributeState()
 {
 	m_attributes = new CompoundData;
+	m_photonTarget = false;
 }
 
 IECoreAppleseed::AttributeState::AttributeState( const AttributeState &other )
 {
 	m_attributes = other.m_attributes->copy();
 	m_shadingState = other.m_shadingState;
-	m_visibilityDictionary = other.m_visibilityDictionary;
 	m_alphaMap = other.m_alphaMap;
+	m_photonTarget = other.m_photonTarget;
+	m_visibilityDictionary = other.m_visibilityDictionary;
 }
 
 void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDataPtr value )
@@ -97,6 +99,17 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "as:shading_samples attribute expects an IntData value." );
 		}
 	}
+	else if( name == "as:photon_target" )
+	{
+		if( const BoolData *f = runTimeCast<const BoolData>( value ) )
+		{
+			m_photonTarget = f->readable();
+		}
+		else
+		{
+			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "photon_target attribute expect a BoolData value." );
+		}
+	}
 	else if( 0 == name.compare( 0, 14, "as:visibility:" ) )
 	{
 		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )
@@ -129,6 +142,11 @@ const asf::Dictionary &IECoreAppleseed::AttributeState::visibilityDictionary() c
 const std::string &IECoreAppleseed::AttributeState::alphaMap() const
 {
 	return m_alphaMap;
+}
+
+bool IECoreAppleseed::AttributeState::photonTarget() const
+{
+	return m_photonTarget;
 }
 
 void IECoreAppleseed::AttributeState::addOSLShader( ConstShaderPtr shader )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -101,7 +101,7 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 	}
 	else if( name == "as:photon_target" )
 	{
-		if( const BoolData *f = runTimeCast<const BoolData>( value ) )
+		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )
 		{
 			m_photonTarget = f->readable();
 		}
@@ -149,6 +149,12 @@ bool IECoreAppleseed::AttributeState::photonTarget() const
 	return m_photonTarget;
 }
 
+void IECoreAppleseed::AttributeState::attributesHash( IECore::MurmurHash &hash ) const
+{
+	hash.append( m_alphaMap );
+	hash.append( m_photonTarget );
+}
+
 void IECoreAppleseed::AttributeState::addOSLShader( ConstShaderPtr shader )
 {
 	m_shadingState.addOSLShader( shader );
@@ -164,14 +170,14 @@ bool IECoreAppleseed::AttributeState::shadingStateValid() const
 	return m_shadingState.valid();
 }
 
-const MurmurHash &IECoreAppleseed::AttributeState::shaderGroupHash() const
+void IECoreAppleseed::AttributeState::shaderGroupHash( IECore::MurmurHash &hash ) const
 {
-	return m_shadingState.shaderGroupHash();
+	m_shadingState.shaderGroupHash( hash );
 }
 
-const MurmurHash &IECoreAppleseed::AttributeState::materialHash() const
+void IECoreAppleseed::AttributeState::materialHash( IECore::MurmurHash &hash ) const
 {
-	return m_shadingState.materialHash();
+	m_shadingState.materialHash( hash );
 }
 
 string IECoreAppleseed::AttributeState::createShaderGroup( asr::Assembly &assembly )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -97,20 +97,6 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "as:shading_samples attribute expects an IntData value." );
 		}
 	}
-	else if( name == "gaffer:deformationBlurSegments" )
-	{
-		if( const IntData *f = runTimeCast<const IntData>( value.get() ) )
-		{
-			// round samples to the next power of 2 as
-			// appleseed only supports power of 2 number of deformation segments.
-			int samples = asf::next_pow2( f->readable() );
-			m_attributes->writable()[name] = new IntData( samples );
-		}
-		else
-		{
-			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "as:shading_samples attribute expects an IntData value." );
-		}
-	}
 	else if( 0 == name.compare( 0, 14, "as:visibility:" ) )
 	{
 		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/InteractivePrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/InteractivePrimitiveConverter.cpp
@@ -49,7 +49,7 @@ IECoreAppleseed::InteractivePrimitiveConverter::InteractivePrimitiveConverter( c
 {
 }
 
-asf::auto_release_ptr<asr::Object> IECoreAppleseed::InteractivePrimitiveConverter::doConvertPrimitive( PrimitivePtr primitive, const MurmurHash &primitiveHash )
+asf::auto_release_ptr<asr::Object> IECoreAppleseed::InteractivePrimitiveConverter::doConvertPrimitive( PrimitivePtr primitive,  const string &name )
 {
 	asf::auto_release_ptr<asr::Object> obj;
 
@@ -60,8 +60,7 @@ asf::auto_release_ptr<asr::Object> IECoreAppleseed::InteractivePrimitiveConverte
 
 	if( obj.get() )
 	{
-		string objectName = primitiveHash.toString();
-		obj->set_name( objectName.c_str() );
+		obj->set_name( name.c_str() );
 	}
 	else
 	{

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -116,7 +116,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 	asf::auto_release_ptr<asr::Assembly> ass = asr::AssemblyFactory().create( assemblyName.c_str(), asr::ParamArray() );
 	const asr::Object *objPtr = obj.get();
 	ass->objects().insert( obj );
-	createObjectInstance( *ass, objPtr, objName, materialName );
+	createObjectInstance( *ass, objPtr, objName, attrState, materialName );
 	const asr::Assembly *p = ass.get();
 	parentAssembly.assemblies().insert( ass );
 
@@ -136,7 +136,8 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( cons
 	return convertPrimitive( primitives[0], attrState, materialName, parentAssembly );
 }
 
-void IECoreAppleseed::PrimitiveConverter::createObjectInstance( asr::Assembly &assembly, const renderer::Object *obj, const string &objSourceName, const string &materialName )
+void IECoreAppleseed::PrimitiveConverter::createObjectInstance( asr::Assembly &assembly, const renderer::Object *obj,
+	const string &objSourceName, const AttributeState &attrState, const string &materialName )
 {
 	assert( obj );
 
@@ -150,6 +151,13 @@ void IECoreAppleseed::PrimitiveConverter::createObjectInstance( asr::Assembly &a
 		materials.insert( "default", materialName.c_str() );
 	}
 
-	asf::auto_release_ptr<asr::ObjectInstance> objInstance = asr::ObjectInstanceFactory::create( instanceName.c_str(), asr::ParamArray(), sourceName.c_str(), asf::Transformd::make_identity(), materials, materials );
+	asr::ParamArray params;
+
+	if( attrState.photonTarget() )
+	{
+		params.insert( "photon_target", "true" );
+	}
+
+	asf::auto_release_ptr<asr::ObjectInstance> objInstance = asr::ObjectInstanceFactory::create( instanceName.c_str(), params, sourceName.c_str(), asf::Transformd::make_identity(), materials, materials );
 	assembly.object_instances().insert( objInstance );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -759,7 +759,7 @@ string IECoreAppleseed::RendererImplementation::currentMaterialName()
 
 void IECoreAppleseed::RendererImplementation::createAssemblyInstance( const string &assemblyName )
 {
-	string assemblyInstanceName = m_attributeStack.top().name() + "_instance";
+	string assemblyInstanceName = m_attributeStack.top().name() + "_assembly_instance";
 
 	asr::ParamArray params;
 	params.insert( "visibility", m_attributeStack.top().visibilityDictionary() );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -121,13 +121,6 @@ void IECoreAppleseed::RendererImplementation::constructCommon()
 	m_project = asr::ProjectFactory::create( "project" );
 	m_project->add_default_configurations();
 
-	// create some needed parameters that don't get created by default.
-	// possible bug in appleseed?
-	{
-		asr::Configuration *cfg = m_project->configurations().get_by_name( "final" );
-		cfg->get_parameters().insert_path( "sppm.initial_radius", "1.0" );
-	}
-
 	// create some basic project entities.
 	asf::auto_release_ptr<asr::Frame> frame( asr::FrameFactory::create( "beauty", asr::ParamArray() ) );
 	m_project->set_frame( frame );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -712,7 +712,8 @@ string IECoreAppleseed::RendererImplementation::currentShaderGroupName()
 
 	if( m_attributeStack.top().shadingStateValid() )
 	{
-		MurmurHash shaderGroupHash = m_attributeStack.top().shaderGroupHash();
+		MurmurHash shaderGroupHash;
+		m_attributeStack.top().shaderGroupHash( shaderGroupHash );
 
 		ShaderGroupMap::const_iterator it( m_shaderGroupNames.find( shaderGroupHash ) );
 
@@ -736,7 +737,8 @@ string IECoreAppleseed::RendererImplementation::currentMaterialName()
 
 	if( m_attributeStack.top().shadingStateValid() )
 	{
-		MurmurHash materialHash = m_attributeStack.top().materialHash();
+		MurmurHash materialHash;
+		m_attributeStack.top().materialHash( materialHash );
 
 		MaterialMap::const_iterator it( m_materialNames.find( materialHash ) );
 

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/PrimitiveConverterTest.py
@@ -65,6 +65,22 @@ class PrimitiveConverterTest( unittest.TestCase ):
 		r = IECoreAppleseed.Renderer()
 		r.worldBegin()
 
+		m = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+
+		self.__createDefaultShader( r )
+		m.render( r )
+
+		self.__createGlossyShader( r )
+		m.render( r )
+
+		self.failUnless( self.__countAssemblies( r ) == 2 )
+		self.failUnless( self.__countAssemblyInstances( r ) == 2 )
+
+	def testAttributesNoInstancing( self ) :
+
+		r = IECoreAppleseed.Renderer()
+		r.worldBegin()
+
 		self.__createDefaultShader( r )
 
 		m = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
@@ -80,8 +96,13 @@ class PrimitiveConverterTest( unittest.TestCase ):
 		m.render( r )
 		r.attributeEnd()
 
-		self.failUnless( self.__countAssemblies( r ) == 3 )
-		self.failUnless( self.__countAssemblyInstances( r ) == 3 )
+		r.attributeBegin()
+		r.setAttribute( "as:photon_target", IECore.BoolData( True ) )
+		m.render( r )
+		r.attributeEnd()
+
+		self.failUnless( self.__countAssemblies( r ) == 4 )
+		self.failUnless( self.__countAssemblyInstances( r ) == 4 )
 
 	def testNoAutoInstancing( self ) :
 
@@ -106,6 +127,11 @@ class PrimitiveConverterTest( unittest.TestCase ):
 	def __createDefaultShader( self, r ) :
 
 		s = IECore.Shader( "data/shaders/matte.oso", "surface" )
+		s.render( r )
+
+	def __createGlossyShader( self, r ) :
+
+		s = IECore.Shader( "data/shaders/glossy.oso", "surface" )
 		s.render( r )
 
 	def __getMainAssembly( self, r ) :

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/data/shaders/glossy.osl
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/data/shaders/glossy.osl
@@ -1,0 +1,5 @@
+
+surface glossy(float Ks = 0.8, color Cs = 1)
+{
+    Ci = Ks * Cs * microfacet("ggx", N, 0.05, 1.5, 0);
+}

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/data/shaders/glossy.oso
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/data/shaders/glossy.oso
@@ -1,0 +1,27 @@
+OpenShadingLanguage 1.00
+# Compiled by oslc 1.6.2dev
+surface glossy
+param	float	Ks	0.80000001		%read{2,2} %write{2147483647,-1}
+param	color	Cs	1 1 1		%read{2,2} %write{2147483647,-1}
+global	normal	N	%read{1,1} %write{2147483647,-1}
+global	closure color	Ci	%read{2147483647,-1} %write{3,3}
+temp	closure color	$tmp1	%read{3,3} %write{1,1}
+const	string	$const1	"ggx"		%read{1,1} %write{2147483647,-1}
+const	float	$const2	0.050000001		%read{1,1} %write{2147483647,-1}
+const	float	$const3	1.5		%read{1,1} %write{2147483647,-1}
+const	int	$const4	0		%read{1,1} %write{2147483647,-1}
+const	string	$const5	"microfacet"		%read{0,1} %write{2147483647,-1}
+const	vector	$const6	0 0 0		%read{1,1} %write{2147483647,-1}
+temp	color	$tmp3	%read{3,3} %write{2,2}
+code ___main___
+# glossy.osl:4
+#     Ci = Ks * Cs * microfacet("ggx", N, 0.05, 1.5, 0);
+	functioncall	$const5 2 	%filename{"glossy.osl"} %line{4} %argrw{"r"}
+# /home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h:529
+#                          float yalpha, float eta, int refract) BUILTIN;
+	closure		$tmp1 $const5 $const1 N $const6 $const2 $const2 $const3 $const4 	%filename{"/home/est/Devel/appleseedhq/appleseed/sandbox/shaders/stdosl.h"} %line{529} %argrw{"wrrrrrrrr"}
+# glossy.osl:4
+#     Ci = Ks * Cs * microfacet("ggx", N, 0.05, 1.5, 0);
+	mul		$tmp3 Ks Cs 	%filename{"glossy.osl"} %line{4} %argrw{"wrr"}
+	mul		Ci $tmp1 $tmp3 	%argrw{"wrr"}
+	end


### PR DESCRIPTION
- Changed the way hashes are computed for attributes and shaders. It's now more consistent with the way they work in other Cortex classes, like Primitive.

- Small refactors of PrimitiveConverters. Removed BatchPrimitiveConverter implementation details from the PrimitiveConverter interface.

- Added photon target attribute.

Plus other small changes and improvements.
No changes outside of IECoreAppleseed.