### PR TITLE
FromMayaPlugConverter, PointArray type Maya plugs support

### DIFF
--- a/include/IECoreMaya/FromMayaArrayDataConverter.h
+++ b/include/IECoreMaya/FromMayaArrayDataConverter.h
@@ -39,6 +39,7 @@
 #include "maya/MDoubleArray.h"
 #include "maya/MStringArray.h"
 #include "maya/MVectorArray.h"
+#include "maya/MPointArray.h"
 
 #include "IECore/VectorTypedData.h"
 
@@ -75,6 +76,8 @@ typedef FromMayaArrayDataConverter<MDoubleArray, IECore::FloatVectorData> FromMa
 typedef FromMayaArrayDataConverter<MStringArray, IECore::StringVectorData> FromMayaArrayDataConverterss;
 typedef FromMayaArrayDataConverter<MVectorArray, IECore::V3fVectorData> FromMayaArrayDataConverterVV3f;
 typedef FromMayaArrayDataConverter<MVectorArray, IECore::V3dVectorData> FromMayaArrayDataConverterVV3d;
+typedef FromMayaArrayDataConverter<MPointArray, IECore::V3fVectorData> FromMayaArrayDataConverterPV3f;
+typedef FromMayaArrayDataConverter<MPointArray, IECore::V3dVectorData> FromMayaArrayDataConverterPV3d;
 typedef FromMayaArrayDataConverter<MVectorArray, IECore::Color3fVectorData> FromMayaArrayDataConverterVC3f;
 
 } // namespace IECoreMaya

--- a/include/IECoreMaya/TypeIds.h
+++ b/include/IECoreMaya/TypeIds.h
@@ -121,6 +121,8 @@ enum TypeId
 	FromMayaLocatorConverterTypeId = 109074,
 	ToMayaLocatorConverterTypeId = 109075,
 	ToMayaCurveConverterTypeId = 109076,
+	FromMayaArrayDataConverterPV3fTypeId = 109077,
+	FromMayaArrayDataConverterPV3dTypeId = 109078,
 	// Remember to update TypeIdBinding.cpp
 	LastTypeId = 109999
 };

--- a/src/IECoreMaya/FromMayaArrayDataConverter.cpp
+++ b/src/IECoreMaya/FromMayaArrayDataConverter.cpp
@@ -38,10 +38,41 @@
 
 #include "IECore/VectorTypedData.h"
 
+#include "IECore/GeometricTypedData.h"
+
 using namespace IECore;
 
 namespace IECoreMaya
 {
+
+namespace
+{
+
+template<typename F, typename T>
+struct SetInterpolation
+{
+	static void set( T* resultData ){}
+};
+
+template<typename T>
+struct SetInterpolation<MPointArray, IECore::GeometricTypedData<T> >
+{
+	static void set( IECore::GeometricTypedData<T> *resultData )
+	{
+		resultData->setInterpretation( IECore::GeometricData::Point );
+	}
+};
+
+template<typename T>
+struct SetInterpolation<MVectorArray, IECore::GeometricTypedData<T> >
+{
+	static void set( IECore::GeometricTypedData<T> *resultData )
+	{
+		resultData->setInterpretation( IECore::GeometricData::Vector );
+	}
+};
+
+}
 
 template<typename F, typename T>
 FromMayaArrayDataConverter<F,T>::FromMayaArrayDataConverter( const MObject &object )
@@ -68,6 +99,8 @@ IECore::ObjectPtr FromMayaArrayDataConverter<F,T>::doConversion( const MObject &
 		resultArray[i] = IECore::convert<typename T::ValueType::value_type, typename MArrayTraits<F>::ValueType>( array[i] );
 	}
 
+	SetInterpolation<F, T>::set( resultData.get() );
+
 	return resultData;
 }
 
@@ -78,6 +111,8 @@ IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterdf, 
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterss, FromMayaArrayDataConverterssTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterVV3f, FromMayaArrayDataConverterVV3fTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterVV3d, FromMayaArrayDataConverterVV3dTypeId )
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterPV3f, FromMayaArrayDataConverterPV3fTypeId )
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterPV3d, FromMayaArrayDataConverterPV3dTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaArrayDataConverterVC3f, FromMayaArrayDataConverterVC3fTypeId )
 
 // Registrations and instantiations
@@ -95,5 +130,7 @@ REGISTER_AND_INSTANTIATE( MStringArray, StringVectorData, true )
 REGISTER_AND_INSTANTIATE( MVectorArray, V3fVectorData, false )
 REGISTER_AND_INSTANTIATE( MVectorArray, V3dVectorData, true )
 REGISTER_AND_INSTANTIATE( MVectorArray, Color3fVectorData, false );
+REGISTER_AND_INSTANTIATE( MPointArray, V3fVectorData, false )
+REGISTER_AND_INSTANTIATE( MPointArray, V3dVectorData, true )
 
 } // namespace IECoreMaya

--- a/src/IECoreMaya/bindings/FromMayaArrayDataConverterBinding.cpp
+++ b/src/IECoreMaya/bindings/FromMayaArrayDataConverterBinding.cpp
@@ -57,5 +57,7 @@ void IECoreMaya::bindFromMayaArrayDataConverter()
 	bind<FromMayaArrayDataConverterss>();
 	bind<FromMayaArrayDataConverterVV3f>();
 	bind<FromMayaArrayDataConverterVV3d>();
+	bind<FromMayaArrayDataConverterPV3f>();
+	bind<FromMayaArrayDataConverterPV3d>();
 	bind<FromMayaArrayDataConverterVC3f>();
 }

--- a/src/IECoreMaya/bindings/TypeIdBinding.cpp
+++ b/src/IECoreMaya/bindings/TypeIdBinding.cpp
@@ -124,6 +124,8 @@ void bindTypeId()
 		.value( "FromMayaProceduralHolderConverter", FromMayaProceduralHolderConverterTypeId )
 		.value( "FromMayaLocatorConverter", FromMayaLocatorConverterTypeId )
 		.value( "ToMayaLocatorConverter", ToMayaLocatorConverterTypeId )
+		.value( "FromMayaArrayDataConverterPV3f", FromMayaArrayDataConverterPV3fTypeId )
+		.value( "FromMayaArrayDataConverterPV3d", FromMayaArrayDataConverterPV3dTypeId )
 	;
 }
 

--- a/test/IECoreMaya/FromMayaPlugConverterTest.py
+++ b/test/IECoreMaya/FromMayaPlugConverterTest.py
@@ -95,5 +95,61 @@ class FromMayaPlugConverterTest( IECoreMaya.TestCase ) :
 		transform = converter.convert()
 		self.assert_( transform.isInstanceOf( IECore.TransformationMatrixdData.staticTypeId() ) )
 
+	def testPointArrayData( self ) :
+		import itertools
+		import maya.OpenMaya as om
+
+		data = [ [ 0.1, 0.2, 0.3, 1 ], [ 0.4, 0.5, 0.6, 1 ] ]
+
+		locator = maya.cmds.spaceLocator()[0]
+		maya.cmds.addAttr( locator, ln="myPoints", dt="pointArray" )
+		maya.cmds.setAttr( locator + "." + "myPoints", 2, *data, type="pointArray" )
+
+		sl = om.MSelectionList()
+		sl.add( locator )
+		o = om.MObject()
+		sl.getDependNode( 0, o )
+		fn = om.MFnDependencyNode( o )
+		plug = fn.findPlug( "myPoints" )
+
+		converter = IECoreMaya.FromMayaPlugConverter.create( plug )
+		self.assert_( converter )
+
+		converted = converter.convert()
+		self.assert_( converted.isInstanceOf( IECore.V3dVectorData.staticTypeId() ) )
+
+		for point, index in itertools.product( xrange( 2 ), xrange( 3 ) ):
+		    self.assertAlmostEqual( converted[ point ][ index ], data[ point ][ index ] )
+
+		self.assertEqual( converted.getInterpretation(), IECore.GeometricData.Interpretation.Point )
+
+	def testVectorArrayData( self ) :
+		import itertools
+		import maya.OpenMaya as om
+
+		data = [ [ 0.1, 0.2, 0.3 ], [ 0.4, 0.5, 0.6 ] ]
+
+		locator = maya.cmds.spaceLocator()[0]
+		maya.cmds.addAttr( locator, ln="myVectors", dt="vectorArray" )
+		maya.cmds.setAttr( locator + "." + "myVectors", 2, *data, type="vectorArray" )
+
+		sl = om.MSelectionList()
+		sl.add( locator )
+		o = om.MObject()
+		sl.getDependNode( 0, o )
+		fn = om.MFnDependencyNode( o )
+		plug = fn.findPlug( "myVectors" )
+
+		converter = IECoreMaya.FromMayaPlugConverter.create( plug )
+		self.assert_( converter )
+
+		converted = converter.convert()
+		self.assert_( converted.isInstanceOf( IECore.V3dVectorData.staticTypeId() ) )
+
+		for point, index in itertools.product( xrange( 2 ), xrange( 3 ) ):
+		    self.assertAlmostEqual( converted[ point ][ index ], data[ point ][ index ] )
+
+		self.assertEqual( converted.getInterpretation(), IECore.GeometricData.Interpretation.Vector )
+
 if __name__ == "__main__":
 	IECoreMaya.TestProgram()


### PR DESCRIPTION
FromMayaPlugConverter converts Maya PointArray type plugs to IECore::Vector3f/3d (3d default) with interpretation=Point.