### PR TITLE
MessageHandlerBinding fix

### DIFF
--- a/include/IECorePython/MessageHandlerBinding.h
+++ b/include/IECorePython/MessageHandlerBinding.h
@@ -35,8 +35,6 @@
 #ifndef IECOREPYTHON_MESSAGEHANDLERBINDING_H
 #define IECOREPYTHON_MESSAGEHANDLERBINDING_H
 
-#include <boost/python.hpp>
-#include "IECore/MessageHandler.h"
 #include "IECorePython/Export.h"
 
 namespace IECorePython

--- a/src/IECorePython/MessageHandlerBinding.cpp
+++ b/src/IECorePython/MessageHandlerBinding.cpp
@@ -47,8 +47,9 @@
 
 using namespace boost::python;
 using namespace IECore;
+using namespace IECorePython;
 
-namespace IECorePython
+namespace
 {
 
 class MessageHandlerWrap : public MessageHandler, public Wrapper<MessageHandler>
@@ -65,22 +66,24 @@ class MessageHandlerWrap : public MessageHandler, public Wrapper<MessageHandler>
 
 };
 
-static void addHandler( CompoundMessageHandler &h, MessageHandlerPtr hh )
+void addHandler( CompoundMessageHandler &h, MessageHandlerPtr hh )
 {
 	h.handlers.insert( hh );
 }
 
-static void removeHandler( CompoundMessageHandler &h, MessageHandlerPtr hh )
+void removeHandler( CompoundMessageHandler &h, MessageHandlerPtr hh )
 {
 	h.handlers.erase( hh );
 }
 
-static LevelFilteredMessageHandlerPtr levelFilteredMessageHandlerConstructor(MessageHandlerPtr handle, MessageHandler::Level level)
+LevelFilteredMessageHandlerPtr levelFilteredMessageHandlerConstructor(MessageHandlerPtr handle, MessageHandler::Level level)
 {
 	return new LevelFilteredMessageHandler( handle, level );
 }
 
-void bindMessageHandler()
+} // namespace
+
+void IECorePython::bindMessageHandler()
 {
 
 	def( "msg", (void (*)( MessageHandler::Level, const std::string &, const std::string &))&msg );
@@ -141,7 +144,5 @@ void bindMessageHandler()
 
 	class_<MessageHandler::Scope, boost::noncopyable>( "_Scope", init<MessageHandler *>() )
 	;
-
-}
 
 }


### PR DESCRIPTION
This fixes a problem whereby the MessageHandler python wrapper would allow python exceptions to leak out into C++, where they can't be handled well. I don't have test cases for this in Cortex beyond those already present, but a future Gaffer pull request contains tests which crash if this isn't fixed here.