### PR TITLE
bounding box in .cob headers if the object is a VisibleRenderable

### DIFF
--- a/src/IECore/ObjectWriter.cpp
+++ b/src/IECore/ObjectWriter.cpp
@@ -43,6 +43,7 @@
 #include "IECore/Object.h"
 #include "IECore/IECore.h"
 #include "IECore/HeaderGenerator.h"
+#include "IECore/VisibleRenderable.h"
 
 using namespace IECore;
 using namespace std;
@@ -82,6 +83,11 @@ void ObjectWriter::doWrite( const CompoundObject *operands )
 	CompoundDataPtr header = boost::static_pointer_cast<CompoundData>( m_headerParameter->getValue()->copy() );
 
 	header->writable()["typeName"] = new StringData( object()->typeName() );
+
+	if( const VisibleRenderable* visibleRenderable = runTimeCast<const VisibleRenderable>(object()) )
+	{
+		header->writable()["bound"] = new Box3fData( visibleRenderable->bound() );
+	}
 
 	CompoundObjectPtr genericHeader = HeaderGenerator::header();
 	for ( CompoundObject::ObjectMap::const_iterator it = genericHeader->members().begin(); it != genericHeader->members().end(); it++ )

--- a/test/IECore/ObjectWriter.py
+++ b/test/IECore/ObjectWriter.py
@@ -70,9 +70,19 @@ class TestObjectWriter( unittest.TestCase ) :
 		self.assertEqual( h["ieCoreVersion"].value, IECore.versionString() )
 		self.assertEqual( h["typeName"].value, "IntData" )
 	
+	def testBoundInHeader( self ) :
+
+		o = IECore.SpherePrimitive()
+		w = IECore.Writer.create( o, "test/spherePrimitive.cob" )
+		w.write()
+
+		h = IECore.Reader.create( "test/spherePrimitive.cob" ).readHeader()
+
+		self.assertEqual( h["bound"].value, o.bound() )
+
 	def tearDown( self ) :
 		
-		for f in ( "test/compoundData.cob", "test/intData.cob" ) :
+		for f in ( "test/compoundData.cob", "test/intData.cob", "test/spherePrimitive.cob" ) :
 			if os.path.isfile( f ) :
 				os.remove( f )
 


### PR DESCRIPTION
Interactive performance for reading sequences of .cob files is currently a lot worse than for .scc files, because the entire file needs to be read to compute the bounding box. It'd be good if the bounding box data was available in the header so we could avoid that. Me and Andrew had a little talk about it, and the options we considered were:

* write the bounding box in the houdini export (ok, but it means we'd have to do it in other possible exporters too)
* use the header generator mechanism (looks like the header generators don't get access to the object)
* this

Can you think of anything else you'd prefer?