### PR TITLE
Don't Require Runtime Dependencies of Arnold at Build Time

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2960,7 +2960,12 @@ if doConfigure :
 
 		# we can't append this before configuring, as then it gets built as
 		# part of the configure process
-		arnoldEnv.Append( LIBS = os.path.basename( coreEnv.subst( "$INSTALL_LIB_NAME" ) ) )
+		arnoldEnv.Append(
+			LIBS = [
+				"ai",
+				os.path.basename( coreEnv.subst( "$INSTALL_LIB_NAME" ) )
+			]
+		 )
 		arnoldPythonModuleEnv.Append( LIBS = os.path.basename( corePythonEnv.subst( "$INSTALL_PYTHONLIB_NAME" ) ) )
 		arnoldProceduralEnv.Append(
 			LIBS = [ 

--- a/SConstruct
+++ b/SConstruct
@@ -2930,7 +2930,17 @@ haveArnold = False
 
 if doConfigure :
 
-	c = Configure( arnoldEnv )
+	# Since we only build shared libraries and not exectuables,
+	# we only need to check that shared libs will link correctly.
+	# This is necessary for arnold, which uses
+	# a run-time compatible, but link-time incompatbile libstdc++
+	# in some obscure studio setups. This approach succeeds because
+	# building a shared library doesn't require resolving the
+	# unresolved symbols of the libraries that it links to.
+	arnoldCheckEnv = arnoldEnv.Clone()
+	arnoldCheckEnv.Append( CXXFLAGS = [ "-fPIC" ] )
+	arnoldCheckEnv.Append( LINKFLAGS = [ "-shared" ] )
+	c = Configure( arnoldCheckEnv )
 
 	if not c.CheckLibWithHeader( "ai", "ai.h", "CXX" ) :
 	


### PR DESCRIPTION
After merging #492, we need some way to get IECoreArnold to compile for Maya at IE.

It appears to work OK if I take the same approach as we did for 3delight in #454 

We create an env for the call to CheckLibWithHeader that specifies it is building a shared library, and therefore doesn't need to resolve runtime dependencies.  The actual version of libstc++ we use at runtime in Maya at IE appears compatible with Arnold.

Note that because I've cloned the env for the check now, I've had to manually declare the dependency on libai.  This really doesn't seem ugly, since we already declare it explicitly for arnoldProceduralEnv and arnoldDriverEnv, so this makes them match more.  An alternative would be to set the "-shared" link flag on arnoldEnv instead of making a separate arnoldCheckEnv - I don't really knows the relative merits of this, but it currently works.