### PR TITLE
Arnold output driver improvements

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
@@ -49,7 +49,10 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreArnold;
 
-static void driverParameters( AtList *params, AtMetaDataStore *metaData )
+namespace
+{
+
+void driverParameters( AtList *params, AtMetaDataStore *metaData )
 {
 	AiParameterSTR( "driverType", "" );
 
@@ -58,16 +61,16 @@ static void driverParameters( AtList *params, AtMetaDataStore *metaData )
 	AiMetaDataSetStr( metaData, 0, "maya.translator", "ie" );
 }
 
-static void driverInitialize( AtNode *node, AtParamValue *parameters )
+void driverInitialize( AtNode *node, AtParamValue *parameters )
 {
 	AiDriverInitialize( node, true, new DisplayDriverPtr );
 }
 
-static void driverUpdate( AtNode *node, AtParamValue *parameters )
+void driverUpdate( AtNode *node, AtParamValue *parameters )
 {
 }
 
-static bool driverSupportsPixelType( const AtNode *node, AtByte pixelType )
+bool driverSupportsPixelType( const AtNode *node, AtByte pixelType )
 {
 	switch( pixelType )
 	{
@@ -82,12 +85,12 @@ static bool driverSupportsPixelType( const AtNode *node, AtByte pixelType )
 	}
 }
 
-static const char **driverExtension()
+const char **driverExtension()
 {
    return 0;
 }
 
-static void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displayWindow, AtBBox2 dataWindow, int bucketSize )
+void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displayWindow, AtBBox2 dataWindow, int bucketSize )
 {
 	std::vector<std::string> channelNames;
 
@@ -152,20 +155,20 @@ static void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2
 	}
 }
 
-static bool driverNeedsBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
+bool driverNeedsBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
 {
 	return true;
 }
 
-static void driverPrepareBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
+void driverPrepareBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
 {
 }
 
-static void driverProcessBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sample_iterator, int x, int y, int sx, int sy, int tId )
+void driverProcessBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sample_iterator, int x, int y, int sx, int sy, int tId )
 {
 }
 
-static void driverWriteBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sampleIterator, int x, int y, int sx, int sy )
+void driverWriteBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sampleIterator, int x, int y, int sx, int sy )
 {
 	DisplayDriverPtr *driver = (DisplayDriverPtr *)AiDriverGetLocalData( node );
 	if( !*driver )
@@ -234,7 +237,7 @@ static void driverWriteBucket( AtNode *node, struct AtOutputIterator *iterator, 
 	}
 }
 
-static void driverClose( AtNode *node, struct AtOutputIterator *iterator )
+void driverClose( AtNode *node, struct AtOutputIterator *iterator )
 {
 	DisplayDriverPtr *driver = (DisplayDriverPtr *)AiDriverGetLocalData( node );
 	if( *driver )
@@ -252,12 +255,14 @@ static void driverClose( AtNode *node, struct AtOutputIterator *iterator )
 	}
 }
 
-static void driverFinish( AtNode *node )
+void driverFinish( AtNode *node )
 {
 	DisplayDriverPtr *driver = (DisplayDriverPtr *)AiDriverGetLocalData( node );
 	delete driver;
 	AiDriverDestroy( node );
 }
+
+} // namespace
 
 AI_EXPORT_LIB bool NodeLoader( int i, AtNodeLib *node )
 {

--- a/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
@@ -49,10 +49,6 @@ using namespace Imath;
 using namespace IECore;
 using namespace IECoreArnold;
 
-#if ( ( AI_VERSION_ARCH_NUM * 100 ) + AI_VERSION_MAJOR_NUM ) >= 401
-#define ARNOLD_4_1
-#endif
-
 static void driverParameters( AtList *params, AtMetaDataStore *metaData )
 {
 	AiParameterSTR( "driverType", "" );
@@ -156,26 +152,18 @@ static void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2
 	}
 }
 
-#ifdef ARNOLD_4_1
-
 static bool driverNeedsBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
 {
 	return true;
 }
 
-#endif // ARNOLD_4_1
-
 static void driverPrepareBucket( AtNode *node, int x, int y, int sx, int sy, int tId )
 {
 }
 
-#ifdef ARNOLD_4_1
-
 static void driverProcessBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sample_iterator, int x, int y, int sx, int sy, int tId )
 {
 }
-
-#endif // ARNOLD_4_1
 
 static void driverWriteBucket( AtNode *node, struct AtOutputIterator *iterator, struct AtAOVSampleIterator *sampleIterator, int x, int y, int sx, int sy )
 {
@@ -285,13 +273,9 @@ AI_EXPORT_LIB bool NodeLoader( int i, AtNodeLib *node )
 			driverSupportsPixelType,
 			driverExtension,
 			driverOpen,
-#ifdef ARNOLD_4_1
 			driverNeedsBucket,
-#endif
 			driverPrepareBucket,
-#ifdef ARNOLD_4_1
 			driverProcessBucket,
-#endif
 			driverWriteBucket,
 			driverClose
 		};


### PR DESCRIPTION
This improves the IECoreArnold output driver to better support progressive rendering. As far as I can tell, an Arnold progressive render is just literally a series of individual renders each with different settings. This leads to a series of open/data/close calls to the display driver, with no additional information to say that they should all be considered part of one render. I've chosen to reuse the previous Cortex display driver if all settings are identical and the display driver is capable of receiving the same buckets more than once. In practice I believe this corresponds exactly to the circumstances of a progressive render to a framebuffer-type display driver like the ones we use in Gaffer/Nuke.

The end result is that an Arnold IPR render (coming soon!) in Gaffer doesn't clear the viewer to black in between each pass, so each pass appears to be a refinement of the previous, as it does in the existing 3delight IPR renders.