### PR TITLE
IECoreAppleseed work

### DIFF
--- a/contrib/IECoreAppleseed/Changes
+++ b/contrib/IECoreAppleseed/Changes
@@ -1,0 +1,22 @@
+# Development
+
+
+# 9.0.0-b4
+
+- Refactored IECore primitive to appleseed entities conversions code.
+- Simplified IECoreAppleseed::RendererImplementation.
+- Use appleseed object alpha maps instead of material alpha maps.
+- Fixed a bug when trying to render a scene without cameras.
+- Use the names set with setAttribute to name the appleseed entities in generated appleseed scene files.
+- Highlight regions being rendered in the interactive display driver. Useful when doing multipass rendering.
+- Small refactors in the display driver code.
+- Removed some unused headers and other formatting changes.
+- Camera and transformation motion blur support
+- Added as:automatic_instancing option to enable / disable auto-instancing.
+- Better error handling for as:mesh_file_format option
+- Better error handling for searchpath option. Added automatic_instancing option
+- Support for appleseed 1.1.2
+- Fixed bug when connecting members of stuct parameters in OSL shaders.
+- Added photon target attribute for objects
+- PrimitiveConverter interface changes. Changed the way hashes are computed in IECoreAppleseed.
+- Fixed assembly instance names when generating appleseed projects.

--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/PrimitiveConverter.h
@@ -63,6 +63,8 @@ class PrimitiveConverter : boost::noncopyable
 
 		virtual ~PrimitiveConverter();
 
+		void setShutterInterval( float openTime, float closeTime );
+
 		virtual void setOption( const std::string &name, IECore::ConstDataPtr value );
 
 		const renderer::Assembly *convertPrimitive( IECore::PrimitivePtr primitive, const AttributeState &attrState, const std::string &materialName, renderer::Assembly &parentAssembly );
@@ -83,6 +85,8 @@ class PrimitiveConverter : boost::noncopyable
 		const foundation::SearchPaths &m_searchPaths;
 		InstanceMapType m_instanceMap;
 		bool m_autoInstancing;
+		float m_shutterOpenTime;
+		float m_shutterCloseTime;
 
 };
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AppleseedUtil.cpp
@@ -42,6 +42,8 @@
 #include "IECoreAppleseed/private/AppleseedUtil.h"
 
 using namespace IECore;
+using namespace Imath;
+using namespace boost;
 using namespace std;
 
 namespace asf = foundation;
@@ -76,14 +78,14 @@ string IECoreAppleseed::dataToString( ConstDataPtr value )
 
 		case V2iDataTypeId :
 			{
-				const Imath::V2i &x = static_cast<const V2iData*>( value.get() )->readable();
+				const V2i &x = static_cast<const V2iData*>( value.get() )->readable();
 				ss << x.x << ", " << x.y;
 			}
 			break;
 
 		case Color3fDataTypeId :
 			{
-				const Imath::Color3f &x = static_cast<const Color3fData*>( value.get() )->readable();
+				const Color3f &x = static_cast<const Color3fData*>( value.get() )->readable();
 				ss << x.x << ", " << x.y << ", " << x.z;
 			}
 			break;
@@ -149,12 +151,12 @@ asr::ParamArray IECoreAppleseed::convertParams( const CompoundDataMap &parameter
 	return result;
 }
 
-string IECoreAppleseed::createColorEntity( asr::ColorContainer &colorContainer, const Imath::C3f &color, const string &name )
+string IECoreAppleseed::createColorEntity( asr::ColorContainer &colorContainer, const C3f &color, const string &name )
 {
 	// for monochrome colors, we don't need to create a color entity at all.
 	if( color.x == color.y && color.x == color.z )
 	{
-		return boost::lexical_cast<string>( color.x );
+		return lexical_cast<string>( color.x );
 	}
 
 	asr::ColorValueArray values( 3, &color.x );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -149,7 +149,7 @@ bool IECoreAppleseed::AttributeState::photonTarget() const
 	return m_photonTarget;
 }
 
-void IECoreAppleseed::AttributeState::attributesHash( IECore::MurmurHash &hash ) const
+void IECoreAppleseed::AttributeState::attributesHash( MurmurHash &hash ) const
 {
 	hash.append( m_alphaMap );
 	hash.append( m_photonTarget );
@@ -170,12 +170,12 @@ bool IECoreAppleseed::AttributeState::shadingStateValid() const
 	return m_shadingState.valid();
 }
 
-void IECoreAppleseed::AttributeState::shaderGroupHash( IECore::MurmurHash &hash ) const
+void IECoreAppleseed::AttributeState::shaderGroupHash( MurmurHash &hash ) const
 {
 	m_shadingState.shaderGroupHash( hash );
 }
 
-void IECoreAppleseed::AttributeState::materialHash( IECore::MurmurHash &hash ) const
+void IECoreAppleseed::AttributeState::materialHash( MurmurHash &hash ) const
 {
 	m_shadingState.materialHash( hash );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/MotionBlockHandler.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/MotionBlockHandler.cpp
@@ -65,7 +65,7 @@ void IECoreAppleseed::MotionBlockHandler::motionBegin( const set<float> &times )
 }
 
 void IECoreAppleseed::MotionBlockHandler::motionEnd( const AttributeState &attrState,
-	renderer::Assembly *mainAssembly )
+	asr::Assembly *mainAssembly )
 {
 	assert( !m_times.empty() );
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -127,7 +127,7 @@ const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( Prim
 
 const asr::Assembly *IECoreAppleseed::PrimitiveConverter::convertPrimitive( const set<float> &times,
 			const vector<PrimitivePtr> &primitives, const AttributeState &attrState,
-			const string &materialName, renderer::Assembly &parentAssembly )
+			const string &materialName, asr::Assembly &parentAssembly )
 {
 	// For now, ignore motion blur and convert only the first primitive.
 	return convertPrimitive( primitives[0], attrState, materialName, parentAssembly );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -32,7 +32,6 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "renderer/api/version.h"
 #include "renderer/api/entity.h"
 
 #include "IECore/MessageHandler.h"
@@ -53,10 +52,18 @@ namespace asr = renderer;
 IECoreAppleseed::PrimitiveConverter::PrimitiveConverter( const asf::SearchPaths &searchPaths ) : m_searchPaths( searchPaths )
 {
 	m_autoInstancing = true;
+	m_shutterOpenTime = 0.0f;
+	m_shutterCloseTime = 0.0f;
 }
 
 IECoreAppleseed::PrimitiveConverter::~PrimitiveConverter()
 {
+}
+
+void IECoreAppleseed::PrimitiveConverter::setShutterInterval( float openTime, float closeTime )
+{
+	m_shutterOpenTime = openTime;
+	m_shutterCloseTime = closeTime;
 }
 
 void IECoreAppleseed::PrimitiveConverter::setOption( const string &name, ConstDataPtr value )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -218,7 +218,8 @@ void IECoreAppleseed::RendererImplementation::camera( const string &name, const 
 		return;
 	}
 
-	CameraPtr cortexCamera = new Camera( name, 0, new CompoundData( parameters ) );
+	CompoundDataPtr params = new CompoundData( parameters );
+	CameraPtr cortexCamera = new Camera( name, 0, params );
 	ToAppleseedCameraConverterPtr converter = new ToAppleseedCameraConverter( cortexCamera );
 	asf::auto_release_ptr<asr::Camera> appleseedCamera( static_cast<asr::Camera*>( converter->convert() ) );
 
@@ -227,6 +228,10 @@ void IECoreAppleseed::RendererImplementation::camera( const string &name, const 
 		msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::camera", "Couldn't create camera." );
 		return;
 	}
+
+	// pass the shutter interval to the primitive converter.
+	const V2f &shutter = params->member<V2fData>( "shutter", true )->readable();
+	m_primitiveConverter->setShutterInterval( shutter.x, shutter.y );
 
 	appleseedCamera->transform_sequence() = m_transformStack.top();
 	setCamera( cortexCamera, appleseedCamera );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -69,8 +69,8 @@
 using namespace IECore;
 using namespace IECoreAppleseed;
 using namespace Imath;
-using namespace std;
 using namespace boost;
+using namespace std;
 
 namespace asf = foundation;
 namespace asr = renderer;
@@ -134,7 +134,7 @@ void IECoreAppleseed::RendererImplementation::constructCommon()
 // options
 ////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::setOption( const string &name, IECore::ConstDataPtr value )
+void IECoreAppleseed::RendererImplementation::setOption( const string &name, ConstDataPtr value )
 {
 	m_optionsMap[name] = value;
 
@@ -143,7 +143,7 @@ void IECoreAppleseed::RendererImplementation::setOption( const string &name, IEC
 		// appleseed render settings.
 
 		string optName( name, 7, string::npos );
-		std::replace( optName.begin(), optName.end(), ':', '.' );
+		replace( optName.begin(), optName.end(), ':', '.' );
 		string valueStr = dataToString( value );
 
 		if( !valueStr.empty() )
@@ -196,7 +196,7 @@ void IECoreAppleseed::RendererImplementation::setOption( const string &name, IEC
 	}
 }
 
-IECore::ConstDataPtr IECoreAppleseed::RendererImplementation::getOption( const string &name ) const
+ConstDataPtr IECoreAppleseed::RendererImplementation::getOption( const string &name ) const
 {
 	OptionsMap::const_iterator it( m_optionsMap.find( name ) );
 
@@ -205,10 +205,10 @@ IECore::ConstDataPtr IECoreAppleseed::RendererImplementation::getOption( const s
 		return it->second;
 	}
 
-	return IECore::ConstDataPtr();
+	return ConstDataPtr();
 }
 
-void IECoreAppleseed::RendererImplementation::camera( const string &name, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::camera( const string &name, const CompoundDataMap &parameters )
 {
 	const string *cameraName = getOptionAs<string>( "render:camera" );
 
@@ -232,7 +232,7 @@ void IECoreAppleseed::RendererImplementation::camera( const string &name, const 
 	setCamera( cortexCamera, appleseedCamera );
 }
 
-void IECoreAppleseed::RendererImplementation::display( const string &name, const string &type, const string &data, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::display( const string &name, const string &type, const string &data, const CompoundDataMap &parameters )
 {
 	// exr and png are special...
 	if( type == "exr" || type == "png" )
@@ -342,7 +342,7 @@ void IECoreAppleseed::RendererImplementation::transformEnd()
 	m_transformStack.pop();
 }
 
-void IECoreAppleseed::RendererImplementation::setTransform( const Imath::M44f &m )
+void IECoreAppleseed::RendererImplementation::setTransform( const M44f &m )
 {
 	if( m_motionHandler->insideMotionBlock() )
 	{
@@ -359,19 +359,19 @@ void IECoreAppleseed::RendererImplementation::setTransform( const string &coordi
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::setTransform", "Not implemented." );
 }
 
-Imath::M44f IECoreAppleseed::RendererImplementation::getTransform() const
+M44f IECoreAppleseed::RendererImplementation::getTransform() const
 {
 	M44d m = m_transformStack.top().get_earliest_transform().get_local_to_parent();
 	return M44f( m );
 }
 
-Imath::M44f IECoreAppleseed::RendererImplementation::getTransform( const string &coordinateSystem ) const
+M44f IECoreAppleseed::RendererImplementation::getTransform( const string &coordinateSystem ) const
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::getTransform", "Not implemented." );
 	return M44f();
 }
 
-void IECoreAppleseed::RendererImplementation::concatTransform( const Imath::M44f &m )
+void IECoreAppleseed::RendererImplementation::concatTransform( const M44f &m )
 {
 	if( m_motionHandler->insideMotionBlock() )
 	{
@@ -404,17 +404,17 @@ void IECoreAppleseed::RendererImplementation::attributeEnd()
 	transformEnd();
 }
 
-void IECoreAppleseed::RendererImplementation::setAttribute( const string &name, IECore::ConstDataPtr value )
+void IECoreAppleseed::RendererImplementation::setAttribute( const string &name, ConstDataPtr value )
 {
 	m_attributeStack.top().setAttribute( name, value );
 }
 
-IECore::ConstDataPtr IECoreAppleseed::RendererImplementation::getAttribute( const string &name ) const
+ConstDataPtr IECoreAppleseed::RendererImplementation::getAttribute( const string &name ) const
 {
 	return m_attributeStack.top().getAttribute( name );
 }
 
-void IECoreAppleseed::RendererImplementation::shader( const string &type, const string &name, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::shader( const string &type, const string &name, const CompoundDataMap &parameters )
 {
 	if( type == "osl:shader" || type == "shader" )
 	{
@@ -432,9 +432,9 @@ void IECoreAppleseed::RendererImplementation::shader( const string &type, const 
 	}
 }
 
-void IECoreAppleseed::RendererImplementation::light( const string &name, const string &handle, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::light( const string &name, const string &handle, const CompoundDataMap &parameters )
 {
-	bool isEnvironment = boost::algorithm::ends_with( name, "_environment_edf" );
+	bool isEnvironment = algorithm::ends_with( name, "_environment_edf" );
 	const string *environmentEDFName = 0;
 
 	// ignore enviromnment EDFs not selected in the appleseed options node.
@@ -470,7 +470,7 @@ void IECoreAppleseed::RendererImplementation::light( const string &name, const s
 			if( paramValue->typeId() == Color3fDataTypeId )
 			{
 				string colorName = m_attributeStack.top().name() + "." + paramName;
-				const Imath::Color3f &col = static_cast<const Color3fData*>( paramValue.get() )->readable();
+				const Color3f &col = static_cast<const Color3fData*>( paramValue.get() )->readable();
 				colorName = createColorEntity( m_project->get_scene()->colors(), col, colorName.c_str() );
 				params.insert( paramName.c_str(), colorName.c_str() );
 			}
@@ -532,7 +532,7 @@ void IECoreAppleseed::RendererImplementation::illuminate( const string &lightHan
 // motion blur
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::motionBegin( const std::set<float> &times )
+void IECoreAppleseed::RendererImplementation::motionBegin( const set<float> &times )
 {
 	if (m_motionHandler->insideMotionBlock() )
 	{
@@ -558,37 +558,37 @@ void IECoreAppleseed::RendererImplementation::motionEnd()
 // primitives
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::points( size_t numPoints, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::points( size_t numPoints, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::points", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::disk( float radius, float z, float thetaMax, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::disk( float radius, float z, float thetaMax, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::disk", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::curves( const IECore::CubicBasisf &basis, bool periodic, ConstIntVectorDataPtr numVertices, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::curves( const CubicBasisf &basis, bool periodic, ConstIntVectorDataPtr numVertices, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::curves", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::text( const string &font, const string &text, float kerning, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::text( const string &font, const string &text, float kerning, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::text", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::sphere( float radius, float zMin, float zMax, float thetaMax, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::sphere( float radius, float zMin, float zMax, float thetaMax, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::sphere", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::image( const Imath::Box2i &dataWindow, const Imath::Box2i &displayWindow, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::image( const Box2i &dataWindow, const Box2i &displayWindow, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::image", "Not implemented." );
 }
 
-void IECoreAppleseed::RendererImplementation::mesh( IECore::ConstIntVectorDataPtr vertsPerFace, IECore::ConstIntVectorDataPtr vertIds, const string &interpolation, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::mesh( ConstIntVectorDataPtr vertsPerFace, ConstIntVectorDataPtr vertIds, const string &interpolation, const PrimitiveVariableMap &primVars )
 {
 	if( !m_mainAssembly )
 	{
@@ -596,7 +596,7 @@ void IECoreAppleseed::RendererImplementation::mesh( IECore::ConstIntVectorDataPt
 		return;
 	}
 
-	MeshPrimitivePtr mesh = new IECore::MeshPrimitive( vertsPerFace, vertIds, interpolation );
+	MeshPrimitivePtr mesh = new MeshPrimitive( vertsPerFace, vertIds, interpolation );
 	mesh->variables = primVars;
 
 	string materialName = currentMaterialName();
@@ -614,7 +614,7 @@ void IECoreAppleseed::RendererImplementation::mesh( IECore::ConstIntVectorDataPt
 	}
 }
 
-void IECoreAppleseed::RendererImplementation::nurbs( int uOrder, IECore::ConstFloatVectorDataPtr uKnot, float uMin, float uMax, int vOrder, IECore::ConstFloatVectorDataPtr vKnot, float vMin, float vMax, const IECore::PrimitiveVariableMap &primVars )
+void IECoreAppleseed::RendererImplementation::nurbs( int uOrder, ConstFloatVectorDataPtr uKnot, float uMin, float uMax, int vOrder, ConstFloatVectorDataPtr vKnot, float vMin, float vMax, const PrimitiveVariableMap &primVars )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::nurbs", "Not implemented." );
 }
@@ -633,7 +633,7 @@ void IECoreAppleseed::RendererImplementation::geometry( const string &type, cons
 // procedurals
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::procedural( IECore::Renderer::ProceduralPtr proc )
+void IECoreAppleseed::RendererImplementation::procedural( Renderer::ProceduralPtr proc )
 {
 	// appleseed does not support procedurals yet, so we expand them immediately.
 	proc->render( this );
@@ -643,7 +643,7 @@ void IECoreAppleseed::RendererImplementation::procedural( IECore::Renderer::Proc
 // instancing
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::instanceBegin( const string &name, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::instanceBegin( const string &name, const CompoundDataMap &parameters )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::instanceBegin", "Not implemented." );
 }
@@ -662,7 +662,7 @@ void IECoreAppleseed::RendererImplementation::instance( const string &name )
 // commands
 /////////////////////////////////////////////////////////////////////////////////////////
 
-IECore::DataPtr IECoreAppleseed::RendererImplementation::command( const string &name, const CompoundDataMap &parameters )
+DataPtr IECoreAppleseed::RendererImplementation::command( const string &name, const CompoundDataMap &parameters )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::command", "Not implemented." );
 	return 0;
@@ -672,7 +672,7 @@ IECore::DataPtr IECoreAppleseed::RendererImplementation::command( const string &
 // rerendering
 /////////////////////////////////////////////////////////////////////////////////////////
 
-void IECoreAppleseed::RendererImplementation::editBegin( const string &editType, const IECore::CompoundDataMap &parameters )
+void IECoreAppleseed::RendererImplementation::editBegin( const string &editType, const CompoundDataMap &parameters )
 {
 	msg( Msg::Warning, "IECoreAppleseed::RendererImplementation::editBegin", "Not implemented." );
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ShadingState.cpp
@@ -87,7 +87,7 @@ void IECoreAppleseed::ShadingState::setOSLSurface( ConstShaderPtr surface )
 	m_surfaceShader = surface;
 }
 
-void IECoreAppleseed::ShadingState::shaderGroupHash( IECore::MurmurHash &hash ) const
+void IECoreAppleseed::ShadingState::shaderGroupHash( MurmurHash &hash ) const
 {
 	for( int i = 0, e = m_shaders.size(); i < e; ++i)
 	{
@@ -130,7 +130,7 @@ string IECoreAppleseed::ShadingState::createShaderGroup( asr::Assembly& assembly
 }
 
 
-void IECoreAppleseed::ShadingState::materialHash( IECore::MurmurHash &hash ) const
+void IECoreAppleseed::ShadingState::materialHash( MurmurHash &hash ) const
 {
 	shaderGroupHash( hash );
 	hash.append( m_shadingSamples );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedCameraConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedCameraConverter.cpp
@@ -52,8 +52,8 @@ IE_CORE_DEFINERUNTIMETYPED( ToAppleseedCameraConverter );
 
 ToAppleseedCameraConverter::ConverterDescription<ToAppleseedCameraConverter> ToAppleseedCameraConverter::g_description;
 
-ToAppleseedCameraConverter::ToAppleseedCameraConverter( IECore::CameraPtr toConvert )
-	:	ToAppleseedConverter( "Converts IECore::Cameras to appleseed camera nodes", IECore::Camera::staticTypeId() )
+ToAppleseedCameraConverter::ToAppleseedCameraConverter( CameraPtr toConvert )
+	:	ToAppleseedConverter( "Converts IECore::Cameras to appleseed camera nodes", Camera::staticTypeId() )
 {
 	srcParameter()->setValue( toConvert );
 }
@@ -62,7 +62,7 @@ ToAppleseedCameraConverter::~ToAppleseedCameraConverter()
 {
 }
 
-asr::Entity *ToAppleseedCameraConverter::doConversion( IECore::ConstObjectPtr from, IECore::ConstCompoundObjectPtr operands ) const
+asr::Entity *ToAppleseedCameraConverter::doConversion( ConstObjectPtr from, ConstCompoundObjectPtr operands ) const
 {
 	CameraPtr camera = boost::static_pointer_cast<const Camera>( from )->copy();
 	camera->addStandardParameters();
@@ -107,7 +107,7 @@ asr::Entity *ToAppleseedCameraConverter::doConversion( IECore::ConstObjectPtr fr
 	}
 	else
 	{
-		 IECore::msg( Msg::Warning, "ToAppleseedCameraConverter", "unsupported projection type. Creating a default camera" );
+		 msg( Msg::Warning, "ToAppleseedCameraConverter", "unsupported projection type. Creating a default camera" );
 		 cameraFactory = cameraFactories.lookup( "pinhole_camera" );
 	}
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedConverter.cpp
@@ -63,7 +63,7 @@ renderer::Entity *ToAppleseedConverter::convert() const
 	return doConversion( srcParameter()->getValidatedValue(), operands );
 }
 
-ToAppleseedConverterPtr ToAppleseedConverter::create( IECore::ObjectPtr object )
+ToAppleseedConverterPtr ToAppleseedConverter::create( ObjectPtr object )
 {
 	const CreatorMap &m = creators();
 	CreatorMap::const_iterator it = m.find( object->typeId() );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedMeshConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedMeshConverter.cpp
@@ -45,6 +45,7 @@
 
 using namespace IECoreAppleseed;
 using namespace IECore;
+using namespace Imath;
 using namespace std;
 
 namespace asf = foundation;
@@ -54,8 +55,8 @@ IE_CORE_DEFINERUNTIMETYPED( ToAppleseedMeshConverter );
 
 ToAppleseedMeshConverter::ConverterDescription<ToAppleseedMeshConverter> ToAppleseedMeshConverter::g_description;
 
-ToAppleseedMeshConverter::ToAppleseedMeshConverter( IECore::MeshPrimitivePtr toConvert )
-	:	ToAppleseedShapeConverter( "Converts IECore::MeshPrimitives to appleseed mesh object entities", IECore::MeshPrimitive::staticTypeId() )
+ToAppleseedMeshConverter::ToAppleseedMeshConverter( MeshPrimitivePtr toConvert )
+	:	ToAppleseedShapeConverter( "Converts IECore::MeshPrimitives to appleseed mesh object entities", MeshPrimitive::staticTypeId() )
 {
 	srcParameter()->setValue( toConvert );
 }
@@ -64,13 +65,13 @@ ToAppleseedMeshConverter::~ToAppleseedMeshConverter()
 {
 }
 
-asr::Entity *ToAppleseedMeshConverter::doConversion( IECore::ConstObjectPtr from, IECore::ConstCompoundObjectPtr operands ) const
+asr::Entity *ToAppleseedMeshConverter::doConversion( ConstObjectPtr from, ConstCompoundObjectPtr operands ) const
 {
 	MeshPrimitivePtr mesh = static_cast<const MeshPrimitive *>( from.get() )->copy();
 	const V3fVectorData *p = mesh->variableData<V3fVectorData>( "P", PrimitiveVariable::Vertex );
 	if( !p )
 	{
-		throw IECore::Exception( "MeshPrimitive does not have \"P\" primitive variable of interpolation type Vertex." );
+		throw Exception( "MeshPrimitive does not have \"P\" primitive variable of interpolation type Vertex." );
 	}
 
 	asf::auto_release_ptr<asr::MeshObject> meshObj = asr::MeshObjectFactory::create( "mesh", asr::ParamArray() );
@@ -80,7 +81,7 @@ asr::Entity *ToAppleseedMeshConverter::doConversion( IECore::ConstObjectPtr from
 	{
 		size_t numVertices = p->readable().size();
 		meshObj->reserve_vertices( numVertices );
-		const std::vector<Imath::V3f> &points = p->readable();
+		const std::vector<V3f> &points = p->readable();
 		for( size_t i = 0; i < numVertices; ++i )
 		{
 			meshObj->push_vertex( asr::GVector3( points[i].x, points[i].y, points[i].z ) );
@@ -89,7 +90,7 @@ asr::Entity *ToAppleseedMeshConverter::doConversion( IECore::ConstObjectPtr from
 
 	// triangulate primitive (this should be in appleseed at some point)
 	{
-		IECore::TriangulateOpPtr op = new IECore::TriangulateOp();
+		TriangulateOpPtr op = new TriangulateOp();
 		op->inputParameter()->setValue( mesh );
 		op->throwExceptionsParameter()->setTypedValue( false ); // it's better to see something than nothing
 		op->copyParameter()->setTypedValue( false );
@@ -178,7 +179,7 @@ asr::Entity *ToAppleseedMeshConverter::doConversion( IECore::ConstObjectPtr from
 				{
 					size_t numNormals = n->readable().size();
 					meshObj->reserve_vertex_normals( numNormals );
-					const std::vector<Imath::V3f> &normals = n->readable();
+					const std::vector<V3f> &normals = n->readable();
 					for( size_t i = 0; i < numNormals; ++i)
 					{
 						asr::GVector3 n( normals[i].x, normals[i].y, normals[i].z );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedShapeConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedShapeConverter.cpp
@@ -45,7 +45,7 @@ using namespace std;
 
 IE_CORE_DEFINERUNTIMETYPED( ToAppleseedShapeConverter );
 
-ToAppleseedShapeConverter::ToAppleseedShapeConverter( const std::string &description, IECore::TypeId supportedType )
+ToAppleseedShapeConverter::ToAppleseedShapeConverter( const string &description, IECore::TypeId supportedType )
 	:	ToAppleseedConverter( description, supportedType )
 {
 }

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/TransformStack.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/TransformStack.cpp
@@ -36,6 +36,8 @@
 
 #include <cassert>
 
+using namespace Imath;
+
 namespace asf = foundation;
 namespace asr = renderer;
 
@@ -82,7 +84,7 @@ asr::TransformSequence& IECoreAppleseed::TransformStack::top()
 	return m_stack.top();
 }
 
-void IECoreAppleseed::TransformStack::setTransform( const Imath::M44f &m )
+void IECoreAppleseed::TransformStack::setTransform( const M44f &m )
 {
 	asf::Transformd xform;
 	makeTransform( m, xform );
@@ -90,12 +92,12 @@ void IECoreAppleseed::TransformStack::setTransform( const Imath::M44f &m )
 }
 
 void IECoreAppleseed::TransformStack::setTransform( const std::set<float> &times,
-	const std::vector<Imath::M44f> &transforms )
+	const std::vector<M44f> &transforms )
 {
 	makeTransformSequence( times, transforms, m_stack.top() );
 }
 
-void IECoreAppleseed::TransformStack::concatTransform( const Imath::M44f &m )
+void IECoreAppleseed::TransformStack::concatTransform( const M44f &m )
 {
 	asf::Transformd xform;
 	makeTransform( m, xform );
@@ -105,23 +107,23 @@ void IECoreAppleseed::TransformStack::concatTransform( const Imath::M44f &m )
 }
 
 void IECoreAppleseed::TransformStack::concatTransform( const std::set<float> &times,
-	const std::vector<Imath::M44f> &transforms )
+	const std::vector<M44f> &transforms )
 {
 	asr::TransformSequence seq;
 	makeTransformSequence( times, transforms, seq );
 	m_stack.top() = seq * m_stack.top();
 }
 
-void IECoreAppleseed::TransformStack::makeTransform( const Imath::M44f &m, asf::Transformd &xform ) const
+void IECoreAppleseed::TransformStack::makeTransform( const M44f &m, asf::Transformd &xform ) const
 {
-	Imath::M44d md( m );
+	M44d md( m );
 	xform.set_local_to_parent( asf::Matrix4d( md ) );
 	md.invert();
 	xform.set_parent_to_local( asf::Matrix4d( md ) );
 }
 
 void IECoreAppleseed::TransformStack::makeTransformSequence( const std::set<float> &times,
-	const std::vector<Imath::M44f> &transforms,
+	const std::vector<M44f> &transforms,
 	renderer::TransformSequence &xformSeq ) const
 {
 	assert( times.size() == transforms.size() );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -33,6 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include <vector>
+#include <exception>
 
 #include <boost/thread/locks.hpp>
 #include <boost/thread/mutex.hpp>
@@ -52,7 +53,6 @@
 using namespace IECore;
 using namespace Imath;
 using namespace boost;
-using namespace std;
 
 namespace asf = foundation;
 namespace asr = renderer;
@@ -96,7 +96,7 @@ class DisplayTileCallback : public asr::TileCallbackBase
 		// This method is called before a region is rendered.
 		virtual void pre_render( const size_t x, const size_t y, const size_t width, const size_t height)
 		{
-			boost::lock_guard<boost::mutex> guard( m_mutex );
+			lock_guard<mutex> guard( m_mutex );
 
 			if( m_display_initialized )
 			{
@@ -107,7 +107,7 @@ class DisplayTileCallback : public asr::TileCallbackBase
 		// This method is called after a tile is rendered (final rendering).
 		virtual void post_render_tile( const asr::Frame *frame, const size_t tileX, const size_t tileY )
 		{
-			boost::lock_guard<boost::mutex> guard( m_mutex );
+			lock_guard<mutex> guard( m_mutex );
 
 			if( !m_display_initialized )
 			{
@@ -120,7 +120,7 @@ class DisplayTileCallback : public asr::TileCallbackBase
 		// This method is called after a whole frame is rendered (progressive rendering).
 		virtual void post_render( const asr::Frame *frame )
 		{
-			boost::lock_guard<boost::mutex> guard( m_mutex );
+			lock_guard<mutex> guard( m_mutex );
 
 			if( !m_display_initialized )
 			{
@@ -184,7 +184,7 @@ class DisplayTileCallback : public asr::TileCallbackBase
 
 			try
 			{
-				m_driver = IECore::DisplayDriver::create( m_params.get( "driverType" ), displayWindow, m_data_window, channelNames, parameters );
+				m_driver = DisplayDriver::create( m_params.get( "driverType" ), displayWindow, m_data_window, channelNames, parameters );
 			}
 			catch( const std::exception &e )
 			{
@@ -291,7 +291,7 @@ class DisplayTileCallback : public asr::TileCallbackBase
 		bool m_display_initialized;
 		DisplayDriverPtr m_driver;
 		Box2i m_data_window;
-		vector<float> m_buffer;
+		std::vector<float> m_buffer;
 		size_t m_tile_width;
 		size_t m_tile_height;
 		size_t m_channel_count;


### PR DESCRIPTION
- Removed namespace qualifiers from IECoreAppleseed cpp files.
- Added an IECoreAppleseed changelog. The idea is that I maintain this file with the changes I do. When the Cortex changelog needs to be updated, the relevant parts of the IECoreAppleseed changelog can be copied and pasted without having to check the repository history, pull requests, ...
- The Renderer now passes the shutter interval to the PrimitiveConverter (I need it for deformation motion blur).
