### PR TITLE
IECoreArnold::ParameterAlgo : pass desired type to dataToArray

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -69,7 +69,7 @@ void setParameterInternal( AtNode *node, const char *name, int parameterType, bo
 {
 	if( array )
 	{
-		AtArray *a = ParameterAlgo::dataToArray( value );
+		AtArray *a = ParameterAlgo::dataToArray( value, parameterType );
 		if( !a )
 		{
 			msg( Msg::Warning, "setParameter", boost::format( "Unable to create array from data of type \"%s\" for parameter \"%s\"" ) % value->typeName() % name );


### PR DESCRIPTION
... allowing support for POINT arrays

Pull requesting for comment.  I have not yet assessed whether this change might affect other cases, or require further testing.  It allows me to pass point arrays to Arnold shaders ( otherwise it will just get a type mismatch between Point and the default interpretation of V3fVectorData as Vector ).  I need this to support quad lights.