### PR TITLE
Sorting childNames during ieSceneShape expansion in Maya.

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -286,7 +286,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		if not scene:
 			return []
 			
-		sceneChildren = scene.childNames()
+		sceneChildren = sorted( scene.childNames() )
 		
 		if sceneChildren == []:
 			# No children to expand to

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -184,12 +184,12 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		
 		fn.convertAllToGeometry()
 		
-		children = set( ["|test|testSceneShape", "|test|sceneShape_1"] )
-		self.assertEqual( set(maya.cmds.listRelatives( "|test", f=True )), children )
+		children = ["|test|testSceneShape", "|test|sceneShape_1"]
+		self.assertEqual( maya.cmds.listRelatives( "|test", f=True ), children )
 		self.assertEqual( maya.cmds.getAttr( fn.fullPathName()+".intermediateObject" ), 1 )
 		
-		children = set( ["|test|sceneShape_1|sceneShape_SceneShape1", "|test|sceneShape_1|child", "|test|sceneShape_1|sceneShape_Shape1"] )
-		self.assertEqual( set(maya.cmds.listRelatives( "|test|sceneShape_1", f=True )), children )
+		children = ["|test|sceneShape_1|sceneShape_SceneShape1", "|test|sceneShape_1|child", "|test|sceneShape_1|sceneShape_Shape1"]
+		self.assertEqual( maya.cmds.listRelatives( "|test|sceneShape_1", f=True ), children )
 		self.assertEqual( maya.cmds.getAttr( "|test|sceneShape_1|sceneShape_SceneShape1.intermediateObject" ), 1 )
 		self.assertEqual( maya.cmds.nodeType( "|test|sceneShape_1|sceneShape_Shape1" ), "mesh")
 		


### PR DESCRIPTION
This is required to produce consistent results for Maya hierarchy, which can be valuable when trying to automate behaviour on certain groups via a rig. It also matches the sorting we do in Houdini.