### PR TITLE
IECoreAppleseed: small improvements

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/EditBlockHandler.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/EditBlockHandler.h
@@ -73,8 +73,8 @@ class EditBlockHandler : boost::noncopyable
 		class RendererController;
 
 		renderer::Project &m_project;
-		RendererController *m_rendererController;
-		renderer::MasterRenderer *m_renderer;
+		std::auto_ptr<RendererController> m_rendererController;
+		std::auto_ptr<renderer::MasterRenderer> m_renderer;
 		boost::thread m_renderingThread;
 		int m_editDepth;
 		std::string m_exactScopeName;

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/EditBlockHandler.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/EditBlockHandler.cpp
@@ -59,11 +59,6 @@ class IECoreAppleseed::EditBlockHandler::RendererController : public asr::Defaul
 			m_status = ContinueRendering;
 		}
 
-		virtual void release()
-		{
-			delete this;
-		}
-
 		virtual Status get_status() const
 		{
 			return m_status;


### PR DESCRIPTION
In EditBlockHandler:

- Use smart pointers instead of raw pointers.
- Destroy the Renderer before the RendererController.
