### PR TITLE
Revert "SConstruct : Don't check for Arnold lib, just headers."

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2932,7 +2932,7 @@ if doConfigure :
 
 	c = Configure( arnoldEnv )
 
-	if not c.CheckCXXHeader( "ai.h" ) :
+	if not c.CheckLibWithHeader( "ai", "ai.h", "CXX" ) :
 	
 		sys.stderr.write( "WARNING : no ai library found, not building IECoreArnold - check ARNOLD_ROOT.\n" )
 		c.Finish()


### PR DESCRIPTION
This reverts commit 73e35dbbb5b55ffb0fa30ee2493b7573ef21a174.

Removing the check caused SCons to remove the "-lai" flag it was adding automatically. While this worked on Linux where the dependency was resolved at runtime, it broke the linking on OS X.

I'd like to get this merged while we talk about how to deal with the "build IECoreArnold for Maya 2014" issue at IE, because the problem is holding up my work on standalone stuff (and is actually affecting Linux too in some use cases).