### PR TITLE
Fixed crash when converting integer and float list attributes

### DIFF
--- a/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
@@ -394,6 +394,11 @@ void FromHoudiniGeometryConverter::transferAttribData(
 	{
 		case GA_STORECLASS_FLOAT :
 		{
+			if( !attr->getAIFTuple() )
+			{
+				// not supporting variable lists
+				return;
+			}
 			switch ( attr->getTupleSize() )
 			{
 				case 1 :
@@ -494,6 +499,11 @@ void FromHoudiniGeometryConverter::transferAttribData(
 		}
 		case GA_STORECLASS_INT :
  		{
+			if( !attr->getAIFTuple() )
+			{
+				// not supporting variable lists
+				return;
+			}
 			switch ( attr->getTupleSize() )
 			{
 				case 1 :
@@ -595,7 +605,12 @@ void FromHoudiniGeometryConverter::transferDetailAttribs( const GU_Detail *geo, 
 		switch ( attrRef.getStorageClass() )
 		{
 			case GA_STORECLASS_FLOAT :
-			{
+			{	
+				if( !attr->getAIFTuple() )
+				{
+					// not supporting variable lists
+					continue;
+				}
 				switch ( attr->getTupleSize() )
 				{
 					case 1 :
@@ -645,6 +660,11 @@ void FromHoudiniGeometryConverter::transferDetailAttribs( const GU_Detail *geo, 
 			}
 			case GA_STORECLASS_INT :
  			{
+				if( !attr->getAIFTuple() )
+				{
+					// not supporting variable lists
+					continue;
+				}
 				switch ( attr->getTupleSize() )
 				{
 					case 1 :


### PR DESCRIPTION
For now these attributes are not supported, as there aren't any appropriate cortex data types for them (in the vertex/point/primitive case anyway)