### PR TITLE
Travis speedup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
+sudo: false
+
 language: cpp
 
 os:
     - linux
 
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libboost-all-dev
-    - sudo apt-get install -qq libopenexr-dev
-    - sudo apt-get install -qq libtbb-dev
-    - sudo apt-get install -qq libfreetype6-dev
+addons:
+  apt:
+    packages:
+    - libboost-all-dev
+    - libopenexr-dev
+    - libtbb-dev
+    - libfreetype6-dev
 
 script:
-    - scons testCore testCorePython CXX=$CXX ENV_VARS_TO_IMPORT="PATH TRAVIS" RMAN_ROOT=$DELIGHT BOOST_LIB_SUFFIX=""
+    - scons -j 2 testCore testCorePython CXX=$CXX ENV_VARS_TO_IMPORT="PATH TRAVIS" RMAN_ROOT=$DELIGHT BOOST_LIB_SUFFIX=""
 
 compiler:
     ## \todo Enable clang here too. We can't with the default Ubuntu boost

--- a/test/IECore/CapturingRendererTest.py
+++ b/test/IECore/CapturingRendererTest.py
@@ -37,6 +37,7 @@ from __future__ import with_statement
 import threading
 import unittest
 import sys
+import os
 
 import IECore
 
@@ -351,6 +352,7 @@ class CapturingRendererTest( unittest.TestCase ) :
 			h = IECore.MurmurHash()
 			return h
 	
+	@unittest.skipIf( "TRAVIS" in os.environ, "Low hardware concurrency on Travis" )
 	def testTopLevelProceduralThreading( self ) :
 	
 		# this is necessary so python will allow threads created by the renderer
@@ -379,6 +381,7 @@ class CapturingRendererTest( unittest.TestCase ) :
 			self.assertEqual( len( c.children() ), 1 )
 			self.failUnless( isinstance( c.children()[0], IECore.SpherePrimitive ) )
 			
+	@unittest.skipIf( "TRAVIS" in os.environ, "Low hardware concurrency on Travis" )
 	def testRecursiveProceduralThreading( self ) :
 	
 		# this is necessary so python will allow threads created by the renderer
@@ -418,6 +421,7 @@ class CapturingRendererTest( unittest.TestCase ) :
 		
 		IECore.ObjectWriter( w, "/tmp/flake.cob" ).write()
 	
+	@unittest.skipIf( "TRAVIS" in os.environ, "Low hardware concurrency on Travis" )
 	def testDisableProceduralThreading( self ) :
 	
 		# this is necessary so python will allow threads created by the renderer

--- a/test/IECore/ThreadingTest.py
+++ b/test/IECore/ThreadingTest.py
@@ -66,6 +66,7 @@ class ThreadingTest( unittest.TestCase ) :
 
 				t.join()
 
+	@unittest.skipIf( "TRAVIS" in os.environ, "Low hardware concurrency on Travis" )
 	def testThreadedOpGains( self ) :
 	
 		## Checks that we actually get a speedup by running a bunch of slow
@@ -208,6 +209,7 @@ class ThreadingTest( unittest.TestCase ) :
 			cachedReader.clear()
 			self.callSomeThings( calls, args=args, threaded=True )
 
+	@unittest.skipIf( "TRAVIS" in os.environ, "Low hardware concurrency on Travis" )
 	def testCachedReaderGains( self ) :
 	
 		args = [


### PR DESCRIPTION
This switches to using Travis' new container based build architecture, and gets the time taken to run our tests down into the 20 minute range, rather than the frequently-going-over-the-limit range that we were in before.