### PR TITLE
Camera Repositions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ lib
 build
 config.log
 mayaLog
+projects
 test/IECore/IECoreTest
 test/IECore/results.txt
 test/IECore/resultsPython.txt

--- a/src/IECoreMaya/FromMayaCameraConverter.cpp
+++ b/src/IECoreMaya/FromMayaCameraConverter.cpp
@@ -148,6 +148,7 @@ IECore::ObjectPtr FromMayaCameraConverter::doConversion( const MDagPath &dagPath
 	CompoundDataPtr maya = new CompoundData;
 	result->blindData()->writable()["maya"] = maya;
 	maya->writable()["aperture"] = new V2fData( Imath::V2f( fnCamera.horizontalFilmAperture(), fnCamera.verticalFilmAperture() ) );
+	maya->writable()["filmOffset"] = new V2fData( Imath::V2f( fnCamera.horizontalFilmOffset(), fnCamera.verticalFilmOffset() ) );
 
 	return result;
 }

--- a/src/IECoreMaya/FromMayaCameraConverter.cpp
+++ b/src/IECoreMaya/FromMayaCameraConverter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2011, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -133,13 +133,14 @@ IECore::ObjectPtr FromMayaCameraConverter::doConversion( const MDagPath &dagPath
 		result->parameters()["projection"] = new StringData( "perspective" );
 
 		// derive horizontal field of view from the viewing frustum
-		float fov = Math<double>::atan( frustum.max.x / clippingPlanes[0] ) * 2.0f;
+		float horizontalFrustumOffset = frustum.max.x - (frustum.max.x - frustum.min.x) / 2.0f;
+		float fov = Math<double>::atan( (frustum.max.x - horizontalFrustumOffset) / ( clippingPlanes[0] ) ) * 2.0f;
 		fov = radiansToDegrees( fov );
 		result->parameters()["projection:fov"] = new FloatData( fov );
 
 		// scale the frustum so that it's -1,1 in x and that gives us the screen window
 		float frustumScale = 2.0f/(frustum.max.x - frustum.min.x);
-		Box2f screenWindow( V2f( -1, frustum.min.y * frustumScale ), V2f( 1, frustum.max.y * frustumScale ) );
+		Box2f screenWindow( V2f( -1 + (horizontalFrustumOffset * frustumScale), frustum.min.y * frustumScale ), V2f( 1 + (horizontalFrustumOffset * frustumScale), frustum.max.y * frustumScale ) );
 		result->parameters()["screenWindow"] = new Box2fData( screenWindow );
 	}
 

--- a/src/IECoreMaya/ToMayaCameraConverter.cpp
+++ b/src/IECoreMaya/ToMayaCameraConverter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -157,6 +157,14 @@ bool ToMayaCameraConverter::doConversion( IECore::ConstObjectPtr from, MObject &
 			Imath::V2f aperture = apertureData->readable();
 			fnCamera.setHorizontalFilmAperture( aperture[0] );
 			fnCamera.setVerticalFilmAperture( aperture[1] );
+		}
+		
+		const V2fData *filmOffsetData = mayaData->member<V2fData>( "filmOffset" );
+		if ( filmOffsetData )
+		{
+			Imath::V2f filmOffset = filmOffsetData->readable();
+			fnCamera.setHorizontalFilmOffset( filmOffset[0] );
+			fnCamera.setVerticalFilmOffset( filmOffset[1] );
 		}
 	}
 	

--- a/test/IECoreMaya/FnParameterisedHolderTest.py
+++ b/test/IECoreMaya/FnParameterisedHolderTest.py
@@ -906,7 +906,7 @@ class FnParameterisedHolderTest( IECoreMaya.TestCase ) :
 
 		for f in [
 			"test/IECoreMaya/referenceEditCounts.ma",
-			"test/IECoreMaya/resultAttrLoadTest.ma"
+			"test/IECoreMaya/resultAttrLoadTest.ma",
 			"test/IECoreMaya/resultGetParameterisedTest.ma",
 		] :
 

--- a/test/IECoreMaya/FromMayaCameraConverterTest.py
+++ b/test/IECoreMaya/FromMayaCameraConverterTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2008-2012, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2008-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -118,6 +118,30 @@ class FromMayaCameraConverterTest( IECoreMaya.TestCase ) :
 		sel.getDagPath( 0, dag )
 		fn = maya.OpenMaya.MFnCamera( dag )
 		self.assertAlmostEqual( camera.parameters()["projection:fov"].value, IECore.radiansToDegrees( fn.horizontalFieldOfView() ), 5 )
+	
+	def testFilmOffset( self ) :
+		
+		for x in [ -0.5, -0.25, 0, 0.25, 0.5 ] :
+			
+			for y in [ -0.5, -0.25, 0, 0.25, 0.5 ] :
+				
+				maya.cmds.setAttr( "perspShape.horizontalFilmOffset", x )
+				maya.cmds.setAttr( "perspShape.verticalFilmOffset", y )
+				camera = IECoreMaya.FromMayaCameraConverter( "perspShape" ).convert()
+				
+				self.assertEqual( camera.getName(), "perspShape" )
+				self.assertEqual( camera.getTransform().transform(), IECore.M44f( maya.cmds.getAttr( "persp.worldMatrix[0]" ) ) )
+				self.assertEqual( camera.parameters()["resolution"].value, IECore.V2i( maya.cmds.getAttr( "defaultResolution.width" ), maya.cmds.getAttr( "defaultResolution.height" ) ) )
+				self.assertEqual( camera.parameters()["clippingPlanes"].value, IECore.V2f( maya.cmds.getAttr( "perspShape.nearClipPlane" ), maya.cmds.getAttr( "perspShape.farClipPlane" ) ) )
+				self.assertEqual( camera.parameters()["projection"].value, "perspective" )
+				self.assertEqual( camera.blindData()["maya"]["aperture"].value, IECore.V2f( maya.cmds.getAttr( "perspShape.horizontalFilmAperture" ), maya.cmds.getAttr( "perspShape.verticalFilmAperture" ) ) )
+				
+				sel = maya.OpenMaya.MSelectionList()
+				sel.add( "perspShape" )
+				dag = maya.OpenMaya.MDagPath()
+				sel.getDagPath( 0, dag )
+				fn = maya.OpenMaya.MFnCamera( dag )
+				self.assertAlmostEqual( camera.parameters()["projection:fov"].value, IECore.radiansToDegrees( fn.horizontalFieldOfView() ), 5 )
 
 if __name__ == "__main__":
 	IECoreMaya.TestProgram()


### PR DESCRIPTION
This fixes a bug in `FromMayaCameraConverter` when the horizontal film offset is non-zero. Now that we're correctly handling film offsets, I've also added support to the `ToMayaCameraConverter` so we can load them again. That bit is all terribly Maya specific (just like how we handle aperture), and in the long run I think we want to come up with a more full featured spec for `IECore.Camera` so we can load this data into any app.... but for now, lets just fix the bug and make sure we can round trip that data in Maya.

I've also added a commit to clean up after the maya tests, as that's been annoying my for some time...