### PR TITLE
IECoreGL : Fixes relating to custom vertex shaders

### DIFF
--- a/include/IECoreGL/Primitive.h
+++ b/include/IECoreGL/Primitive.h
@@ -96,6 +96,23 @@ class IECOREGL_API Primitive : public Renderable
 		/// Most classes will not need to override this method - reasons for overriding would be
 		/// to substitute in custom geometry or vertex shaders and/or to bind in attributes
 		/// not already specified with addUniformAttribute() or addVertexAttribute().
+		///
+		/// \todo We need to rethink this mechanism. The problem is that we've ended up using
+		/// this method for two things - firstly to get a ShaderSetup where all the primitive
+		/// variables are bound (good), and secondly we've abused it to actually change the
+		/// shader in PointsPrimitive and CurvePrimitive. Asking for a setup for one shader and getting
+		/// back a setup for another doesn't make a great deal of sense. There are several
+		/// competing sources of source code for shaders :
+		///
+		/// - The user-provided source coming through Renderer::shader().
+		/// - The vertex and geometry shaders that PointsPrimitive and CurvesPrimitive need
+		///   to insert.
+		/// - The constant fragment shader that Primitive needs to insert to do wireframe
+		///   shading etc.
+		/// - The ID fragment shader needed for the Selector.
+		///
+		/// We should redesign our API so that we first resolve these requirements to generate
+		/// a shader, and then use shaderSetup() just to apply primitive variables to it.
 		virtual const Shader::Setup *shaderSetup( const Shader *shader, State *state ) const;
 		/// Adds the primitive variables held by this Primitive to the specified Shader::Setup.
 		/// Vertex attributes will be prefixed as specified, and for each vertex attribute

--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -119,14 +119,18 @@ class IECOREGL_API Selector : boost::noncopyable
 		
 		/// The IDRender mode requires a shader which takes a name
 		/// via a "uniform uint ieCoreGLName" parameter and outputs it
-		/// via an "out uint ieCoreGLNameOut" fragment output.
-		/// Typically one is set up automatically in baseState(), but
-		/// if rendering must be performed with an alternative shader
-		/// then it may be passed via this function.
+		/// via an "out uint ieCoreGLNameOut" fragment output. The
+		/// defaultIDShader() meets these criteria and will be bound
+		/// automatically when the selector constructs in IDRender mode.
+		/// Note however, that if any other shaders are subsequently
+		/// bound while the selector is active, they too must meet the
+		/// same critera.
 		void pushIDShader( const IECoreGL::Shader *idShader );
-		
-		/// Revert to previous ID shader:
+		/// Reverts to the previous ID shader.
 		void popIDShader();
+
+		/// A shader suitable for use in IDRender mode.
+		static const Shader *defaultIDShader();
 		
 		/// Returns the currently active Selector - this may be used
 		/// in drawing code to retrieve a selector to call loadName()

--- a/include/IECoreGL/ShaderStateComponent.h
+++ b/include/IECoreGL/ShaderStateComponent.h
@@ -76,6 +76,9 @@ class IECOREGL_API ShaderStateComponent : public StateComponent
 		ShaderLoader *shaderLoader();
 		TextureLoader *textureLoader();
 
+		/// Returns a hash to uniquely identify this shader state.
+		IECore::MurmurHash hash() const;
+
 		/// Returns a Shader::Setup object for binding the shader. This function can
 		/// only be called from a thread with a valid GL context.
 		Shader::Setup *shaderSetup();

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -102,7 +102,7 @@ void Primitive::addPrimitiveVariable( const std::string &name, const IECore::Pri
 	}
 }
 
-static Shader *constant2()
+static Shader *mostBasicShader()
 {
 
 	static const char *vertexSource =
@@ -163,9 +163,9 @@ void Primitive::render( State *state ) const
 	// with a simple shader and early out.
 	if( currentSelector && currentSelector->mode() == Selector::GLSelect )
 	{
-		const Shader *constantShader = constant2();
-		const Shader::Setup *constantSetup = shaderSetup( constantShader, state );
-		Shader::Setup::ScopedBinding constantBinding( *constantSetup );
+		const Shader *basicShader = mostBasicShader();
+		const Shader::Setup *basicSetup = shaderSetup( basicShader, state );
+		Shader::Setup::ScopedBinding basicBinding( *basicSetup );
 		render( state, Primitive::DrawSolid::staticTypeId() );
 		return;
 	}

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -74,7 +74,58 @@ IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( Primitive::PointWidth, Pr
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( Primitive::Selectable, PrimitiveSelectableTypeId, bool, true );
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( Primitive::TransparencySort, PrimitiveTransparencySortStateComponentTypeId, bool, true );
 
+} // namespace IECoreGL
+
+//////////////////////////////////////////////////////////////////////////
+// Utilities
+//////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+Shader *mostBasicShader()
+{
+	static const char *vertexSource =
+		
+		"#if __VERSION__ <= 120\n"
+		"#define in attribute\n"
+		"#define out varying\n"
+		"#endif\n"
+		""
+		"in vec3 vertexP;"
+		""
+		"void main()"
+		"{"
+		"	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4( vertexP, 1 );"
+		"}";
+		
+	static const char *fragmentSource =
+	
+		"void main()"
+		"{"
+			"gl_FragColor = vec4( 1, 1, 1, 1 );"
+		"}";
+
+	static ShaderPtr s = new Shader( vertexSource, fragmentSource );
+	return s.get();
 }
+
+Shader *flatConstant()
+{
+	static const char *fragmentSource =
+
+		"uniform vec3 Cs;" // get colour from uniform Cs, bypassing vertexCs
+		""
+		"void main()"
+		"{"
+		"	gl_FragColor = vec4( Cs, 1 );"
+		"}";
+
+	static ShaderPtr s = new Shader( "", fragmentSource );
+	return s.get();
+}
+
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////
 // Primitive implementation
@@ -101,51 +152,6 @@ void Primitive::addPrimitiveVariable( const std::string &name, const IECore::Pri
 		addVertexAttribute( name, primVar.data );
 	}
 }
-
-static Shader *mostBasicShader()
-{
-
-	static const char *vertexSource =
-		
-		"#if __VERSION__ <= 120\n"
-		"#define in attribute\n"
-		"#define out varying\n"
-		"#endif\n"
-		""
-		"in vec3 vertexP;"
-		""
-		"void main()"
-		"{"
-		"	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4( vertexP, 1 );"
-		"}";
-		
-	static const char *fragmentSource =
-	
-		"void main()"
-		"{"
-			"gl_FragColor = vec4( 1, 1, 1, 1 );"
-		"}";
-
-	static ShaderPtr s = new Shader( vertexSource, fragmentSource );
-	return s.get();
-}
-
-static Shader *flatConstant()
-{
-
-	static const char *fragmentSource =
-
-		"uniform vec3 Cs;" // get colour from uniform Cs, bypassing vertexCs
-		""
-		"void main()"
-		"{"
-		"	gl_FragColor = vec4( Cs, 1 );"
-		"}";
-
-	static ShaderPtr s = new Shader( "", fragmentSource );
-	return s.get();
-}
-
 
 void Primitive::render( State *state ) const
 {

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -44,6 +44,7 @@
 #include "IECoreGL/Exception.h"
 #include "IECoreGL/TypedStateComponent.h"
 #include "IECoreGL/ShaderStateComponent.h"
+#include "IECoreGL/ShaderLoader.h"
 #include "IECoreGL/Shader.h"
 #include "IECoreGL/NumericTraits.h"
 #include "IECoreGL/UniformFunctions.h"
@@ -110,8 +111,47 @@ Shader *mostBasicShader()
 	return s.get();
 }
 
-Shader *flatConstant()
+struct FlatConstant
 {
+
+	FlatConstant( const IECore::MurmurHash &hash, const Shader::ConstSetupPtr &shaderSetup = Shader::ConstSetupPtr() )
+		:	hash( hash ), shaderSetup( shaderSetup )
+	{
+	}
+
+	IECore::MurmurHash hash;
+	Shader::ConstSetupPtr shaderSetup;
+
+	bool operator < ( const FlatConstant &rhs )
+	{
+		return hash < rhs.hash;
+	}
+
+};
+
+// Makes a constant shader by taking the vertex and geometry
+// shader from the state and combining them with a flat fragment
+// shader.
+const Shader::Setup *flatConstantShaderSetup( State *state )
+{
+	ShaderStateComponent *shaderStateComponent = state->get<ShaderStateComponent>();
+	const IECore::MurmurHash hash = shaderStateComponent->hash();
+
+	// If we've made an equivalent shader before, then
+	// just return it.
+	static vector<FlatConstant> flatConstants;
+	vector<FlatConstant>::iterator it = lower_bound(
+		flatConstants.begin(),
+		flatConstants.end(),
+		hash
+	);
+	if( it != flatConstants.end() && it->hash == hash )
+	{
+		return it->shaderSetup.get();
+	}
+
+	// If we haven't, then make one.
+
 	static const char *fragmentSource =
 
 		"uniform vec3 Cs;" // get colour from uniform Cs, bypassing vertexCs
@@ -121,8 +161,17 @@ Shader *flatConstant()
 		"	gl_FragColor = vec4( Cs, 1 );"
 		"}";
 
-	static ShaderPtr s = new Shader( "", fragmentSource );
-	return s.get();
+	const Shader *originalShader = shaderStateComponent->shaderSetup()->shader();
+	ShaderLoader *shaderLoader = shaderStateComponent->shaderLoader();
+	ConstShaderPtr shader = shaderLoader->create( originalShader->vertexSource(), originalShader->geometrySource(), fragmentSource );
+	Shader::SetupPtr shaderSetup = new Shader::Setup( shader );
+	shaderStateComponent->addParametersToShaderSetup( shaderSetup.get() );
+
+	// Put it in our store so we don't have to remake it next time.
+
+	flatConstants.insert( it, FlatConstant( hash, shaderSetup.get() ) );
+
+	return shaderSetup.get();
 }
 
 } // namespace
@@ -216,18 +265,27 @@ void Primitive::render( State *state ) const
 	}
 	
 	// get a constant shader suitable for drawing wireframes, points etc.
-	const Shader *constantShader = flatConstant();
+	// we do this by taking the current shader from the state and overriding
+	// just the fragment shader within it - we want to keep any vertex or
+	// geometry shader the user has specified.
+	const Shader::Setup *uniformSetup;
 	if( currentSelector && currentSelector->mode() == Selector::IDRender )
 	{
 		// if we're in IDRender mode, then the constant shader is unsuitable,
 		// and we should instead use the ID shader we've been given.
-		constantShader = state->get<ShaderStateComponent>()->shaderSetup()->shader();
+		uniformSetup = state->get<ShaderStateComponent>()->shaderSetup();
 	}
-	
-	const Shader::Setup *constantSetup = shaderSetup( constantShader, state );
-	Shader::Setup::ScopedBinding constantBinding( *constantSetup );
+	else
+	{
+		uniformSetup = flatConstantShaderSetup( state );
+	}
+	Shader::Setup::ScopedBinding uniformBinding( *uniformSetup );
+
+	const Shader::Setup *primitiveSetup = shaderSetup( uniformSetup->shader(), state );
+	Shader::Setup::ScopedBinding primitiveBinding( *primitiveSetup );
+
 	GLint csIndex = -1;
-	if( const Shader::Parameter *csParameter = constantSetup->shader()->csParameter() )
+	if( const Shader::Parameter *csParameter = uniformSetup->shader()->csParameter() )
 	{
 		csIndex = csParameter->location;
 	}

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -84,33 +84,6 @@ IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( Primitive::TransparencySo
 namespace
 {
 
-Shader *mostBasicShader()
-{
-	static const char *vertexSource =
-		
-		"#if __VERSION__ <= 120\n"
-		"#define in attribute\n"
-		"#define out varying\n"
-		"#endif\n"
-		""
-		"in vec3 vertexP;"
-		""
-		"void main()"
-		"{"
-		"	gl_Position = gl_ProjectionMatrix * gl_ModelViewMatrix * vec4( vertexP, 1 );"
-		"}";
-		
-	static const char *fragmentSource =
-	
-		"void main()"
-		"{"
-			"gl_FragColor = vec4( 1, 1, 1, 1 );"
-		"}";
-
-	static ShaderPtr s = new Shader( vertexSource, fragmentSource );
-	return s.get();
-}
-
 struct FlatConstant
 {
 
@@ -223,9 +196,10 @@ void Primitive::render( State *state ) const
 	// with a simple shader and early out.
 	if( currentSelector && currentSelector->mode() == Selector::GLSelect )
 	{
-		const Shader *basicShader = mostBasicShader();
-		const Shader::Setup *basicSetup = shaderSetup( basicShader, state );
-		Shader::Setup::ScopedBinding basicBinding( *basicSetup );
+		const Shader::Setup *uniformSetup = flatConstantShaderSetup( state, /* forIDRender = */ false );
+		Shader::Setup::ScopedBinding uniformBinding( *uniformSetup );
+		const Shader::Setup *primitiveSetup = shaderSetup( uniformSetup->shader(), state );
+		Shader::Setup::ScopedBinding primitiveBinding( *primitiveSetup );
 		render( state, Primitive::DrawSolid::staticTypeId() );
 		return;
 	}

--- a/src/IECoreGL/Selector.cpp
+++ b/src/IECoreGL/Selector.cpp
@@ -243,40 +243,6 @@ class Selector::Implementation : public IECore::RefCounted
 
 	private :
 		
-		void bindIDShader( const IECoreGL::Shader *shader )
-		{
-			if( shader == m_currentIDShader )
-			{
-				// early out to avoid the relatively expensive operations
-				// below if we've already loaded the shader.
-				return;
-			}
-		
-			const IECoreGL::Shader::Parameter *nameParameter = shader->uniformParameter( "ieCoreGLNameIn" );
-			if( !nameParameter )
-			{
-				throw IECore::Exception( "ID shader does not have an ieCoreGLNameIn parameter" );
-			}
-			
-			GLint fragDataLocation = glGetFragDataLocation( shader->program(), "ieCoreGLNameOut" );
-			if( fragDataLocation < 0 )
-			{
-				throw IECore::Exception( "ID shader does not have an ieCoreGLNameOut output" );			
-			}
-			
-			m_nameUniformLocation = nameParameter->location;
-			
-			m_currentIDShader = shader;
-			glUseProgram( m_currentIDShader->program() );
-			
-			std::vector<GLenum> buffers;
-			buffers.resize( fragDataLocation + 1, GL_NONE );
-			buffers[buffers.size()-1] = GL_COLOR_ATTACHMENT0;
-			glDrawBuffers( buffers.size(), &buffers[0] );
-			
-			loadNameIDRender( m_currentName );
-		}
-		
 		Mode m_mode;
 		Imath::M44d m_postProjectionMatrix;
 		std::vector<HitRecord> &m_hits;
@@ -400,6 +366,40 @@ class Selector::Implementation : public IECore::RefCounted
 			{
 				m_hits.push_back( it->second );
 			}
+		}
+
+		void bindIDShader( const IECoreGL::Shader *shader )
+		{
+			if( shader == m_currentIDShader )
+			{
+				// early out to avoid the relatively expensive operations
+				// below if we've already loaded the shader.
+				return;
+			}
+
+			const IECoreGL::Shader::Parameter *nameParameter = shader->uniformParameter( "ieCoreGLNameIn" );
+			if( !nameParameter )
+			{
+				throw IECore::Exception( "ID shader does not have an ieCoreGLNameIn parameter" );
+			}
+
+			GLint fragDataLocation = glGetFragDataLocation( shader->program(), "ieCoreGLNameOut" );
+			if( fragDataLocation < 0 )
+			{
+				throw IECore::Exception( "ID shader does not have an ieCoreGLNameOut output" );
+			}
+
+			m_nameUniformLocation = nameParameter->location;
+
+			m_currentIDShader = shader;
+			glUseProgram( m_currentIDShader->program() );
+
+			std::vector<GLenum> buffers;
+			buffers.resize( fragDataLocation + 1, GL_NONE );
+			buffers[buffers.size()-1] = GL_COLOR_ATTACHMENT0;
+			glDrawBuffers( buffers.size(), &buffers[0] );
+
+			loadNameIDRender( m_currentName );
 		}
 
 		//////////////////////////////////////////////////////////////////////////

--- a/src/IECoreGL/ShaderStateComponent.cpp
+++ b/src/IECoreGL/ShaderStateComponent.cpp
@@ -61,12 +61,14 @@ class ShaderStateComponent::Implementation : public IECore::RefCounted
 			:	m_shaderLoader( ShaderLoader::defaultShaderLoader() ), m_textureLoader( TextureLoader::defaultTextureLoader() ), m_fragmentSource( "" ), m_geometrySource( "" ), m_vertexSource( "" ), 
 				m_parameterMap( 0 ), m_shaderSetup( 0 )
 		{
+			initHash();
 		}
 
 		Implementation( ShaderLoaderPtr shaderLoader, TextureLoaderPtr textureLoader, const std::string &vertexSource, const std::string &geometrySource, const std::string &fragmentSource, IECore::ConstCompoundObjectPtr parameterValues )
 			:	m_shaderLoader( shaderLoader ), m_textureLoader( textureLoader ), m_fragmentSource( fragmentSource ), m_geometrySource( geometrySource ),
 				m_vertexSource( vertexSource ), m_parameterMap( parameterValues->copy() ), m_shaderSetup( 0 )
 		{
+			initHash();
 		}
 
 		ShaderLoader *shaderLoader()
@@ -77,6 +79,11 @@ class ShaderStateComponent::Implementation : public IECore::RefCounted
 		TextureLoader *textureLoader()
 		{
 			return m_textureLoader.get();
+		}
+
+		IECore::MurmurHash hash() const
+		{
+			return m_hash;
 		}
 		
 		Shader::Setup *shaderSetup()
@@ -144,8 +151,20 @@ class ShaderStateComponent::Implementation : public IECore::RefCounted
 		std::string m_fragmentSource;
 		std::string m_geometrySource;
 		std::string m_vertexSource;
-		IECore::CompoundObjectPtr m_parameterMap;		
+		IECore::CompoundObjectPtr m_parameterMap;
+		IECore::MurmurHash m_hash;
 		mutable Shader::SetupPtr m_shaderSetup;
+
+		void initHash()
+		{
+			m_hash.append( m_fragmentSource );
+			m_hash.append( m_geometrySource );
+			m_hash.append( m_vertexSource );
+			if( m_parameterMap )
+			{
+				m_parameterMap->hash( m_hash );
+			}
+		}
 
 		void ensureShaderSetup() const
 		{
@@ -203,7 +222,12 @@ TextureLoader *ShaderStateComponent::textureLoader()
 {
 	return m_implementation->textureLoader();
 }
-		
+
+IECore::MurmurHash ShaderStateComponent::hash() const
+{
+	return m_implementation->hash();
+}
+
 Shader::Setup *ShaderStateComponent::shaderSetup()
 {
 	return m_implementation->shaderSetup();

--- a/src/IECoreGL/bindings/ShaderStateComponentBinding.cpp
+++ b/src/IECoreGL/bindings/ShaderStateComponentBinding.cpp
@@ -68,6 +68,7 @@ void bindShaderStateComponent()
 		.def( init<ShaderLoaderPtr, TextureLoaderPtr, const std::string &, const std::string &, const std::string &, IECore::ConstCompoundObjectPtr>() )
 		.def( "shaderLoader", &shaderLoader )
 		.def( "textureLoader", &textureLoader )
+		.def( "hash", &ShaderStateComponent::hash )
 		.def( "shaderSetup", &shaderSetup )
 	;
 }


### PR DESCRIPTION
This fixes several scenarios in which custom vertex shaders were ignored in IECoreGL, resulting in things being rendered in the wrong place. It's not particularly pretty stuff due to a need to maintain backwards compatibility and an awkward API that isn't quite suited to what we're trying to do - there's a brief description of the problems in the final commit. Definitely one that needs looking at with one's suspicious hat on...