### PR TITLE
GEOIO_Translator fileStat for bounding box

### DIFF
--- a/include/IECoreHoudini/GEO_CobIOTranslator.h
+++ b/include/IECoreHoudini/GEO_CobIOTranslator.h
@@ -40,6 +40,7 @@
 #include "GEO/GEO_IOTranslator.h"
 #include "GU/GU_Detail.h"
 #include "UT/UT_IStream.h"
+#include "GA/GA_Stat.h"
 
 namespace IECoreHoudini
 {
@@ -79,6 +80,11 @@ class GEO_CobIOTranslator : public GEO_IOTranslator
 		virtual GA_Detail::IOStatus fileLoad( GEO_Detail *geo, UT_IStream &is, int ate_magic );		
 		/// Saves a cob by attempting to find a FromHoudiniGeometryConverter matching the given GEO_Detail
 		virtual GA_Detail::IOStatus fileSaveToFile( const GEO_Detail *geo, std::ostream &os, const char *fileName );
+		//@}
+
+		//@{
+		/// Reads only header of the file, 
+		virtual bool fileStat( const char *fileName, GA_Stat &stat, uint level );
 		//@}
 
 };

--- a/src/IECoreHoudini/GEO_CobIOTranslator.cpp
+++ b/src/IECoreHoudini/GEO_CobIOTranslator.cpp
@@ -40,6 +40,7 @@
 #include "IECoreHoudini/GEO_CobIOTranslator.h"
 #include "IECoreHoudini/FromHoudiniGeometryConverter.h"
 #include "IECoreHoudini/ToHoudiniGeometryConverter.h"
+#include "IECoreHoudini/Convert.h"
 
 using namespace IECore;
 using namespace IECoreHoudini;
@@ -162,4 +163,28 @@ GA_Detail::IOStatus GEO_CobIOTranslator::fileSaveToFile( const GEO_Detail *geo, 
 	((std::ofstream&)os).close();
 	
 	return fileSaveToFile( geo, fileName );
+}
+
+bool GEO_CobIOTranslator::fileStat( const char *fileName, GA_Stat &stat, uint level )
+{
+	try
+	{
+		ReaderPtr reader = Reader::create( fileName );
+		if ( !reader )
+		{
+			return false;
+		}
+		
+		ConstCompoundObjectPtr header = reader->readHeader();
+
+		UT_BoundingBox bbox = convert<UT_BoundingBox>( reader->readHeader()->member<const Box3fData>( "bound", true )->readable() );
+
+		stat.setBounds( bbox );
+	}
+	catch ( ... )
+	{
+		return false;
+	}
+
+	return true;
 }


### PR DESCRIPTION
Delayed Load Geometry shader in Houdini needs `fileStat` method to query file statistics at initialization time.