### PR TITLE
Light prefixes

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/RendererImplementation.cpp
@@ -629,8 +629,21 @@ void IECoreAppleseed::RendererImplementation::light( const string &name, const s
 		return;
 	}
 
+	const char *unprefixedName = name.c_str();
+	if( name.find( ':' ) != string::npos )
+	{
+		if( boost::starts_with( name, "as:" ) )
+		{
+			unprefixedName += 3;
+		}
+		else
+		{
+			return;
+		}
+	}
+
 	// check if the light is an environment light.
-	if( algorithm::ends_with( name, "_environment_edf" ) )
+	if( algorithm::ends_with( unprefixedName, "_environment_edf" ) )
 	{
 		const string &lightName = m_attributeStack.top().name();
 		const string *environmentEDFName = getOptionAs<string>( "as:environment_edf" );
@@ -663,11 +676,11 @@ void IECoreAppleseed::RendererImplementation::light( const string &name, const s
 		}
 
 		const bool *envEDFVisible = getOptionAs<bool>( "as:environment_edf_background" );
-		m_lightHandler->environment( name, handle, envEDFVisible && *envEDFVisible, parameters );
+		m_lightHandler->environment( unprefixedName, handle, envEDFVisible && *envEDFVisible, parameters );
 	}
 	else
 	{
-		m_lightHandler->light( name, handle,
+		m_lightHandler->light( unprefixedName, handle,
 			m_transformStack.top().get_earliest_transform(), parameters );
 	}
 }

--- a/contrib/IECoreArnold/src/IECoreArnold/RendererImplementation.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/RendererImplementation.cpp
@@ -40,6 +40,7 @@
 #include "OpenEXR/ImathBoxAlgo.h"
 
 #include "boost/format.hpp"
+#include "boost/algorithm/string/predicate.hpp"
 
 #include "IECore/MessageHandler.h"
 #include "IECore/MeshPrimitive.h"
@@ -484,10 +485,23 @@ void IECoreArnold::RendererImplementation::shader( const std::string &type, cons
 
 void IECoreArnold::RendererImplementation::light( const std::string &name, const std::string &handle, const IECore::CompoundDataMap &parameters )
 {
-	AtNode *l = AiNode( name.c_str() );
+	const char *unprefixedName = name.c_str();
+	if( name.find( ':' ) != string::npos )
+	{
+		if( boost::starts_with( name, "ai:" ) )
+		{
+			unprefixedName += 3;
+		}
+		else
+		{
+			return;
+		}
+	}
+
+	AtNode *l = AiNode( unprefixedName );
 	if( !l )
 	{
-		msg( Msg::Warning, "IECoreArnold::RendererImplementation::light", boost::format( "Couldn't load light \"%s\"" ) % name );
+		msg( Msg::Warning, "IECoreArnold::RendererImplementation::light", boost::format( "Couldn't load light \"%s\"" ) % unprefixedName );
 		return;
 	}
 	for( CompoundDataMap::const_iterator parmIt=parameters.begin(); parmIt!=parameters.end(); parmIt++ )

--- a/contrib/IECoreArnold/test/IECoreArnold/RendererTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/RendererTest.py
@@ -732,8 +732,24 @@ class RendererTest( unittest.TestCase ) :
 		ass = "".join( file( self.__assFileName ).readlines() )
 		self.assertTrue( "aspect_ratio 0.5" in ass )
 
+	def testLightPrefixes( self ) :
+
+		r = IECoreArnold.Renderer( self.__assFileName )
+
+		with IECore.WorldBlock( r ) :
+
+			r.light( "distant_light", "genericHandle", {} )
+			r.light( "ri:point_light", "renderManHandle", {} )
+			r.light( "ai:spot_light", "arnoldLight", {} )
+
+		ass = "".join( file( self.__assFileName ).readlines() )
+
+		self.assertTrue( "distant_light" in ass )
+		self.assertTrue( "spot_light" in ass )
+		self.assertTrue( "point_light" not in ass )
+
 	def tearDown( self ) :
-			
+
 		for f in [
 			self.__displayFileName,
 			self.__assFileName,

--- a/src/IECoreRI/RendererImplementation.cpp
+++ b/src/IECoreRI/RendererImplementation.cpp
@@ -1385,6 +1385,19 @@ void IECoreRI::RendererImplementation::shader( const std::string &type, const st
 
 void IECoreRI::RendererImplementation::light( const std::string &name, const std::string &handle, const IECore::CompoundDataMap &parameters )
 {
+	const char *unprefixedName = name.c_str();
+	if( name.find( ':' ) != string::npos )
+	{
+		if( boost::starts_with( name, "ri:" ) )
+		{
+			unprefixedName += 3;
+		}
+		else
+		{
+			return;
+		}
+	}
+
 	ScopedContext scopedContext( m_context );
 	IECore::CompoundDataMap parametersCopy = parameters;
 	parametersCopy["__handleid"] = new StringData( handle );
@@ -1405,11 +1418,11 @@ void IECoreRI::RendererImplementation::light( const std::string &name, const std
 
 	if( areaLight )
 	{
-		RiAreaLightSourceV( const_cast<char *>(name.c_str()), pl.n(), pl.tokens(), pl.values() );
+		RiAreaLightSourceV( const_cast<char *>( unprefixedName ), pl.n(), pl.tokens(), pl.values() );
 	}
 	else
 	{
-		RiLightSourceV( const_cast<char *>(name.c_str()), pl.n(), pl.tokens(), pl.values() );
+		RiLightSourceV( const_cast<char *>( unprefixedName ), pl.n(), pl.tokens(), pl.values() );
 	}
 }
 

--- a/test/IECoreRI/Renderer.py
+++ b/test/IECoreRI/Renderer.py
@@ -696,6 +696,23 @@ class RendererTest( IECoreRI.TestCase ) :
 		self.assertTrue( "ClippingPlane" in rib )
 		self.assertTrue( "1 2 3 1" in rib )
 
+	def testLightPrefixes( self ) :
+
+		r = IECoreRI.Renderer( "test/IECoreRI/output/lightPrefixes.rib" )
+
+		with WorldBlock( r ) :
+
+			r.light( "genericLight", "genericHandle", {} )
+			r.light( "ri:renderManLight", "renderManHandle", {} )
+			r.light( "ai:arnoldLight", "arnoldLight", {} )
+
+		del r
+
+		rib = "".join( file( "test/IECoreRI/output/lightPrefixes.rib" ).readlines() )
+		self.assertTrue( 'LightSource "genericLight"' in rib )
+		self.assertTrue( 'LightSource "renderManLight"' in rib )
+		self.assertFalse( "arnold" in rib )
+
 	def tearDown( self ) :
 
 		IECoreRI.TestCase.tearDown( self )


### PR DESCRIPTION
This allows the various `Renderer::light()` implementations to ignore lights destined for other renderers. It works in the same manner as the existing prefix support for options, attributes and shaders. It's needed for some work @danieldresser and I are doing for visualising lights in Gaffer.