### PR TITLE
TransformOp now takes a copy of the data before altering it.

### DIFF
--- a/src/IECore/TransformOp.cpp
+++ b/src/IECore/TransformOp.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2008-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2008-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -84,17 +84,20 @@ const StringVectorParameter * TransformOp::primVarsParameter() const
 void TransformOp::modifyPrimitive( Primitive * primitive, const CompoundObject * operands )
 {
 	const std::vector<std::string> &pv = m_primVarsParameter->getTypedValue();
-	std::set< Data* > visitedData;
 	for ( std::vector<std::string>::const_iterator it = pv.begin(); it != pv.end(); ++it )
 	{
 		PrimitiveVariableMap::iterator pIt = primitive->variables.find( *it );
-		if ( pIt == primitive->variables.end() || !pIt->second.data || visitedData.find( pIt->second.data.get() ) != visitedData.end() )
+		if ( pIt == primitive->variables.end() || !pIt->second.data )
 		{
 			continue;
 		}
 		
+		// We need to take a copy of the data in case other
+		// primitive variables were referencing the same data,
+		// and are not in the list of variables to modify.
+		pIt->second.data = pIt->second.data->copy();
+		
 		Data *data = pIt->second.data.get();
-		visitedData.insert( data );
 		
 		// fix for old files that don't store Interpretation properly
 		V3fVectorData *v3fData = runTimeCast<V3fVectorData>( data );

--- a/test/IECore/TransformOpTest.py
+++ b/test/IECore/TransformOpTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2008-2013, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2008-2015, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -107,6 +107,18 @@ class TestTransformOp( unittest.TestCase ) :
 		self.assertEqual( ms["vel"].data, V3fVectorData( [ x * V3f( 1, 2, 3 ) for x in m["vel"].data ], GeometricData.Interpretation.Vector ) )
 		self.assertEqual( ms["vel"].data, ms["sameVel"].data )
 		
+	def testIdenticalPrimVarsCanBeExcluded( self ) :
+		
+		m = MeshPrimitive.createBox( Box3f( V3f( -1 ), V3f( 1 ) ) )
+		MeshNormalsOp()( input = m, copyInput = False )
+		m["vel"] = PrimitiveVariable( PrimitiveVariable.Interpolation.Vertex, V3fVectorData( [ V3f( 0.5 ) ] * 8, GeometricData.Interpretation.Vector ) )
+		m["otherVel"] = m["vel"]
+		
+		ms = TransformOp()( input=m, primVarsToModify = StringVectorData( [ "vel" ] ), matrix = M44fData( M44f.createScaled( V3f( 1, 2, 3 ) ) ) )
+		
+		self.assertEqual( ms["vel"].data, V3fVectorData( [ x * V3f( 1, 2, 3 ) for x in m["vel"].data ], GeometricData.Interpretation.Vector ) )
+		self.assertNotEqual( ms["vel"].data, ms["otherVel"].data )
+		self.assertEqual( ms["otherVel"].data, m["otherVel"].data )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -516,8 +516,8 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 			sc.writeTransform( IECore.M44dData( matrix ), 0 )
 			
 			mesh = IECore.MeshPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1)))
-			mesh["Pref"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, mesh["P"].data.copy() )
-			mesh["otherP"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, mesh["P"].data.copy() )
+			mesh["Pref"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, mesh["P"].data )
+			mesh["otherP"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, mesh["P"].data )
 			mesh["Cs"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [ IECore.V3f( 0, 0, 1 ) ] * 8 ) )
 			sc.writeObject( mesh, 0 )
 		


### PR DESCRIPTION
This was necessary to avoid unwanted transformation of identical primitive variables. Since the `TransformOp` takes a list of variables to alter, we want to make sure that we only alter the variables in the list. Prior to this change, a user of the `TransformOp` could have been unintentionally altering other primitive variables which point to the same data.

I suppose an argument could be made that 2 identical prim vars (ref counting the same data) should both be transformed, because they're meant to be the same. I'm justifying this change by claiming that the user of the `TransformOp` doesn't care what was considered "the same" before the transfomation, and is instead concerned with controlling what has changed and what hasn't, after the transformation. If that user intended both prim vars to transform the same way, then they would include both in the list of variables to alter. If they in fact did include both, we're now separating the two by making the copy. There probably is some extra logic we could embed to avoid the copy in that case, but I wasn't sure the extra complication was worth while.