### PR TITLE
Added mightHaveFn arg to registerCustomAttributes.

### DIFF
--- a/include/IECoreMaya/LiveScene.h
+++ b/include/IECoreMaya/LiveScene.h
@@ -176,6 +176,7 @@ class LiveScene : public IECore::SceneInterface
 		typedef boost::function<bool (const MDagPath &, const Name &, int )> HasTagFn;
 		typedef boost::function<void (const MDagPath &, NameList &, int)> ReadTagsFn;
 		typedef boost::function<void (const MDagPath &, NameList &)> NamesFn;
+		typedef boost::function<bool (const MDagPath &, const Name &)> MightHaveFn;
 		
 		// Register callbacks for custom objects.
 		// The has function will be called during hasObject and it stops in the first one that returns true.
@@ -185,7 +186,9 @@ class LiveScene : public IECore::SceneInterface
 		// Register callbacks for custom attributes.
 		// The names function will be called during attributeNames and hasAttribute.
 		// The readAttr method is called if the names method returns the expected attribute, so it should return a valid Object pointer or raise an Exception.
+		// If the mightHave function is specified, it will be called before names function for early out, to see if the names function can return the expected attribute.
 		static void registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn );
+		static void registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn, MightHaveFn mightHaveFn);
 		
 		// Register callbacks for nodes to define custom tags
 		// The functions will be called during hasTag and readTags.
@@ -219,6 +222,7 @@ class LiveScene : public IECore::SceneInterface
 		{
 			NamesFn m_names;
 			ReadAttrFn m_read;
+			MightHaveFn m_mightHave;
 		};
 		
 		static std::vector< CustomReader > &customObjectReaders();

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -256,6 +256,14 @@ bool LiveScene::hasAttribute( const Name &name ) const
 	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
 	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
 	{
+		if ( it->m_mightHave )
+		{
+			if ( ! it->m_mightHave( m_dagPath, name ) )
+			{
+				continue;
+			}
+		}
+
 		NameList names;
 		{
 			// call it->m_names under a mutex, as it could be reading plug values,
@@ -839,9 +847,15 @@ void LiveScene::registerCustomObject( HasFn hasFn, ReadFn readFn )
 
 void LiveScene::registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn )
 {
+	registerCustomAttributes( namesFn, readFn, 0 );
+}
+
+void LiveScene::registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn, MightHaveFn mightHaveFn )
+{
 	CustomAttributeReader r;
 	r.m_names = namesFn;
 	r.m_read = readFn;
+	r.m_mightHave = mightHaveFn;
 	customAttributeReaders().push_back(r);
 }
 


### PR DESCRIPTION
IECoreMaya::LiveScene::registerCustomAttributes() takes the third argument mightHaveFn.
If the mightHave function is specified, it will be called before names function for early out, to see if the names function can return the expected attribute.
It was added because for some custom attributes names function can be the performance bottle neck.