### PR TITLE
LinkedScenes - remove warning for ancestorTags

### DIFF
--- a/src/IECore/LinkedScene.cpp
+++ b/src/IECore/LinkedScene.cpp
@@ -701,7 +701,7 @@ void LinkedScene::writeAttribute( const Name &name, const Object *attribute, dou
 			{
 				std::string pathStr;
 				SceneInterface::pathToString( sceneRoot->readable(), pathStr );
-				msg( Msg::Warning, "LinkedScene::writeAttribute", ( boost::format( "Detected ancestor tags while creating link to file %s at location %s." ) % fileName->readable() % pathStr ).str() );
+				msg( Msg::Debug, "LinkedScene::writeAttribute", ( boost::format( "Detected ancestor tags while creating link to file %s at location %s." ) % fileName->readable() % pathStr ).str() );
 			}
 			tags.clear();
 


### PR DESCRIPTION
Lowering the message level for the indication that there are ancestor tags defined at the point of the link in a LinkedScene
Having it as a warning was causing confusion and is almost always unnecessary.
