### PR TITLE
Enable SSE4.1 when building IECoreAppleseed.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3161,6 +3161,7 @@ appleseedEnv.Append(
 		"contrib/IECoreAppleseed/include",
 	],
 	CPPFLAGS = [
+		"-msse4.1",
 		"-DAPPLESEED_ENABLE_IMATH_INTEROP",
 		"-DAPPLESEED_WITH_OIIO",
 		"-DAPPLESEED_WITH_OSL",
@@ -3179,6 +3180,7 @@ appleseedPythonModuleEnv.Append(
 		"contrib/IECoreAppleseed/include/bindings",
 	],
 	CPPFLAGS = [
+		"-msse4.1",
 		"-DAPPLESEED_ENABLE_IMATH_INTEROP",
 		"-DAPPLESEED_WITH_OIIO",
 		"-DAPPLESEED_WITH_OSL",


### PR DESCRIPTION
appleseed master now uses some SSE4.1 intrinsics:
https://github.com/appleseedhq/appleseed/commit/a4278be4726d01a72a6d9850f5a26cf7431b416f