### PR TITLE
Fixed time remapping for old style links in linked scenes

### DIFF
--- a/src/IECore/LinkedScene.cpp
+++ b/src/IECore/LinkedScene.cpp
@@ -998,22 +998,56 @@ ConstSceneInterfacePtr LinkedScene::expandLink( const StringData *fileName, cons
 
 double LinkedScene::remappedLinkTime( double time ) const
 {
-	ConstDoubleDataPtr t = runTimeCast< const DoubleData >( m_mainScene->readAttribute( timeLinkAttribute, time ) );
-	if ( !t )
+	if( m_mainScene->hasAttribute( timeLinkAttribute ) )
 	{
-		throw Exception( "Invalid time when querying for time remapping!" );
+		ConstDoubleDataPtr t = runTimeCast< const DoubleData >( m_mainScene->readAttribute( timeLinkAttribute, time ) );
+		if ( !t )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		return t->readable();
 	}
-	return t->readable();
+	else
+	{
+		ConstCompoundDataPtr d = runTimeCast< const CompoundData >( m_mainScene->readAttribute( linkAttribute, time ) );
+		if( !d )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		ConstDoubleDataPtr t = d->member<DoubleData>( g_time );
+		if( !t )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		return t->readable();
+	}
 }
 
 double LinkedScene::remappedLinkTimeAtSample( size_t sampleIndex ) const
 {
-	ConstDoubleDataPtr t = runTimeCast< const DoubleData >( static_cast<const SampledSceneInterface*>(m_mainScene.get())->readAttributeAtSample( timeLinkAttribute, sampleIndex ) );
-	if ( !t )
+	if( m_mainScene->hasAttribute( timeLinkAttribute ) )
 	{
-		throw Exception( "Invalid time when querying for time remapping!" );
+		ConstDoubleDataPtr t = runTimeCast< const DoubleData >( static_cast<const SampledSceneInterface*>(m_mainScene.get())->readAttributeAtSample( timeLinkAttribute, sampleIndex ) );
+		if ( !t )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		return t->readable();
 	}
-	return t->readable();
+	else
+	{
+		ConstCompoundDataPtr d = runTimeCast< const CompoundData >( static_cast<const SampledSceneInterface*>(m_mainScene.get())->readAttributeAtSample( linkAttribute, sampleIndex ) );
+		if( !d )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		ConstDoubleDataPtr t = d->member<DoubleData>( g_time );
+		if( !t )
+		{
+			throw Exception( "Invalid time when querying for time remapping!" );
+		}
+		return t->readable();
+	}
 }
 
 SceneInterfacePtr LinkedScene::child( const Name &name, MissingBehaviour missingBehaviour )
@@ -1090,7 +1124,7 @@ SceneInterfacePtr LinkedScene::child( const Name &name, MissingBehaviour missing
 			ConstCompoundDataPtr d = runTimeCast< const CompoundData >( c->readAttribute( linkAttribute, 0 ) );
 			/// we found the link attribute...
 			int linkDepth;
-			bool timeRemapped = false;
+			bool timeRemapped = ( d->member<DoubleData>( g_time ) != NULL );
 			ConstSceneInterfacePtr l = expandLink( d->member< const StringData >( g_fileName ), d->member< const InternedStringVectorData >( g_root ), linkDepth );
 			if ( l )
 			{

--- a/test/IECore/LinkedSceneTest.py
+++ b/test/IECore/LinkedSceneTest.py
@@ -409,6 +409,45 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertEqual( Aa.readTransformAsMatrix( 0.8 ), A.readTransformAsMatrix( 0.8 / 8 ) )
 		self.assertEqual( Aa.readTransformAsMatrix( 0.9 ), A.readTransformAsMatrix( 0.9 / 8 ) )
 	
+	def testOldStyleTimeRemapping( self ):
+
+		# write as a scene cache so we can write old style attributes:
+		l2 = IECore.SceneCache( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		t2 = l2.createChild("transform2")
+		i2 = t2.createChild("instance2")
+		
+		# write with time locked to zero:
+		linkAttr = IECore.CompoundData( 
+			{
+				"fileName": IECore.StringData("test/IECore/data/sccFiles/animatedSpheres.scc"),
+				"root": IECore.InternedStringVectorData( [] ),
+				"time": IECore.DoubleData( 0.0 )
+			}
+		)
+		i2.writeAttribute( IECore.LinkedScene.linkAttribute, linkAttr, 0.0 )
+
+		del l2, i2, t2
+		
+		l = IECore.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		t2 = l.child("transform2")
+		i2 = t2.child("instance2")
+		A = i2.child("A")
+		
+		m = IECore.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		Aa = m.child("A")
+		
+		# time should be locked to zero:
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.1 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.2 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.3 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.4 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.5 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.6 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.7 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.8 / 8 ) )
+		self.assertEqual( Aa.readTransformAsMatrix( 0.0 ), A.readTransformAsMatrix( 0.9 / 8 ) )
+
+	
 	def readSavedScenes( self, fileVersion ):
 
 		def recurseCompare( basePath, virtualScene, realScene, atLink = True ) :


### PR DESCRIPTION
I'm actually doing this because the IECoreMaya::LiveScene uses the old style link attributes (for which time remapping was not working). Ideally we should update the IECoreMaya::LiveScene to support the new style attributes and remove the old code, but that seems potentially disruptive.