### PR TITLE
3delight OSL Support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1760,8 +1760,17 @@ if doConfigure :
 			riSources.remove( "src/IECoreRI/SHWDeepImageWriter.cpp" )
 			riPythonSources.remove( "src/IECoreRI/bindings/SHWDeepImageReaderBinding.cpp" )
 			riPythonSources.remove( "src/IECoreRI/bindings/SHWDeepImageWriterBinding.cpp" )
-		
-		c.Finish()	
+
+		if haveDelight and c.CheckCXXHeader( "nsi.h" ) :
+
+			riSources.append( glob.glob( "src/IECoreRI/NSI/*.cpp" ) )
+			riEnv.Append( CPPFLAGS = [ "-DIECORERI_WITH_NSI" ] )
+
+		elif haveDelight :
+
+			sys.stderr.write( "WARNING : NSI API not found - not building NSI support.\n" )
+
+		c.Finish()
 
 		# we can't append this before configuring, as then it gets built as
 		# part of the configure process

--- a/include/IECoreRI/NSI/AttributeAlgo.h
+++ b/include/IECoreRI/NSI/AttributeAlgo.h
@@ -1,0 +1,58 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORERI_NSI_ATTRIBUTEALGO_H
+#define IECORERI_NSI_ATTRIBUTEALGO_H
+
+#include "nsi.h"
+
+#include "IECore/Data.h"
+#include "IECore/CompoundData.h"
+
+#include "IECoreRI/Export.h"
+
+namespace IECoreRI
+{
+
+namespace NSI
+{
+
+IECORERI_API void setAttribute( NSIContext_t context, NSIHandle_t object, const char *name, const IECore::Data *value );
+IECORERI_API void setAttributes( NSIContext_t context, NSIHandle_t object, const IECore::CompoundDataMap &values );
+
+} // namespace NSI
+
+} // namespace IECoreRI
+
+#endif // IECORERI_NSI_ATTRIBUTEALGO_H

--- a/include/IECoreRI/NSI/private/HandleGenerator.h
+++ b/include/IECoreRI/NSI/private/HandleGenerator.h
@@ -1,0 +1,73 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORERI_NSI_HANDLEGENERATOR_H
+#define IECORERI_NSI_HANDLEGENERATOR_H
+
+#include <string>
+
+#include "tbb/atomic.h"
+
+#include "boost/noncopyable.hpp"
+#include "boost/shared_ptr.hpp"
+
+namespace IECoreRI
+{
+
+namespace NSI
+{
+
+// Used to generate a series of handles which are guaranteed
+// to be unique.
+class HandleGenerator : public boost::noncopyable
+{
+
+	public :
+
+		// Generates a unique handle based on the hint.
+		std::string generate( const std::string &hint );
+
+	private :
+
+		tbb::atomic<int> m_handleCount;
+
+};
+
+typedef boost::shared_ptr<HandleGenerator> HandleGeneratorPtr;
+
+} // namespace NSI
+
+} // namespace IECoreRI
+
+#endif // IECORERI_NSI_HANDLEGENERATOR_H

--- a/include/IECoreRI/NSI/private/ShaderState.h
+++ b/include/IECoreRI/NSI/private/ShaderState.h
@@ -1,0 +1,77 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORERI_NSI_SHADERSTATE_H
+#define IECORERI_NSI_SHADERSTATE_H
+
+#include "boost/unordered_map.hpp"
+#include "boost/shared_ptr.hpp"
+
+#include "IECore/CompoundData.h"
+
+#include "IECoreRI/NSI/private/HandleGenerator.h"
+
+namespace IECoreRI
+{
+
+namespace NSI
+{
+
+// Class for managing the current NSI shading network
+// within an attribute stack.
+class ShaderState
+{
+
+	public :
+
+		ShaderState( HandleGeneratorPtr handleGenerator );
+		ShaderState( const ShaderState &other );
+
+		bool shader( const std::string &type, const std::string &name, const IECore::CompoundDataMap &parameters );
+
+	private :
+
+		typedef boost::unordered_map<std::string, std::string> HandleMap;
+		typedef boost::shared_ptr<HandleMap> HandleMapPtr;
+
+		HandleMapPtr m_handleMap;
+		HandleGeneratorPtr m_handleGenerator;
+
+};
+
+} // namespace NSI
+
+} // namespace IECoreRI
+
+#endif // IECORERI_NSI_SHADERSTATE_H

--- a/include/IECoreRI/private/RendererImplementation.h
+++ b/include/IECoreRI/private/RendererImplementation.h
@@ -41,6 +41,8 @@
 #include "tbb/recursive_mutex.h"
 #include "tbb/mutex.h"
 
+#include "boost/make_shared.hpp"
+
 #include "ri.h"
 
 #include "IECore/CachedReader.h"
@@ -58,6 +60,10 @@
 
 #include "IECoreRI/Export.h"
 #include "IECoreRI/Renderer.h"
+
+#ifdef IECORERI_WITH_NSI
+#include "IECoreRI/NSI/private/ShaderState.h"
+#endif // IECORERI_WITH_NSI
 
 namespace IECoreRI
 {
@@ -150,6 +156,13 @@ class IECORERI_API RendererImplementation : public IECore::Renderer
 			// accessed from multiple threads when running threaded procedurals
 			typedef tbb::recursive_mutex ObjectHandlesMutex;
 			ObjectHandlesMutex objectHandlesMutex;
+#ifdef IECORERI_WITH_NSI
+			SharedData()
+				:	handleGenerator( boost::make_shared<NSI::HandleGenerator>() )
+			{
+			}
+			NSI::HandleGeneratorPtr handleGenerator;
+#endif
 		};
 				
 		RtContextHandle m_context;
@@ -202,8 +215,10 @@ class IECORERI_API RendererImplementation : public IECore::Renderer
 
 		struct AttributeState
 		{
-			AttributeState();
-			AttributeState( const AttributeState &other );
+#ifdef IECORERI_WITH_NSI
+			AttributeState( const NSI::ShaderState &nsiShaderState );
+			NSI::ShaderState nsiShaderState;
+#endif // IECORERI_WITH_NSI
 			std::map<std::string, std::string> primVarTypeHints;
 		};
 		std::stack<AttributeState> m_attributeStack;

--- a/src/IECoreRI/NSI/AttributeAlgo.cpp
+++ b/src/IECoreRI/NSI/AttributeAlgo.cpp
@@ -1,0 +1,133 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/format.hpp"
+
+#include "IECore/SimpleTypedData.h"
+#include "IECore/VectorTypedData.h"
+#include "IECore/MessageHandler.h"
+
+#include "IECoreRI/NSI/AttributeAlgo.h"
+
+using namespace IECore;
+
+namespace
+{
+
+NSIType_t convertGeometricInterpretation( GeometricData::Interpretation interpretation )
+{
+	switch( interpretation )
+	{
+		case GeometricData::None :
+			/// \todo This isn't really right - we should probably treat
+			/// this as float[3] instead. We need to be using Interpretation
+			/// consistently across the board before this becomes an option
+			/// though.
+			return NSITypeVector;
+		case GeometricData::Point :
+			return NSITypePoint;
+		case GeometricData::Normal :
+			return NSITypeNormal;
+		case GeometricData::Vector :
+			return NSITypeVector;
+		case GeometricData::Color :
+			return NSITypeColor;
+	}
+	return NSITypeInvalid;
+}
+
+} // namespace
+
+namespace IECoreRI
+{
+
+namespace NSI
+{
+
+void setAttribute( NSIContext_t context, NSIHandle_t object, const char *name, const IECore::Data *value )
+{
+	NSIParam_t param = {
+		name,
+		NULL, // data
+		NSITypeInvalid,
+		0, // arraylength
+		1  // count
+	};
+
+	const char *charPtr = NULL;
+	switch( value->typeId() )
+	{
+		case IntDataTypeId :
+			param.type = NSITypeInteger;
+			param.data = static_cast<const IntData *>( value )->baseReadable();
+			break;
+		case FloatDataTypeId :
+			param.type = NSITypeFloat;
+			param.data = static_cast<const FloatData *>( value )->baseReadable();
+			break;
+		case Color3fDataTypeId :
+			param.type = NSITypeColor;
+			param.data = static_cast<const Color3fData *>( value )->baseReadable();
+			break;
+		case V3fDataTypeId :
+			param.type = convertGeometricInterpretation( static_cast<const V3fData *>( value )->getInterpretation() );
+			param.data = static_cast<const Color3fData *>( value )->baseReadable();
+			break;
+		case StringDataTypeId :
+			param.type = NSITypeString;
+			charPtr = static_cast<const StringData *>( value )->readable().c_str();
+			param.data = &charPtr;
+			break;
+		default :
+			msg( Msg::Warning, "NSI::setAttribute", boost::format( "Attribute \"%s\" has unsupported datatype \"%s\"." ) % name % value->typeName() );
+			break;
+	}
+
+	if( param.type && param.data )
+	{
+		NSISetAttribute( context, object, 1, &param );
+	}
+}
+
+void setAttribute( NSIContext_t context, NSIHandle_t object, const IECore::CompoundDataMap &values )
+{
+	for( CompoundDataMap::const_iterator it = values.begin(), eIt = values.end(); it != eIt; ++it )
+	{
+		setAttribute( context, object, it->first.c_str(), it->second.get() );
+	}
+}
+
+} // namespace NSI
+
+} // namespace IECoreRI

--- a/src/IECoreRI/NSI/HandleGenerator.cpp
+++ b/src/IECoreRI/NSI/HandleGenerator.cpp
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/lexical_cast.hpp"
+
+#include "IECoreRI/NSI/private/HandleGenerator.h"
+
+using namespace IECoreRI::NSI;
+
+std::string HandleGenerator::generate( const std::string &hint )
+{
+	return hint + "#" + boost::lexical_cast<std::string>( m_handleCount++ );
+}
+

--- a/src/IECoreRI/NSI/ShaderState.cpp
+++ b/src/IECoreRI/NSI/ShaderState.cpp
@@ -1,0 +1,155 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "nsi.h"
+#include "nsi_ri.h"
+
+#include "boost/make_shared.hpp"
+#include "boost/algorithm/string/predicate.hpp"
+
+#include "IECore/SimpleTypedData.h"
+
+#include "IECoreRI/NSI/AttributeAlgo.h"
+#include "IECoreRI/NSI/private/ShaderState.h"
+
+using namespace std;
+using namespace boost;
+using namespace IECore;
+using namespace IECoreRI::NSI;
+
+ShaderState::ShaderState( HandleGeneratorPtr handleGenerator )
+	:	m_handleMap( boost::make_shared<HandleMap>() ), m_handleGenerator( handleGenerator )
+{
+}
+
+ShaderState::ShaderState( const ShaderState &other )
+	:	m_handleMap( other.m_handleMap ), m_handleGenerator( other.m_handleGenerator )
+{
+}
+
+bool ShaderState::shader( const std::string &type, const std::string &name, const IECore::CompoundDataMap &parameters )
+{
+	if( !starts_with( type, "osl:" ) )
+	{
+		return false;
+	}
+
+	const StringData *handleData = NULL;
+	CompoundDataMap::const_iterator handleIt = parameters.find( "__handle" );
+	if( handleIt != parameters.end() )
+	{
+		handleData = runTimeCast<const StringData>( handleIt->second.get() );
+	}
+
+	std::string nsiHandle = m_handleGenerator->generate( handleData ? handleData->readable() : name );
+
+	NSIContext_t nsiContext = RiToNSIContext( RiGetContext() );
+	NSICreate(
+		nsiContext,
+		nsiHandle.c_str(),
+		"shader", // type
+		0, // nparams
+		NULL // params
+	);
+
+	const char *fileName = name.c_str();
+	NSIParam_t fileNameParam = { "shaderfilename", &fileName, NSITypeString, 0, 1 };
+	NSISetAttribute(
+		nsiContext,
+		nsiHandle.c_str(),
+		1,
+		&fileNameParam
+	);
+
+	if( handleData )
+	{
+		// We need to store the NSI handle so we can look it up later
+		// when linking shaders. Since we do lazy shallow copies in our
+		// copy constructor, we must now do a full deep copy if we are
+		// to modify the handle map.
+		if( !m_handleMap.unique() )
+		{
+			m_handleMap = make_shared<HandleMap>( *m_handleMap );
+		}
+		(*m_handleMap)[handleData->readable()] = nsiHandle;
+	}
+
+	for( CompoundDataMap::const_iterator it = parameters.begin(), eIt = parameters.end(); it != eIt; ++it )
+	{
+		if( it == handleIt )
+		{
+			continue;
+		}
+
+		if( const StringData *valueData = runTimeCast<const StringData>( it->second.get() ) )
+		{
+			const string &value = valueData->readable();
+			if( starts_with( value, "link:" ) )
+			{
+				const size_t i = value.find_first_of( "." );
+				const string fromHandle( value.begin() + 5, value.begin() + i );
+				const char *fromAttr = value.c_str() + i + 1;
+
+				HandleMap::const_iterator fromNSIHandleIt = m_handleMap->find( fromHandle );
+				if( fromNSIHandleIt != m_handleMap->end() )
+				{
+					NSIConnect(
+						nsiContext,
+						fromNSIHandleIt->second.c_str(),
+						fromAttr,
+						nsiHandle.c_str(),
+						it->first.c_str()
+					);
+				}
+				continue;
+			}
+		}
+
+		setAttribute( nsiContext, nsiHandle.c_str(), it->first.c_str(), it->second.get() );
+	}
+
+	if( type == "osl:surface" )
+	{
+		const char *h = nsiHandle.c_str();
+		RiAttribute( "nsi", "string oslsurface", &h, RI_NULL );
+	}
+	else if( type == "osl:displacement" )
+	{
+		const char *h = nsiHandle.c_str();
+		RiAttribute( "nsi", "string osldisplacement", &h, RI_NULL );
+	}
+
+
+	return true;
+}


### PR DESCRIPTION
This adds support for specifying OSL shader networks to 3delight via the fledgling NSI API. With this we have just enough to start exploring the 3delight/OSL combo in Gaffer.