### PR TITLE
Debug jpg

### DIFF
--- a/src/IECore/JPEGImageReader.cpp
+++ b/src/IECore/JPEGImageReader.cpp
@@ -95,7 +95,7 @@ bool JPEGImageReader::canRead( const string &fileName )
 	in.seekg(0, ios_base::beg);
 	in.read((char *) &magic, sizeof(unsigned int));
 
-	return magic == 0xe0ffd8ff || magic == 0xffd8ffe0 || magic == 0xe1ffd8ff || magic == 0xffd8ffe1 ;
+	return magic == 0xe0ffd8ff || magic == 0xffd8ffe0 || magic == 0xe1ffd8ff || magic == 0xffd8ffe1 || magic == 0xdbffd8ff;
 }
 
 void JPEGImageReader::channelNames( vector<string> &names )


### PR DESCRIPTION
### core
- an artist was using a JPG image from internet.
- trying to publish it from Jabuka, it was failing.
- IECore.Reader.create using IECore.JPGImageReader.canRead was assuming the file couldn't be read.
- the magic number test was returning false because we wasn't using this specific magic number value.
- Hence, I add this new magic number value.
- I runned the test fine.