### PR TITLE
Houdini SceneCache nodes can load the full path

### DIFF
--- a/include/IECoreHoudini/OBJ_SceneCacheTransform.h
+++ b/include/IECoreHoudini/OBJ_SceneCacheTransform.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -105,6 +105,7 @@ class OBJ_SceneCacheTransform : public OBJ_SceneCacheNode<OBJ_SubNet>
 			UT_String shapeFilter;
 			UT_String tagFilterStr;
 			UT_StringMMPattern tagFilter;
+			UT_String fullPathName;
 		};
 		
 		/// Called by expandHierarchy() and doExpandChildren() when the SceneCache contains an object.

--- a/include/IECoreHoudini/SOP_SceneCacheSource.h
+++ b/include/IECoreHoudini/SOP_SceneCacheSource.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2012-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2012-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -79,6 +79,7 @@ class SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 			GeometryType geometryType;
 			std::string attributeFilter;
 			std::string attributeCopy;
+			std::string fullPathName;
 			UT_StringMMPattern shapeFilter;
 			UT_StringMMPattern tagFilter;
 			
@@ -94,7 +95,7 @@ class SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 		// Groups, and CoordinateSystems. Updates animatedTopology and animatedPrimVars if appropriate.
 		IECore::ConstObjectPtr transformObject( const IECore::Object *object, const Imath::M44d &transform, Parameters &params );
 		// Convert the object to Houdini, optimizing for animated primitive variables if possible.
-		bool convertObject( const IECore::Object *object, const std::string &name, Parameters &params );
+		bool convertObject( const IECore::Object *object, const std::string &name, const IECore::SceneInterface *scene, Parameters &params );
 		
 		void loadObjects( const IECore::SceneInterface *scene, Imath::M44d transform, double time, Space space, Parameters &params, size_t rootSize );
 		IECore::MatrixTransformPtr matrixTransform( Imath::M44d t );

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -67,6 +67,7 @@ class SceneCacheNode : public BaseType
 		static PRM_Name pAttributeCopy;
 		static PRM_Name pTagFilter;
 		static PRM_Name pShapeFilter;
+		static PRM_Name pFullPathName;
 		
 		static PRM_Default rootDefault;
 		static PRM_Default spaceDefault;
@@ -122,6 +123,8 @@ class SceneCacheNode : public BaseType
 		void getShapeFilter( UT_String &filter ) const;
 		void getShapeFilter( UT_StringMMPattern &filter ) const;
 		void setShapeFilter( const UT_String &filter );
+		void getFullPathName( UT_String &name ) const;
+		void setFullPathName( const UT_String &name );
 		void referenceParent( const char *parmName );
 		
 		/// Access point to the actual SceneCache. All users should only access the cache

--- a/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -97,11 +97,12 @@ void OBJ_SceneCacheGeometry::expandHierarchy( const SceneInterface *scene )
 
 void OBJ_SceneCacheGeometry::pushToHierarchy()
 {
-	UT_String attribFilter, attribCopy, tagFilter, shapeFilter;
+	UT_String attribFilter, attribCopy, tagFilter, shapeFilter, fullPathName;
 	getAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
 	getTagFilter( tagFilter );
 	getShapeFilter( shapeFilter );
+	getFullPathName( fullPathName );
 	GeometryType geomType = getGeometryType();
 	
 	UT_PtrArray<OP_Node*> children;
@@ -113,6 +114,7 @@ void OBJ_SceneCacheGeometry::pushToHierarchy()
 		sop->setAttributeCopy( attribCopy );
 		sop->setTagFilter( tagFilter );
 		sop->setShapeFilter( shapeFilter );
+		sop->setFullPathName( fullPathName );
 		sop->setGeometryType( (SOP_SceneCacheSource::GeometryType)geomType );
 	}
 }
@@ -135,7 +137,7 @@ void OBJ_SceneCacheGeometry::doExpandGeometry( const SceneInterface *scene )
 		sopSpace = SOP_SceneCacheSource::Path;
 	}
 	
-	UT_String attribFilter, attribCopy, tagFilter, shapeFilter;
+	UT_String attribFilter, attribCopy, tagFilter, shapeFilter, fullPathName;
 	getAttributeFilter( attribFilter );
 	sop->setAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
@@ -144,6 +146,8 @@ void OBJ_SceneCacheGeometry::doExpandGeometry( const SceneInterface *scene )
 	sop->setTagFilter( tagFilter );
 	getShapeFilter( shapeFilter );
 	sop->setShapeFilter( shapeFilter );
+	getFullPathName( fullPathName );
+	sop->setFullPathName( fullPathName );
 	
 	sop->setSpace( sopSpace );
 	sop->setObjectOnly( objectOnly );

--- a/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -143,6 +143,7 @@ void OBJ_SceneCacheTransform::expandHierarchy( const SceneInterface *scene )
 	getShapeFilter( params.shapeFilter );
 	getTagFilter( params.tagFilterStr );
 	getTagFilter( params.tagFilter );
+	getFullPathName( params.fullPathName );
 	
 	if ( params.hierarchy == FlatGeometry )
 	{
@@ -216,6 +217,7 @@ OBJ_Node *OBJ_SceneCacheTransform::doExpandObject( const SceneInterface *scene, 
 	geo->setAttributeFilter( params.attributeFilter );
 	geo->setAttributeCopy( params.attributeCopy );
 	geo->setShapeFilter( params.shapeFilter );
+	geo->setFullPathName( params.fullPathName );
 	
 	bool visible = tagged( scene, params.tagFilter );
 	if ( visible )
@@ -241,6 +243,7 @@ OBJ_Node *OBJ_SceneCacheTransform::doExpandChild( const SceneInterface *scene, O
 	xform->setAttributeFilter( params.attributeFilter );
 	xform->setAttributeCopy( params.attributeCopy );
 	xform->setShapeFilter( params.shapeFilter );
+	xform->setFullPathName( params.fullPathName );
 	xform->setInt( pHierarchy.getToken(), 0, 0, params.hierarchy );
 	xform->setInt( pDepth.getToken(), 0, 0, params.depth );
 	
@@ -342,10 +345,11 @@ void OBJ_SceneCacheTransform::doExpandChildren( const SceneInterface *scene, OP_
 
 void OBJ_SceneCacheTransform::pushToHierarchy()
 {
-	UT_String attribFilter, attribCopy, shapeFilter;
+	UT_String attribFilter, attribCopy, shapeFilter, fullPathName;
 	getAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
 	getShapeFilter( shapeFilter );
+	getFullPathName( fullPathName );
 	GeometryType geometryType = getGeometryType();
 	
 	UT_String tagFilterStr;
@@ -361,6 +365,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 		xform->setAttributeFilter( attribFilter );
 		xform->setAttributeCopy( attribCopy );
 		xform->setShapeFilter( shapeFilter );
+		xform->setFullPathName( fullPathName );
 		xform->setGeometryType( geometryType );
 		
 		std::string file;
@@ -387,6 +392,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 		geo->setAttributeFilter( attribFilter );
 		geo->setAttributeCopy( attribCopy );
 		geo->setShapeFilter( shapeFilter );
+		geo->setFullPathName( fullPathName );
 		geo->setGeometryType( (OBJ_SceneCacheGeometry::GeometryType)geometryType );
 		
 		std::string file;
@@ -420,6 +426,7 @@ OBJ_SceneCacheTransform::Parameters::Parameters( const Parameters &other )
 	shapeFilter = other.shapeFilter;
 	tagFilterStr = other.tagFilterStr;
 	tagFilter.compile( tagFilterStr );
+	fullPathName = other.fullPathName;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/src/IECoreHoudini/SceneCacheNode.cpp
+++ b/src/IECoreHoudini/SceneCacheNode.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -89,6 +89,9 @@ PRM_Name SceneCacheNode<BaseType>::pTagFilter( "tagFilter", "Tag Filter" );
 
 template<typename BaseType>
 PRM_Name SceneCacheNode<BaseType>::pShapeFilter( "shapeFilter", "Shape Filter" );
+
+template<typename BaseType>
+PRM_Name SceneCacheNode<BaseType>::pFullPathName( "fullPathName", "Full Path Name" );
 
 template<typename BaseType>
 PRM_Name SceneCacheNode<BaseType>::pGeometryType( "geometryType", "Geometry Type" );
@@ -191,7 +194,7 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 	static PRM_Template *thisTemplate = 0;
 	if ( !thisTemplate )
 	{
-		thisTemplate = new PRM_Template[6];
+		thisTemplate = new PRM_Template[7];
 		
 		thisTemplate[0] = PRM_Template(
 			PRM_INT, 1, &pGeometryType, &geometryTypeDefault, &geometryTypeList, 0, 0, 0, 0,
@@ -226,6 +229,14 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 			"match the filter will remain collapsed. In Parenting mode, the tag filters just control initial "
 			"visibility. In FlatGeometry mode they essentially delete the non-tagged geometry. Uses Houdini "
 			"matching syntax, but matches *any* of the tags."
+		);
+		
+		thisTemplate[5] = PRM_Template(
+			PRM_STRING, 1, &pFullPathName, 0, 0, 0, 0, 0, 0,
+			"Load the full path of the object as a primitive attribute with this name. This is for user "
+			"convenience and has no meaning in terms of processing or exporting SceneCaches. If left empty, "
+			"the full path will not be loaded. It is the user's responsibility to remove this attribute prior "
+			"to exporting new SceneCaches if necessary."
 		);
 	}
 	
@@ -516,6 +527,18 @@ template<typename BaseType>
 void SceneCacheNode<BaseType>::setShapeFilter( const UT_String &filter )
 {
 	this->setString( filter, CH_STRING_LITERAL, pShapeFilter.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::getFullPathName( UT_String &name ) const
+{
+	this->evalString( name, pFullPathName.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::setFullPathName( const UT_String &name )
+{
+	this->setString( name, CH_STRING_LITERAL, pFullPathName.getToken(), 0, 0 );
 }
 
 template<typename BaseType>


### PR DESCRIPTION
SceneCacheNodes have a new "Full Path Name" parm to load the full path alongside the relative name of each object. This is a string parm which specifies the name of the attrib to hold the full path data. I chose a string rather than toggle because I wanted to make it clear that this data is arbitrary, and not some native part of SceneCache processing (like "name" or "ieMeshInterpolation"). I've left it blank by default, since we don't want to start loading the full path in existing scenes, we want artists/HDAs to opt-in to this extra data.

The help text for the parm clarifies that this data is not relevant to any automated SceneCache processing or exporting, and that users are responsible for removing that attrib before caching.