### PR TITLE
appleseed: added mesh tangents and motion normals

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/InteractivePrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/InteractivePrimitiveConverter.cpp
@@ -35,6 +35,7 @@
 #include "IECoreAppleseed/private/InteractivePrimitiveConverter.h"
 
 #include "foundation/math/scalar.h"
+#include "renderer/api/version.h"
 
 #include "IECore/MessageHandler.h"
 #include "IECore/MeshPrimitive.h"
@@ -107,7 +108,63 @@ asf::auto_release_ptr<asr::Object> IECoreAppleseed::InteractivePrimitiveConverte
 				mesh->set_vertex_pose( j, i - 1, asr::GVector3( points[j].x, points[j].y, points[j].z ) );
 			}
 
-			// TODO: Handle normals and tangents here when issue #682 is fixed in appleseed.
+			// motion blur for normals and tangents is only supported since appleseed 1.2.0
+			#if APPLESEED_VERSION >= 10200
+				if( mesh->get_vertex_normal_count() != 0 )
+				{
+					PrimitiveVariableMap::const_iterator nIt = m->variables.find( "N" );
+					if( nIt == m->variables.end() )
+					{
+						throw Exception( "MeshPrimitive missing normals in motion sample." );
+					}
+
+					const V3fVectorData *n = runTimeCast<const V3fVectorData>( nIt->second.data.get() );
+					if( !n )
+					{
+						throw Exception( ( boost::format( "MeshPrimitive \"N\" primitive variable has unsupported type \"%s\" (expected V3fVectorData)." ) % nIt->second.data->typeName() ).str() );
+					}
+
+					const std::vector<V3f> &normals = n->readable();
+					size_t numNormals = normals.size();
+					if( numNormals != mesh->get_vertex_normal_count() )
+					{
+						throw Exception( "MeshPrimitive \"N\" primitive variable has different interpolation than first deformation sample." );
+					}
+
+					for( size_t j = 0 ; j < numNormals; ++j )
+					{
+						mesh->set_vertex_normal_pose( j, i - 1, asf::normalize( asr::GVector3( normals[j].x, normals[j].y, normals[j].z ) ) );
+					}
+				}
+
+				// tangents
+				if( mesh->get_vertex_tangent_count() != 0 )
+				{
+					PrimitiveVariableMap::const_iterator tIt = m->variables.find( "uTangent" );
+					if( tIt == m->variables.end() )
+					{
+						throw Exception( "MeshPrimitive missing tangents in motion sample." );
+					}
+
+					const V3fVectorData *t = runTimeCast<const V3fVectorData>( tIt->second.data.get() );
+					if( !t )
+					{
+						throw Exception( ( boost::format( "MeshPrimitive \"uTangent\" primitive variable has unsupported type \"%s\" (expected V3fVectorData)." ) % tIt->second.data->typeName() ).str() );
+					}
+
+					const std::vector<V3f> &tangents = t->readable();
+					size_t numTangents = t->readable().size();
+					if( numTangents != mesh->get_vertex_tangent_count() )
+					{
+						throw Exception( "MeshPrimitive \"uTangent\" primitive variable has different interpolation than first deformation sample." );
+					}
+
+					for( size_t j = 0 ; j < numTangents; ++j )
+					{
+						mesh->set_vertex_tangent_pose( j, i - 1, asf::normalize( asr::GVector3( tangents[j].x, tangents[j].y, tangents[j].z ) ) );
+					}
+				}
+			#endif
 		}
 	}
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedMeshConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ToAppleseedMeshConverter.cpp
@@ -215,7 +215,40 @@ asr::Entity *ToAppleseedMeshConverter::doConversion( ConstObjectPtr from, ConstC
 			}
 			else
 			{
-				msg( Msg::Warning, "ToAppleseedMeshConverter::doConversion", boost::format( "Variable \"N\" has unsupported type \"%s\" (expected V3fVectorData)." ) );
+				msg( Msg::Warning, "ToAppleseedMeshConverter::doConversion", boost::format( "Variable \"N\" has unsupported type \"%s\" (expected V3fVectorData)." ) % nIt->second.data->typeName() );
+			}
+		}
+	}
+
+	// tangents
+	{
+		PrimitiveVariableMap::const_iterator tIt = mesh->variables.find( "uTangent" );
+		if( tIt != mesh->variables.end() )
+		{
+			const V3fVectorData *t = runTimeCast<const V3fVectorData>( tIt->second.data.get() );
+			if( t )
+			{
+				PrimitiveVariable::Interpolation tInterpolation = tIt->second.interpolation;
+				if( tInterpolation == PrimitiveVariable::Varying || tInterpolation == PrimitiveVariable::Vertex )
+				{
+					size_t numTangents = t->readable().size();
+					meshObj->reserve_vertex_tangents( numTangents );
+					const std::vector<V3f> &tangents = t->readable();
+					for( size_t i = 0; i < numTangents; ++i)
+					{
+						asr::GVector3 t( tangents[i].x, tangents[i].y, tangents[i].z );
+						t = asf::normalize( t );
+						meshObj->push_vertex_tangent( t );
+					}
+				}
+				else
+				{
+					msg( Msg::Warning, "ToAppleseedMeshConverter::doConversion", "Variable \"uTangent\" has unsupported interpolation type - not generating tangents." );
+				}
+			}
+			else
+			{
+				msg( Msg::Warning, "ToAppleseedMeshConverter::doConversion", boost::format( "Variable \"uTangent\" has unsupported type \"%s\" (expected V3fVectorData)." ) % tIt->second.data->typeName() );
 			}
 		}
 	}


### PR DESCRIPTION
- Mesh tangents (primitive variable uTangent) are now exported to appleseed meshes.

- Time varying tangents and normals for primitives with deformation blur are now
  exported if appleseed supports them (since version 1.2.0).

- Fixed a warning message in ToAppleseedMeshConverter.

I used "uTangent" because that's the default prim var name in MeshTangentsOp.