### PR TITLE
Arealight control parameter

### DIFF
--- a/include/IECore/Light.h
+++ b/include/IECore/Light.h
@@ -63,7 +63,10 @@ class IECORE_API Light : public StateRenderable
 		/// This is mostly of use for the binding - the parameters()
 		/// function gives more direct access to the contents of the CompoundData
 		/// (it calls readable() or writable() for you).
+		/// \todo: Should return raw pointer to CompoundData, and we should probably remove the
+		/// parameters() methods since the helper methods on ParametersData make it more useful
 		CompoundDataPtr parametersData();
+		const CompoundDataPtr parametersData() const;
 
 		/// Sets this light in Renderer.
 		virtual void render( Renderer *renderer ) const;

--- a/src/IECore/Light.cpp
+++ b/src/IECore/Light.cpp
@@ -97,6 +97,11 @@ CompoundDataPtr Light::parametersData()
 	return m_parameters;
 }
 
+const CompoundDataPtr Light::parametersData() const
+{
+	return m_parameters;
+}
+
 void Light::render( Renderer *renderer ) const
 {
 	renderer->light( m_name, m_handle, parameters() );

--- a/src/IECorePython/LightBinding.cpp
+++ b/src/IECorePython/LightBinding.cpp
@@ -57,7 +57,7 @@ namespace IECorePython
 			.def( "__init__", make_constructor( &construct, default_call_policies(), ( boost::python::arg_( "name" )="distantlight", boost::python::arg_( "handle" )="", boost::python::arg_( "parameters" )=0 ) ) )
 			.add_property( "name", make_function( &Light::getName, return_value_policy<copy_const_reference>() ), &Light::setName )
 			.add_property( "handle", make_function( &Light::getHandle, return_value_policy<copy_const_reference>() ), &Light::setHandle )
-			.add_property( "parameters", &Light::parametersData )
+			.add_property( "parameters", (CompoundDataPtr (Light::*)() )( &Light::parametersData ) )
 		;
 	}
 

--- a/src/IECoreRI/RendererImplementation.cpp
+++ b/src/IECoreRI/RendererImplementation.cpp
@@ -1414,6 +1414,17 @@ void IECoreRI::RendererImplementation::light( const std::string &name, const std
 		parametersCopy.erase( it );
 	}
 
+	it = parametersCopy.find( "__areaLight" );
+	if( it != parametersCopy.end() )
+	{
+		BoolData *b = runTimeCast<BoolData>( it->second.get() );
+		if( b && b->readable() )
+		{
+			areaLight = true;
+		}
+		parametersCopy.erase( it );
+	}
+
 	ParameterList pl( parametersCopy );
 
 	if( areaLight )

--- a/test/IECoreRI/IlluminateTest.py
+++ b/test/IECoreRI/IlluminateTest.py
@@ -91,5 +91,20 @@ class IlluminateTest( IECoreRI.TestCase ) :
 		self.assert_( "AreaLightSource \"spotlight\" \"myLightHandle\"" in l )
 		self.assert_( "LightSource \"spotlight\" \"myLightHandle2\"" in l )
 
+	def testAreaLightNew( self ) :
+		r = IECoreRI.Renderer( self.outputFileName )
+		
+		r.worldBegin()
+		
+		r.light( "spotlight", "myLightHandle", { "intensity" : 2, "colour" : IECore.Color3f( 1, 0, 0 ), "__areaLight" : True } )
+		r.light( "spotlight", "myLightHandle2", { "intensity" : 2, "colour" : IECore.Color3f( 1, 0, 0 ), "__areaLight" : False } )
+		
+		r.worldEnd()
+
+		l = "".join( file( self.outputFileName ).readlines() )
+
+		self.assert_( "AreaLightSource \"spotlight\" \"myLightHandle\"" in l )
+		self.assert_( "LightSource \"spotlight\" \"myLightHandle2\"" in l )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
IECoreRI now looks for an additional parameter named "__areaLight" to cause lights to be output as area lights.  This is helpful because this name can be declared on shaders in RSL, since it doesn't contain a colon.