### PR TITLE
Maya pixel aspect ratio

### DIFF
--- a/src/IECoreMaya/Box3Manipulator.cpp
+++ b/src/IECoreMaya/Box3Manipulator.cpp
@@ -1,11 +1,36 @@
-#include "IECoreMaya/TypeIds.h"
-#include "IECoreMaya/Box3Manipulator.h"
-
-#include "IECore/Parameter.h"
-#include "IECore/CompoundObject.h"
-#include "IECore/SimpleTypedData.h"
-
-#include "IECoreMaya/ParameterisedHolderInterface.h"
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2010-2015, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
 
 #include <maya/MFnStateManip.h>
 #include <maya/MFnFreePointTriadManip.h>
@@ -19,6 +44,15 @@
 #include <maya/MGlobal.h>
 #include <maya/MEulerRotation.h>
 #include <maya/MPxTransformationMatrix.h>
+#undef None // must come after certain Maya includes which include X11/X.h
+
+#include "IECore/Parameter.h"
+#include "IECore/CompoundObject.h"
+#include "IECore/SimpleTypedData.h"
+
+#include "IECoreMaya/TypeIds.h"
+#include "IECoreMaya/Box3Manipulator.h"
+#include "IECoreMaya/ParameterisedHolderInterface.h"
 
 using namespace IECore;
 using namespace IECoreMaya;

--- a/src/IECoreMaya/IECoreMaya.cpp
+++ b/src/IECoreMaya/IECoreMaya.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -44,6 +44,7 @@
 #include "maya/MPxFieldNode.h"
 #include "maya/MPxImagePlane.h"
 #include "maya/MGlobal.h"
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECore/Parameterised.h"
 #include "IECore/LevelFilteredMessageHandler.h"

--- a/src/IECoreMaya/ParameterisedHolder.cpp
+++ b/src/IECoreMaya/ParameterisedHolder.cpp
@@ -56,6 +56,7 @@
 #include "maya/MFnMesh.h"
 #include "maya/MFnGenericAttribute.h"
 #include "maya/MPxManipContainer.h"
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECoreMaya/ParameterisedHolder.h"
 #include "IECoreMaya/ParameterHandler.h"

--- a/src/IECoreMaya/ParameterisedHolderManipContext.cpp
+++ b/src/IECoreMaya/ParameterisedHolderManipContext.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2010, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2010-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -38,6 +38,7 @@
 
 #include <maya/MItSelectionList.h>
 #include <maya/MGlobal.h>
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECore/SimpleTypedData.h"
 #include "IECore/CompoundParameter.h"

--- a/src/IECoreMaya/ProceduralHolderUI.cpp
+++ b/src/IECoreMaya/ProceduralHolderUI.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2007-2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2007-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -49,6 +49,7 @@
 #include "maya/MPointArray.h"
 #include "maya/MDoubleArray.h"
 #include "maya/MFnCamera.h"
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECore/MessageHandler.h"
 

--- a/src/IECoreMaya/SceneShapeUI.cpp
+++ b/src/IECoreMaya/SceneShapeUI.cpp
@@ -52,6 +52,7 @@
 #include "maya/MFnCamera.h"
 #include "maya/MFnStringArrayData.h"
 #include "maya/MStringArray.h"
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECore/MessageHandler.h"
 #include "IECore/MeshPrimitive.h"

--- a/src/IECoreMaya/ViewportPostProcessCallback.cpp
+++ b/src/IECoreMaya/ViewportPostProcessCallback.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2009, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2009-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -35,6 +35,7 @@
 #include "maya/M3dView.h"
 #include "maya/MImage.h"
 #include "maya/MUiMessage.h"
+#undef None // must come after certain Maya includes which include X11/X.h
 
 #include "IECore/ImagePrimitive.h"
 #include "IECore/Writer.h"


### PR DESCRIPTION
FromMayaCameraConverter now accounts for pixel aspect ratio.

While we generally want to move away from Maya RenderGlobals, we're not quite ready to make that break yet, and we need to support alternate pixel aspect ratios in the mean time.

The first commit was necessary to compile for Maya (2014.sp4) now that GeometricTypedData.h uses `None` in the interpretation enum. I'm not sure the header reorganization was the best approach. I suppose I could have `#undef None` after the maya headers instead...