### PR TITLE
Changed SXExecutor parameter interpretation

### DIFF
--- a/src/IECoreRI/SXExecutor.cpp
+++ b/src/IECoreRI/SXExecutor.cpp
@@ -256,12 +256,34 @@ class SXExecutor::Implementation : public IECore::RefCounted
 			}
 		}
 
+		bool parameterTypesConsistent( SxType type, IECore::TypeId typeId ) const
+		{
+			switch( typeId )
+			{
+				case FloatVectorDataTypeId :
+					return type == SxFloat;
+				case V3fVectorDataTypeId :
+				case V3fDataTypeId :
+					return type == SxVector || type == SxNormal || type == SxPoint;
+				case Color3fVectorDataTypeId :
+				case Color3fDataTypeId :
+					return type == SxColor;
+				case StringVectorDataTypeId :
+				case StringDataTypeId :
+					return type == SxString;
+				case FloatDataTypeId :
+					return type == SxFloat;
+				default :
+					return type == SxInvalid;
+			}
+		}
+
 		void setVariables( SxParameterList parameterList, const IECore::CompoundData *points, size_t numPoints ) const
 		{
 			for( CompoundDataMap::const_iterator it=points->readable().begin(); it!=points->readable().end(); it++ )
 			{
 				ParameterInfo info = predefinedParameterInfo( it->first.value().c_str() );
-				if( info.type != SxInvalid )
+				if( info.type != SxInvalid && parameterTypesConsistent( info.type, it->second->typeId() ) )
 				{
 					setVariable( parameterList, it->first.value().c_str(), info, true, it->second.get(), numPoints );
 				}

--- a/test/IECoreRI/SXRendererTest.py
+++ b/test/IECoreRI/SXRendererTest.py
@@ -439,18 +439,20 @@ class SXRendererTest( unittest.TestCase ) :
 
 		self.assertEqual( IECore.ImageDiffOp()( imageA=image, imageB=expectedImage, maxError=0 ), IECore.BoolData( False ) )
 	
-	def testWrongType( self ) :
-	
+	def testVVector( self ) :
+
 		self.assertEqual( os.system( "shaderdl -Irsl -o test/IECoreRI/shaders/splineTest.sdl test/IECoreRI/shaders/splineTest.sl" ), 0 )
 
 		r = IECoreRI.SXRenderer()
-		
+
 		r.shader( "surface", "test/IECoreRI/shaders/splineTest.sdl", {} )
-				
+	
 		p = self.__rectanglePoints( IECore.Box2i( IECore.V2i( 0 ), IECore.V2i( 10 ) ) )
-		p["t"] = p["P"]
-		
-		self.assertRaises( RuntimeError, r.shade, p )
+
+		# this should work, as you might want to use a V3f primvar called v (velocity) in
+		# your shader:
+		p["v"] = p["P"]
+		r.shade( p )
 
 	def testWrongSize( self ) :
 	
@@ -951,9 +953,7 @@ class SXRendererTest( unittest.TestCase ) :
 			transP = points["P"][i] * IECore.M44f.createTranslated( IECore.V3f(0,0,2) ) * IECore.M44f.createRotated( IECore.V3f(1,0,0) )
 			
 			self.failUnless( ( shaderP - transP ).length() < 1.e-5 )
-			
-		
-	
+
 	def tearDown( self ) :
 				
 		files = [


### PR DESCRIPTION
It turns out that if you give the SXExecutor a V3fVectorData parameter called "v", it complains at you, as it thinks "v" is a texture coordinate and demands a FloatVectorData instead. This caused puzzlement when a lighter tried to use SX to scale a velocity primvar called "v", so I've changed the logic a bit.