### PR TITLE
BlindDataHolder threading fix

### DIFF
--- a/include/IECore/BlindDataHolder.h
+++ b/include/IECore/BlindDataHolder.h
@@ -61,7 +61,7 @@ class IECORE_API BlindDataHolder : public Object
 
 	private :
 
-		mutable CompoundDataPtr m_data;
+		CompoundDataPtr m_data;
 
 		static const unsigned int m_ioVersion;
 

--- a/src/IECore/BlindDataHolder.cpp
+++ b/src/IECore/BlindDataHolder.cpp
@@ -46,7 +46,7 @@ IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(BlindDataHolder);
 
 BlindDataHolder::BlindDataHolder()
 {
-	m_data = 0;
+	m_data = new CompoundData();
 }
 
 BlindDataHolder::BlindDataHolder(CompoundDataPtr data) : m_data(data)
@@ -60,19 +60,11 @@ BlindDataHolder::~BlindDataHolder()
 
 CompoundData *BlindDataHolder::blindData()
 {
-	if ( !m_data )
-	{
-		m_data = new CompoundData();
-	}
 	return m_data.get();
 }
 
 const CompoundData *BlindDataHolder::blindData() const
 {
-	if ( !m_data )
-	{
-		m_data = new CompoundData();
-	}
 	return m_data.get();
 }
 
@@ -80,21 +72,14 @@ void BlindDataHolder::copyFrom( const Object *other, CopyContext *context )
 {
 	Object::copyFrom( other, context );
 	const BlindDataHolder *tOther = static_cast<const BlindDataHolder *>( other );
-	if ( tOther->m_data )
-	{
-		m_data = context->copy<CompoundData>( tOther->m_data.get() );
-	}
-	else 
-	{
-		m_data = 0;
-	}
+	m_data = context->copy<CompoundData>( tOther->m_data.get() );
 }
 
 void BlindDataHolder::save( SaveContext *context ) const
 {
 	Object::save( context );
 
-	bool haveData = ( m_data && m_data->readable().size() );
+	bool haveData = m_data->readable().size();
 
 	if ( haveData )
 	{
@@ -117,7 +102,7 @@ void BlindDataHolder::load( LoadContextPtr context )
 	}
 	else
 	{
-		m_data = 0;
+		m_data = new CompoundData();
 	}
 }
 
@@ -128,31 +113,13 @@ bool BlindDataHolder::isEqualTo( const Object *other ) const
 		return false;
 	}
 	const BlindDataHolder *tOther = static_cast<const BlindDataHolder *>( other );
-	if ( m_data )
-	{
-		if ( tOther->m_data )
-		{
-			return m_data->isEqualTo( tOther->m_data.get() );
-		}
-		else 
-		{
-			return ( m_data->readable().size() == 0 );
-		}
-	}
-	if ( tOther->m_data )
-	{
-		return ( tOther->m_data->readable().size() == 0 );
-	}
-	return true;
+	return m_data->isEqualTo( tOther->m_data.get() );
 }
 
 void BlindDataHolder::memoryUsage( Object::MemoryAccumulator &a ) const
 {
 	Object::memoryUsage( a );
-	if ( m_data )
-	{
-		a.accumulate( m_data.get() );
-	}
+	a.accumulate( m_data.get() );
 }
 
 void BlindDataHolder::hash( MurmurHash &h ) const
@@ -160,7 +127,7 @@ void BlindDataHolder::hash( MurmurHash &h ) const
 	Object::hash( h );
 	// Our hash when blindData is empty or when m_data is unnitialized is the same.
 	// This is currently garanteed by CompoundData but we are safer this way.
-	if ( m_data && m_data->readable().size() )
+	if ( m_data->readable().size() )
 	{
 		m_data->hash( h );
 	}

--- a/test/IECore/BlindDataHolder.py
+++ b/test/IECore/BlindDataHolder.py
@@ -102,6 +102,9 @@ class TestBlindDataHolder(unittest.TestCase):
 
 		b2 = Object.load( iface, "test" )
 		self.assertEqual( b1, b2 )
+		
+		# should have written a "blindData" entry into the indexed io hierarchy
+		self.failUnless( isinstance( iface.directory( ["test","data","BlindDataHolder", "data", "blindData"], IndexedIO.MissingBehaviour.NullIfMissing ), IndexedIO ) )
 
 		# second test: overriding with no blind data
 		b1 = BlindDataHolder()
@@ -123,6 +126,9 @@ class TestBlindDataHolder(unittest.TestCase):
 		g1.save( iface, "test" )
 		g2 = Object.load( iface, "test" )
 		self.assertEqual( g1, g2 )
+		
+		# "blindData" entry should be excluded from the IndexedIO hierarchy
+		self.assertEqual( iface.directory( ["test","data","BlindDataHolder"], IndexedIO.MissingBehaviour.NullIfMissing ), None )
 		
 	def testHash( self ) :
 	


### PR DESCRIPTION
BlindDataHolder::blindData() was not thread safe for uninitialized m_data because it didn't have a lock, which was breaking highly instanced renders on one of our shows.

Instead of adding a lock, I went for just always initializing m_data, as it makes things simpler anyway and doesn't break compatibility. What was the reason for initializing it to zero?

And yeah, I am a loser for doing this at 9pm on a Friday...