### PR TITLE
Using GA_StringTableStatistics to find the number of strings in an attribute

### DIFF
--- a/src/IECoreHoudini/FromHoudiniCompoundObjectConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniCompoundObjectConverter.cpp
@@ -70,7 +70,9 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniCompoundObjectConverter:
 	{
 		const GA_Attribute *nameAttr = attrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		if ( tuple->getTableEntries( nameAttr ) < 2 )
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		if ( stats.getEntries() < 2 )
 		{
 			return Inapplicable;
 		}

--- a/src/IECoreHoudini/FromHoudiniCurvesConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniCurvesConverter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2010-2014, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2010-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -103,7 +103,9 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniCurvesConverter::canConv
 	{
 		const GA_Attribute *nameAttr = attrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		if ( tuple->getTableEntries( nameAttr ) < 2 )
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		if ( stats.getEntries() < 2 )
 		{
 			return Ideal;
 		}

--- a/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGroupConverter.cpp
@@ -115,7 +115,9 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniGroupConverter::canConve
 	{
 		const GA_Attribute *nameAttr = attrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		if ( tuple->getTableEntries( nameAttr ) > 1 )
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		if ( stats.getEntries() > 1 )
 		{
 			return Ideal;
 		}

--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2010-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2010-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -78,7 +78,9 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniPolygonsConverter::canCo
 	{
 		const GA_Attribute *nameAttr = attrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		if ( tuple->getTableEntries( nameAttr ) < 2 )
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		if ( stats.getEntries() < 2 )
 		{
 			return Ideal;
 		}

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -591,7 +591,9 @@ bool LiveScene::hasObject() const
 		
 		const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		GA_Size numShapes = tuple->getTableEntries( nameAttr );
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		GA_Size numShapes = stats.getEntries();
 		if ( !numShapes )
 		{
 			return true;
@@ -716,7 +718,9 @@ void LiveScene::childNames( NameList &childNames ) const
 		
 		const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		GA_Size numShapes = tuple->getTableEntries( nameAttr );
+		GA_StringTableStatistics stats;
+		tuple->getStatistics( nameAttr, stats );
+		GA_Size numShapes = stats.getEntries();
 		for ( GA_Size i=0; i < numShapes; ++i )
 		{
 			const char *currentName = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, i ) );
@@ -888,7 +892,9 @@ OP_Node *LiveScene::retrieveChild( const Name &name, Path &contentPath, MissingB
 				{
 					const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 					const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-					GA_Size numShapes = tuple->getTableEntries( nameAttr );
+					GA_StringTableStatistics stats;
+					tuple->getStatistics( nameAttr, stats );
+					GA_Size numShapes = stats.getEntries();
 					for ( GA_Size i=0; i < numShapes; ++i )
 					{
 						const char *currentName = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, i ) );

--- a/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
+++ b/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
@@ -257,7 +257,9 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::renderFrame( fpreal time, UT_Interrupt *bo
 				reRoot = false;
 				const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 				const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-				GA_Size numShapes = tuple->getTableEntries( nameAttr );
+				GA_StringTableStatistics stats;
+				tuple->getStatistics( nameAttr, stats );
+				GA_Size numShapes = stats.getEntries();
 				if ( numShapes == 0 )
 				{
 					reRoot = true;

--- a/test/IECoreHoudini/FromHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/FromHoudiniPolygonsConverter.py
@@ -3,7 +3,7 @@
 #  Copyright 2010 Dr D Studios Pty Limited (ACN 127 184 954) (Dr. D Studios),
 #  its affiliates and/or its licensors.
 #
-#  Copyright (c) 2010-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2010-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -810,6 +810,18 @@ class TestFromHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 		self.assertTrue( "ieMeshInterpolation" not in result.keys() )
 		self.assertEqual( result.interpolation, "linear" )
 		self.assertTrue( "N" in result.keys() )
+	
+	def testRename( self ) :
+		
+		torus = self.createTorus()
+		name = torus.createOutputNode( "name" )
+		name.parm( "name1" ).set( "foo" )
+		rename = name.createOutputNode( "name" )
+		rename.parm( "name1" ).set( "bar" )
+		
+		converter = IECoreHoudini.FromHoudiniGeometryConverter.create( rename )
+		self.assertTrue( isinstance( converter, IECoreHoudini.FromHoudiniPolygonsConverter ) )
+		self.assertTrue( isinstance( converter.convert(), IECore.MeshPrimitive ) )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This is used in place of `GA_AIFSharedStringTuple::getTableEntries()` because it returns the number of active strings, and the table itself is allowed to have dead strings that we should be ignoring. Tested in both Houdini 13 and 14.