### PR TITLE
ConfigLoader : Ignore duplicate paths.

### DIFF
--- a/python/IECore/ConfigLoader.py
+++ b/python/IECore/ConfigLoader.py
@@ -52,7 +52,14 @@ def loadConfig( searchPaths, contextDict, raiseExceptions = False, subdirectory 
 	paths = searchPaths.paths
 	paths.reverse()
 
+	visitedPaths = set()
 	for path in paths :
+
+		if path in visitedPaths :
+			continue
+		else :
+			visitedPaths.add( path )
+
 		pyExtTest = re.compile( "^[^~].*\.py$" )
 		for dirPath, dirNames, fileNames in os.walk( os.path.join( path, subdirectory ) ) :
 			for fileName in filter( pyExtTest.search, sorted( fileNames ) ) :

--- a/test/IECore/ConfigLoaderTest.py
+++ b/test/IECore/ConfigLoaderTest.py
@@ -215,7 +215,25 @@ class ConfigLoaderTest( unittest.TestCase ) :
 		
 		expectedFile = os.path.abspath( os.path.join( path, "config.py" ) )
 		self.assertEqual( contextDict["myFile"], expectedFile )
-		
+
+	def testDuplicatePathsIgnored( self ) :
+
+		contextDict = {}
+		IECore.loadConfig(
+
+			IECore.SearchPath(
+				os.path.dirname( __file__ ) + "/config/orderOne:" +
+				os.path.dirname( __file__ ) + "/config/orderTwo:" +
+				os.path.dirname( __file__ ) + "/config/orderOne",
+				":"
+			),
+
+			contextDict,
+
+		)
+
+		self.assertEqual( contextDict["a"], 2 )
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
This fixes problems we had in getting Gaffer running at Cinesite, and also removes the need for some nasty workarounds in the Gaffer startup files, where they were having to check for a second execution and early-out in that case.