### PR TITLE
Added copy constructor for LRUCache::CachedEntry.

### DIFF
--- a/include/IECore/LRUCache.h
+++ b/include/IECore/LRUCache.h
@@ -155,6 +155,7 @@ class LRUCache : private boost::noncopyable
 		struct CacheEntry
 		{
 			CacheEntry(); // status == New, previous == next == NULL
+			CacheEntry( const CacheEntry &other );
 			
 			Value value; // value for this item
 			Cost cost; // the cost for this item

--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -46,10 +46,16 @@ namespace IECore
 
 template<typename Key, typename Value>
 LRUCache<Key, Value>::CacheEntry::CacheEntry()
-	:	value(), cost( 0 ), previous( NULL ), next( NULL ), status( New )
+	:	value(), cost( 0 ), previous( NULL ), next( NULL ), status( New ), mutex()
 {
 }
-			
+
+template<typename Key, typename Value>
+LRUCache<Key, Value>::CacheEntry::CacheEntry( const CacheEntry &other )
+	:	value( other.value ), cost( other.cost ), previous( other.previous ), next( other.next ), status( other.status ), mutex()
+{
+}
+
 template<typename Key, typename Value>
 LRUCache<Key, Value>::LRUCache( GetterFunction getter )
 	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( 500 )


### PR DESCRIPTION
This was necessary because in TBB 4.3 mutexes are not copyable.