### PR TITLE
ScopedGILLock : Fixed shutdown crashes.

### DIFF
--- a/src/IECorePython/ScopedGILLock.cpp
+++ b/src/IECorePython/ScopedGILLock.cpp
@@ -37,7 +37,7 @@
 using namespace IECorePython;
 
 ScopedGILLock::ScopedGILLock()
-	:	m_threadsInitialised( PyEval_ThreadsInitialized() )
+	:	m_threadsInitialised( Py_IsInitialized() && PyEval_ThreadsInitialized() )
 {
 	if( m_threadsInitialised )
 	{


### PR DESCRIPTION
This fixes a crash whereby :

- A pure C++ library declares a static class
- Which then has python callbacks registered with it, which are wrapped in a ScopedGILLock
- Python shuts down, and calls exit(), which runs C++ static destructors
- The C++ static class is destroyed, releasing the python callbacks, which try to use the ScopedGILLock
- ScopedGILLock tries to obtain a lock, but Python has already been shutdown
- Boom

The solution is to just make ScopedGILLocks into no-ops if Python is no longer initialised. We did the same thing in ScopedGILRelease previously to fix a similar issue.