### PR TITLE
Fixed "name" attribute bug in IECoreHoudini.LiveScene()

### DIFF
--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -611,9 +611,16 @@ bool LiveScene::hasObject() const
 			return true;
 		}
 		
-		for ( GA_Size i=0; i < numShapes; ++i )
+		GA_Size numStrings = stats.getCapacity();
+		for ( GA_Size i=0; i < numStrings; ++i )
 		{
-			const char *currentName = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, i ) );
+			GA_StringIndexType validatedIndex = tuple->validateTableHandle( nameAttr, i );
+			if ( validatedIndex < 0 )
+			{
+				continue;
+			}
+			
+			const char *currentName = tuple->getTableString( nameAttr, validatedIndex );
 			const char *match = matchPath( currentName );
 			if ( match && *match == *emptyString )
 			{
@@ -730,12 +737,16 @@ void LiveScene::childNames( NameList &childNames ) const
 		
 		const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 		const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-		GA_StringTableStatistics stats;
-		tuple->getStatistics( nameAttr, stats );
-		GA_Size numShapes = stats.getEntries();
-		for ( GA_Size i=0; i < numShapes; ++i )
+		GA_Size numStrings = tuple->getTableEntries( nameAttr );
+		for ( GA_Size i=0; i < numStrings; ++i )
 		{
-			const char *currentName = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, i ) );
+			GA_StringIndexType validatedIndex = tuple->validateTableHandle( nameAttr, i );
+			if ( validatedIndex < 0 )
+			{
+				continue;
+			}
+			
+			const char *currentName = tuple->getTableString( nameAttr, validatedIndex );
 			const char *match = matchPath( currentName );
 			if ( match && *match != *emptyString )
 			{
@@ -904,12 +915,16 @@ OP_Node *LiveScene::retrieveChild( const Name &name, Path &contentPath, MissingB
 				{
 					const GA_Attribute *nameAttr = nameAttrRef.getAttribute();
 					const GA_AIFSharedStringTuple *tuple = nameAttr->getAIFSharedStringTuple();
-					GA_StringTableStatistics stats;
-					tuple->getStatistics( nameAttr, stats );
-					GA_Size numShapes = stats.getEntries();
-					for ( GA_Size i=0; i < numShapes; ++i )
+					GA_Size numStrings = tuple->getTableEntries( nameAttr );
+					for ( GA_Size i=0; i < numStrings; ++i )
 					{
-						const char *currentName = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, i ) );
+						GA_StringIndexType validatedIndex = tuple->validateTableHandle( nameAttr, i );
+						if ( validatedIndex < 0 )
+						{
+							continue;
+						}
+						
+						const char *currentName = tuple->getTableString( nameAttr, validatedIndex );
 						const char *match = matchPath( currentName );
 						if ( match && *match != *emptyString )
 						{

--- a/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
+++ b/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
@@ -267,10 +267,20 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::renderFrame( fpreal time, UT_Interrupt *bo
 				}
 				else if ( numShapes == 1 )
 				{
-					const char *name = tuple->getTableString( nameAttr, tuple->validateTableHandle( nameAttr, 0 ) );
-					if( ( name == 0 ) || ( !strcmp( name, "" ) || !strcmp( name, "/" ) ) )
+					GA_Size numStrings = stats.getCapacity();
+					for ( GA_Size i=0; i < numStrings; ++i )
 					{
-						reRoot = true;
+						GA_StringIndexType validatedIndex = tuple->validateTableHandle( nameAttr, i );
+						if ( validatedIndex < 0 )
+						{
+							continue;
+						}
+						
+						const char *name = tuple->getTableString( nameAttr, validatedIndex );
+						if( ( name == 0 ) || ( !strcmp( name, "" ) || !strcmp( name, "/" ) ) )
+						{
+							reRoot = true;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This bug could be triggered by using an attribwrangle on the name attribute, because it keeps bogus strings in the shared table rather than cleaning them up.

See 24b41be434375d2eb366ff72a6ff9431c286b70f for more background information.