### PR TITLE
IECoreMaya SceneShape Expansion

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -187,22 +187,17 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 	# If the path isn't already in the queries, add it and return the new index.
 	def __queryIndexForPath( self, path ):
 
-		node = self.fullPathName()
-		index = None
-		validIndices = maya.cmds.getAttr( node+".queryPaths", mi=True )
-		if not validIndices:
-			index = 0
-		else:
-			for id in validIndices:
-				# Check if we can reuse a query path
-				if maya.cmds.getAttr( node+".queryPaths["+str(id)+"]" ) == path:
-					index = id
-					break
-			if index is None:
-				# Didn't find path, get the next available index
-				index = max( i for i in validIndices ) +1
-				
-		maya.cmds.setAttr( node+".queryPaths["+str(index)+"]", path, type="string" )
+		queryPaths = self.findPlug( "queryPaths" )
+		validIndices = maya.OpenMaya.MIntArray()
+		queryPaths.getExistingArrayAttributeIndices( validIndices )
+		for i in validIndices:
+			# Check if we can reuse a query path
+			if queryPaths.elementByLogicalIndex( i ).asString() == path :
+				return i
+
+		# Didn't find path, get the next available index
+		index = max(validIndices) + 1 if validIndices else 0
+		queryPaths.elementByLogicalIndex( index ).setString( path )
 		return index
 	
 	## create the given child for the scene shape

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -46,7 +46,7 @@ import StringUtil
 
 
 ## A function set for operating on the IECoreMaya::SceneShape type.
-class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
+class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 	## Initialise the function set for the given procedural object, which may
 	# either be an MObject or a node name in string or unicode form.
@@ -55,7 +55,7 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 		if isinstance( object, str ) or isinstance( object, unicode ) :
 			object = StringUtil.dependencyNodeFromString( object )
 
-		maya.OpenMaya.MFnDependencyNode.__init__( self, object )
+		maya.OpenMaya.MFnDagNode.__init__( self, object )
 
 	## Creates a new node under a transform of the specified name. Returns a function set instance operating on this new node.
 	@staticmethod
@@ -144,18 +144,6 @@ class FnSceneShape( maya.OpenMaya.MFnDependencyNode ) :
 		if toSelect:
 			maya.cmds.select( toSelect, r=True )
 			
-	
-	## Returns the full path name to this node.
-	def fullPathName( self ) :
-		
-		try :
-			f = maya.OpenMaya.MFnDagNode( self.object() )
-			return f.fullPathName()
-		except :
-			pass
-
-		return self.name()
-		
 	def sceneInterface( self ) :
 
 		return _IECoreMaya._sceneShapeSceneInterface( self )

--- a/src/IECoreMaya/bindings/ToMayaMeshConverterBinding.cpp
+++ b/src/IECoreMaya/bindings/ToMayaMeshConverterBinding.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2013, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2013-2015, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -37,6 +37,8 @@
 
 #include "boost/python.hpp"
 
+#include "IECore/MessageHandler.h"
+
 #include "IECoreMaya/StatusException.h"
 #include "IECoreMaya/ToMayaMeshConverter.h"
 #include "IECoreMaya/bindings/ToMayaMeshConverterBinding.h"
@@ -48,7 +50,7 @@ using namespace IECoreMaya;
 using namespace boost::python;
 
 // we use the shape name instead of MObject
-static void setMeshInterpolationAttribute( std::string n, std::string interpolation )
+static bool setMeshInterpolationAttribute( std::string n, std::string interpolation )
 {
 	MSelectionList l;
 	StatusException::throwIfError( l.add( MString( n.c_str() ) ) );
@@ -59,13 +61,17 @@ static void setMeshInterpolationAttribute( std::string n, std::string interpolat
 	s = l.getDependNode( 0, o );
 	if( !s )
 	{
-		throw Exception("Could not get depedency node!");
+		IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::setMeshInterpolationAttribute",  "Could not get depedency node: " + n );
+		return false;
 	}
 
 	if ( !ToMayaMeshConverter::setMeshInterpolationAttribute( o, interpolation ) )
 	{
-		throw Exception( "Failed to set interpolation attribute in " + n );
+		IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::setMeshInterpolationAttribute",  "Failed to set interpolation attribute in " + n );
+		return false;
 	}
+	
+	return true;
 }
 
 void IECoreMaya::bindToMayaMeshConverter()


### PR DESCRIPTION
This PR is about improving performance when expanding ieSceneShapes in Maya for characters with massive amounts of hierarchy as well as shapes. This reduced runtime of loading a newly expanded ieSceneShape into an animation rig for such a character from 103.1494 seconds to 73.4175 seconds.

I also changed the binding for ToMayaMeshConverter::setMeshInterpolationAttribute() to match the c++ equivalent as the exception was preventing my testing at first. Warning instead of throwing seems more in keeping with how the other converters behave.