### PR TITLE
IECoreAppleseed: Renderer::setOption changes and improvements

### DIFF
--- a/contrib/IECoreAppleseed/Changes
+++ b/contrib/IECoreAppleseed/Changes
@@ -1,5 +1,11 @@
 # Development
 
+- If the rendering_threads option is set to zero, use all CPU cores for rendering.
+- Max intensity clamping can be disabled now by setting the as:cfg:pt:max_ray_intensity option to zero.
+- Fixed appleseed errors while binding inputs of object instances when objects are renamed in Gaffer.
+
+# 9.0.0-b5
+
 - Camera, transformation, deformation motion blur support.
 - Lights can now be turned on and off.
 - Interactive rendering support.


### PR DESCRIPTION
- set decorrelate_pixels automatically depending on render passes.
- if the rendering_threads option is zero, use all CPU cores for rendering.
- if the as:cfg:pt:max_ray_intensity option is zero, disable max intensity clamping.
- disable max number of bounces for max_path_length options set to zero.
- check the type of the Data passed to setOption before accessing it.