### PR TITLE
Arnold mesh conversion improvements

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
@@ -33,6 +33,10 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include <algorithm>
+
+#include "boost/algorithm/string/predicate.hpp"
+
 #include "ai.h"
 
 #include "IECore/Exception.h"
@@ -55,21 +59,178 @@ using namespace IECoreArnold;
 namespace
 {
 
-AtArray *faceVaryingIndices( const IECore::MeshPrimitive *mesh )
+AtArray *identityIndices( size_t size )
 {
-	vector<int> ids;
-	ids.resize( mesh->variableSize( PrimitiveVariable::FaceVarying ) );
-	for( size_t i=0, e=ids.size(); i < e; i++ )
+	AtArray *result = AiArrayAllocate( size, 1, AI_TYPE_UINT );
+	for( size_t i=0; i < size; ++i )
 	{
-		ids[i] = i;
+		AiArraySetInt( result, i, i );
 	}
-	return AiArrayConvert( ids.size(), 1, AI_TYPE_INT, (void *)&(ids[0]) );
+	return result;
+}
+
+template<typename T>
+const T *variableData( const PrimitiveVariableMap &variables, const std::string &name, PrimitiveVariable::Interpolation interpolation = PrimitiveVariable::Invalid )
+{
+	PrimitiveVariableMap::const_iterator it = variables.find( name );
+	if( it==variables.end() )
+	{
+		return NULL;
+	}
+	if( interpolation != PrimitiveVariable::Invalid && it->second.interpolation != interpolation )
+	{
+		return NULL;
+	}
+	return runTimeCast<T>( it->second.data.get() );
+}
+
+// Cortex represents UV sets horribly, with the u and v stored as separate primitive variables.
+// RenderMan's FaceVarying data format is also horrible for UV sets, because it throws away all
+// connectivity information, duplicating UVs so that each face vertex has its own value. To work
+// around this, Cortex stores a third variable holding the indices into the original data, so we
+// have a record of the connectivity. This is all done by convention, and because that's what the
+// FromMayaMeshConverter has evolved to do.
+//
+// All this plays poorly with Arnold, because it stores UVs sanely, as an array of 2d vectors with
+// an indices array to index into them per face-vertex. So this function converts the Cortex
+// representation into the Arnold form, so that Arnold can use the connectivity to correctly
+// interpolate the uvs.
+//
+// We should really improve the Cortex representation as follows :
+//
+// - Use V2fVectorData for UVs.
+// - Add an optional IntVectorData indices array into the PrimitiveVariable class to store
+//   indices into the UV array, and associating the indices directly with the data.
+// - Use the above to avoid the duplication of UVs when storing FaceVarying UVs, so we can
+//   do a straightforward conversion to Arnold, and only do the dumb duplication on conversion
+///  to RenderMan.
+// - Perhaps also add a role enum to PrimitiveVariable, so we can distinguish between UVs and
+///  things that just happen to hold V2fVectorData.
+void convertIndexedUVSet( const std::string &setName, PrimitiveVariableMap &variables, AtNode *node )
+{
+	const std::string sName = setName == "" ? "s" : setName + "_s";
+	const std::string tName = setName == "" ? "t" : setName + "_t";
+	const std::string indicesName = setName == "" ? "stIndices" : setName + "Indices";
+
+	const FloatVectorData *sData = variableData<FloatVectorData>( variables, sName, PrimitiveVariable::FaceVarying );
+	const FloatVectorData *tData = variableData<FloatVectorData>( variables, tName, PrimitiveVariable::FaceVarying );
+	const IntVectorData *indicesData = variableData<IntVectorData>( variables, indicesName, PrimitiveVariable::FaceVarying );
+
+	if( !( sData && tData && indicesData ) )
+	{
+		return;
+	}
+
+	const vector<float> &s = sData->readable();
+	const vector<float> &t = tData->readable();
+	const vector<int> &indices = indicesData->readable();
+
+	int numUVs = 1 + *max_element( indices.begin(), indices.end() );
+	AtArray *uvsArray = AiArrayAllocate( numUVs, 1, AI_TYPE_POINT2 );
+	AtArray *indicesArray = AiArrayAllocate( indices.size(), 1, AI_TYPE_UINT );
+
+	for( size_t i = 0, e = indices.size(); i < e; ++i )
+	{
+		AtPoint2 uv = { s[i], 1.0f - t[i] };
+		AiArraySetPnt2( uvsArray, indices[i], uv );
+		AiArraySetUInt( indicesArray, i, indices[i] );
+	}
+
+	if( setName == "" )
+	{
+		AiNodeSetArray( node, "uvlist", uvsArray );
+		AiNodeSetArray( node, "uvidxs", indicesArray );
+	}
+	else
+	{
+		AiNodeDeclare( node, setName.c_str(), "indexed POINT2" );
+		AiNodeSetArray( node, setName.c_str(), uvsArray );
+		AiNodeSetArray( node, (setName + "idxs").c_str(), indicesArray );
+	}
+
+	variables.erase( sName );
+	variables.erase( tName );
+	variables.erase( indicesName );
+}
+
+// Version of the above for when we have no indices available.
+void convertUVSet( const std::string &setName, PrimitiveVariableMap &variables, const vector<int> &vertexIds, AtNode *node )
+{
+	const std::string sName = setName == "" ? "s" : setName + "_s";
+	const std::string tName = setName == "" ? "t" : setName + "_t";
+
+	const FloatVectorData *sData = variableData<FloatVectorData>( variables, sName );
+	const FloatVectorData *tData = variableData<FloatVectorData>( variables, tName );
+
+	if( !( sData && tData ) )
+	{
+		return;
+	}
+
+	PrimitiveVariable::Interpolation sInterpolation = variables.find( "s" )->second.interpolation;
+	PrimitiveVariable::Interpolation tInterpolation = variables.find( "t" )->second.interpolation;
+	if( sInterpolation != tInterpolation )
+	{
+		msg(
+			Msg::Warning, "ToArnoldMeshConverter::doConversion",
+			boost::format( "Variables \"%s\" and \"%s\" have different interpolation - not generating uvs." ) % sName % tName
+		);
+		return;
+	}
+
+	if( sInterpolation != PrimitiveVariable::Varying && sInterpolation != PrimitiveVariable::Vertex && sInterpolation != PrimitiveVariable::FaceVarying )
+	{
+		msg(
+			Msg::Warning, "ToArnoldMeshConverter::doConversion",
+			boost::format( "Variables \"%s\" and \"%s\" have different interpolation types - not generating uvs." ) % sName % tName
+		);
+		return;
+	}
+
+	const vector<float> &s = sData->readable();
+	const vector<float> &t = tData->readable();
+
+	AtArray *uvsArray = AiArrayAllocate( s.size(), 1, AI_TYPE_POINT2 );
+	for( size_t i = 0, e = s.size(); i < e; ++i )
+	{
+		AtPoint2 uv = { s[i], 1.0f - t[i] };
+		AiArraySetPnt2( uvsArray, i, uv );
+	}
+
+	AtArray *indicesArray = NULL;
+	if( sInterpolation == PrimitiveVariable::FaceVarying )
+	{
+		indicesArray = identityIndices( vertexIds.size() );
+	}
+	else
+	{
+		indicesArray = AiArrayAllocate( vertexIds.size(), 1, AI_TYPE_UINT );
+		for( size_t i = 0, e = vertexIds.size(); i < e; ++i )
+		{
+			AiArraySetUInt( indicesArray, i, vertexIds[i] );
+		}
+	}
+
+	if( setName == "" )
+	{
+		AiNodeSetArray( node, "uvlist", uvsArray );
+		AiNodeSetArray( node, "uvidxs", indicesArray );
+	}
+	else
+	{
+		AiNodeDeclare( node, setName.c_str(), "indexed POINT2" );
+		AiNodeSetArray( node, setName.c_str(), uvsArray );
+		AiNodeSetArray( node, (setName + "idxs").c_str(), indicesArray );
+	}
+
+	variables.erase( sName );
+	variables.erase( tName );
 }
 
 AtNode *convertCommon( const IECore::MeshPrimitive *mesh )
 {
 
-	// make the result mesh and add topology
+	// Make the result mesh and add topology
 
 	AtNode *result = AiNode( "polymesh" );
 
@@ -87,7 +248,7 @@ AtNode *convertCommon( const IECore::MeshPrimitive *mesh )
 		AiArrayConvert( vertexIds.size(), 1, AI_TYPE_INT, (void *)&( vertexIds[0] ) )
 	);
 
-	// set subdivision
+	// Set subdivision
 
 	if( mesh->interpolation()=="catmullClark" )
 	{
@@ -95,68 +256,44 @@ AtNode *convertCommon( const IECore::MeshPrimitive *mesh )
 		AiNodeSetBool( result, "smoothing", true );
 	}
 
-	// add uvs
+	// Convert primitive variables. We start with indexed uvs,
+	// since those require matching sets of three variables.
+	// Each successful conversion removes the used variables
+	// so they are not used by the next potential conversion.
 
-	const FloatVectorData *s = mesh->variableData<FloatVectorData>( "s" );
-	const FloatVectorData *t = mesh->variableData<FloatVectorData>( "t" );
-	if( s && t )
+	PrimitiveVariableMap variablesToConvert = mesh->variables;
+	variablesToConvert.erase( "P" ); // These will be converted
+	variablesToConvert.erase( "N" ); // outside of this function.
+
+	// Convert and remove indexed UVs first.
+	for( PrimitiveVariableMap::iterator it = variablesToConvert.begin(), eIt = variablesToConvert.end(); it != eIt; ++it )
 	{
-		PrimitiveVariable::Interpolation sInterpolation = mesh->variables.find( "s" )->second.interpolation;
-		PrimitiveVariable::Interpolation tInterpolation = mesh->variables.find( "t" )->second.interpolation;
-		if( sInterpolation == tInterpolation )
+		if( boost::ends_with( it->first, "Indices" ) )
 		{
-			if( sInterpolation == PrimitiveVariable::Varying || sInterpolation == PrimitiveVariable::Vertex || sInterpolation == PrimitiveVariable::FaceVarying )
-			{
-				// interleave the uvs and set them
-				vector<float> st;
-				st.reserve( s->readable().size() * 2 );
-				for( vector<float>::const_iterator sIt = s->readable().begin(), tIt = t->readable().begin(), eIt = s->readable().end(); sIt != eIt; sIt++, tIt++ )
-				{
-					st.push_back( *sIt );
-					st.push_back( 1.0f - *tIt );
-				}
-				AiNodeSetArray(
-					result,
-					"uvlist",
-					AiArrayConvert( s->readable().size(), 1, AI_TYPE_POINT2, (void *)&(st[0]) )
-				);
-				// build uv indices
-				if( sInterpolation == PrimitiveVariable::FaceVarying )
-				{
-					AiNodeSetArray(
-						result,
-						"uvidxs",
-						faceVaryingIndices( mesh )
-					);
-				}
-				else
-				{
-					AiNodeSetArray(
-						result,
-						"uvidxs",
-						AiArrayConvert( vertexIds.size(), 1, AI_TYPE_INT, (void *)&( vertexIds[0] ) )
-					);
-				}
-			}
-			else
-			{
-				msg( Msg::Warning, "ToArnoldMeshConverter::doConversion", "Variables s and t have unsupported interpolation type - not generating uvs." );
-			}
-		}
-		else
-		{
-			msg( Msg::Warning, "ToArnoldMeshConverter::doConversion", "Variables s and t have different interpolation - not generating uvs." );
+			convertIndexedUVSet(
+				it->first == "stIndices" ? "" : it->first.substr( 0, it->first.size() - 7 ),
+				variablesToConvert, result
+			);
 		}
 	}
-	else if( s || t )
+
+	// Then convert and remove non-indexed uvs.
+	for( PrimitiveVariableMap::iterator it = variablesToConvert.begin(), eIt = variablesToConvert.end(); it != eIt; ++it )
 	{
-		msg( Msg::Warning, "ToArnoldMeshConverter::doConversion", "Only one of s and t available - not generating uvs." );
+		if( it->first == "s" || boost::ends_with( it->first, "_s" ) )
+		{
+			convertUVSet(
+				it->first == "s" ? "" : it->first.substr( 0, it->first.size() - 2 ),
+				variablesToConvert, vertexIds, result
+			);
+		}
 	}
 
-	// add arbitrary user parameters
-
-	const char *ignore[] = { "P", "s", "t", "stIndices", "N", 0 };
-	ShapeAlgo::convertPrimitiveVariables( mesh, result, ignore );
+	// Finally, do a generic conversion of anything that remains.
+	for( PrimitiveVariableMap::iterator it = variablesToConvert.begin(), eIt = variablesToConvert.end(); it != eIt; ++it )
+	{
+		ShapeAlgo::convertPrimitiveVariable( mesh, it->second, result, ( "user:" + it->first ).c_str() );
+	}
 
 	return result;
 }
@@ -200,7 +337,7 @@ void convertNormalIndices( const IECore::MeshPrimitive *mesh, AtNode *node, Prim
 		AiNodeSetArray(
 			node,
 			"nidxs",
-			faceVaryingIndices( mesh )
+			identityIndices( mesh->variableSize( PrimitiveVariable::FaceVarying ) )
 		);
 	}
 	else

--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -53,6 +53,16 @@ using namespace IECoreArnold;
 namespace
 {
 
+AtArray *identityIndices( size_t size )
+{
+	AtArray *result = AiArrayAllocate( size, 1, AI_TYPE_UINT );
+	for( size_t i=0; i < size; ++i )
+	{
+		AiArraySetInt( result, i, i );
+	}
+	return result;
+}
+
 ConstFloatVectorDataPtr radius( const Primitive *primitive )
 {
 	if( ConstFloatVectorDataPtr radius = primitive->variableData<FloatVectorData>( "radius" ) )
@@ -196,6 +206,10 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 		{
 			typeString = "varying ";
 		}
+		else if( primitiveVariable.interpolation == PrimitiveVariable::FaceVarying )
+		{
+			typeString = "indexed ";
+		}
 
 		if( typeString == "" )
 		{
@@ -213,6 +227,14 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 		if( array )
 		{
 			AiNodeSetArray( shape, name, array );
+			if( primitiveVariable.interpolation == PrimitiveVariable::FaceVarying )
+			{
+				AiNodeSetArray(
+					shape,
+					(name + string("idxs")).c_str(),
+					identityIndices( array->nelements )
+				);
+			}
 		}
 		else
 		{

--- a/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
@@ -115,6 +115,30 @@ class MeshTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetFlt( a, i ), i )
 				self.assertEqual( arnold.AiArrayGetVec( v, i ), i )
 
+	def testFaceVaryingPrimitiveVariables( self ) :
+
+		m = IECore.MeshPrimitive.createPlane(
+			IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ),
+			IECore.V2i( 2 ),
+		)
+		self.assertEqual( m.variableSize( IECore.PrimitiveVariable.Interpolation.FaceVarying ), 16 )
+
+		m["myPrimVar"] = IECore.PrimitiveVariable(
+			IECore.PrimitiveVariable.Interpolation.FaceVarying,
+			IECore.FloatVectorData( range( 0, 16 ) )
+		)
+
+		with IECoreArnold.UniverseBlock() :
+
+			n = IECoreArnold.NodeAlgo.convert( m )
+			a = arnold.AiNodeGetArray( n, "user:myPrimVar" )
+			ia = arnold.AiNodeGetArray( n, "user:myPrimVaridxs" )
+			self.assertEqual( a.contents.nelements, 16 )
+			self.assertEqual( ia.contents.nelements, 16 )
+			for i in range( 0, 16 ) :
+				self.assertEqual( arnold.AiArrayGetFlt( a, i ), i )
+				self.assertEqual( arnold.AiArrayGetUInt( ia, i ), i )
+
 	def testMotion( self ) :
 
 		m1 = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )

--- a/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
@@ -65,6 +65,30 @@ class MeshTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetPnt2( uvs, i ), arnold.AtPoint2( s[i], 1 - t[i] ) )
 				self.assertEqual( arnold.AiArrayGetInt( uvIndices, i ), i )
 
+	def testAdditionalUVs( self ) :
+
+		m = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		m["myMap_s"] = m["s"]
+		m["myMap_t"] = m["t"]
+		s, t = m["s"].data, m["t"].data
+
+
+		with IECoreArnold.UniverseBlock() :
+
+			n = IECoreArnold.NodeAlgo.convert( m )
+
+			uvs = arnold.AiNodeGetArray( n, "myMap" )
+			self.assertEqual( uvs.contents.nelements, 4 )
+
+			uvIndices = arnold.AiNodeGetArray( n, "myMapidxs" )
+			self.assertEqual( uvIndices.contents.nelements, 4 )
+
+			for i in range( 0, 4 ) :
+				p = arnold.AiArrayGetPnt2( uvs, i )
+				self.assertEqual( arnold.AiArrayGetPnt2( uvs, i ), arnold.AtPoint2( s[i], 1 - t[i] ) )
+				self.assertEqual( arnold.AiArrayGetInt( uvIndices, i ), i )
+
+
 	def testNormals( self ) :
 
 		r = IECoreArnold.Renderer()


### PR DESCRIPTION
This adds support for facevarying primitive variables, additional uv sets, and fixes problems with texture coordinate interpolation. One thing I'm not sure on is the naming of the additional UV sets. When we add arbitrary primitive variables in ShapeAlgo, we prefix everything with "user:" to avoid clashes with build in parameters on the Arnold node. I didn't do that for the UV sets, but maybe I should have?