### PR TITLE
appleseed: added nested volume priority attribute

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/private/AttributeState.h
@@ -63,6 +63,8 @@ class AttributeState
 
 		bool photonTarget() const;
 
+		int volumePriority() const;
+
 		void attributesHash( IECore::MurmurHash &hash ) const;
 
 		void addOSLShader( IECore::ConstShaderPtr shader );
@@ -86,6 +88,7 @@ class AttributeState
 		std::string m_alphaMap;
 		bool m_photonTarget;
 		foundation::Dictionary m_visibilityDictionary;
+		int m_volumePriority;
 
 };
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/AttributeState.cpp
@@ -47,6 +47,7 @@ IECoreAppleseed::AttributeState::AttributeState()
 {
 	m_attributes = new CompoundData;
 	m_photonTarget = false;
+	m_volumePriority = 0;
 }
 
 IECoreAppleseed::AttributeState::AttributeState( const AttributeState &other )
@@ -57,6 +58,7 @@ IECoreAppleseed::AttributeState::AttributeState( const AttributeState &other )
 	m_alphaMap = other.m_alphaMap;
 	m_photonTarget = other.m_photonTarget;
 	m_visibilityDictionary = other.m_visibilityDictionary;
+	m_volumePriority = other.m_volumePriority;
 }
 
 void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDataPtr value )
@@ -107,6 +109,17 @@ void IECoreAppleseed::AttributeState::setAttribute( const string &name, ConstDat
 			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "photon_target attribute expect a BoolData value." );
 		}
 	}
+	else if( name == "as:volume_priority" )
+	{
+		if( const IntData *f = runTimeCast<const IntData>( value.get() ) )
+		{
+			m_volumePriority = f->readable();
+		}
+		else
+		{
+			msg( Msg::Error, "IECoreAppleseed::RendererImplementation::setAttribute", "as:volume_priority attribute expects an IntData value." );
+		}
+	}
 	else if( 0 == name.compare( 0, 14, "as:visibility:" ) )
 	{
 		if( const BoolData *f = runTimeCast<const BoolData>( value.get() ) )
@@ -146,10 +159,16 @@ bool IECoreAppleseed::AttributeState::photonTarget() const
 	return m_photonTarget;
 }
 
+int IECoreAppleseed::AttributeState::volumePriority() const
+{
+	return m_volumePriority;
+}
+
 void IECoreAppleseed::AttributeState::attributesHash( MurmurHash &hash ) const
 {
 	hash.append( m_alphaMap );
 	hash.append( m_photonTarget );
+	hash.append( m_volumePriority );
 }
 
 void IECoreAppleseed::AttributeState::addOSLShader( ConstShaderPtr shader )

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/PrimitiveConverter.cpp
@@ -272,6 +272,11 @@ void IECoreAppleseed::PrimitiveConverter::createObjectInstance( asr::Assembly &a
 		params.insert( "photon_target", "true" );
 	}
 
+	if( attrState.volumePriority() != 0 )
+	{
+		params.insert( "volume_priority", attrState.volumePriority() );
+	}
+
 	asf::auto_release_ptr<asr::ObjectInstance> objInstance = asr::ObjectInstanceFactory::create( instanceName.c_str(),
 		params, objectEntityName( objSourceName ).c_str(), asf::Transformd::make_identity(), materials, materials );
 	assembly.object_instances().insert( objInstance );


### PR DESCRIPTION
Added nested volume (nested dielectrics) attributes for the next appleseed release.
Previous versions of appleseed will ignore the volume_priority parameter.
