### PR TITLE
Improved PointsPrimitive support in IECoreArnold

### DIFF
--- a/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
@@ -141,15 +141,29 @@ class PointsTest( unittest.TestCase ) :
 	def testUniformPrimitiveVariable( self ) :
 
 		p = IECore.PointsPrimitive( IECore.V3fVectorData( 10 ) )
-		p["myPrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData( range( 0, 10 ) ) )
+		p["myPrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Uniform, IECore.IntData( 10 ) )
 
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
-			a = arnold.AiNodeGetArray( n, "user:myPrimVar" )
-			self.assertEqual( a.contents.nelements, 10 )
-			for i in range( 0, 10 ) :
-				self.assertEqual( arnold.AiArrayGetInt( a, i ), i )
+			self.assertEqual( arnold.AiNodeGetInt( n, "user:myPrimVar" ), 10 )
+
+	def testVertexPrimitiveVariable( self ) :
+
+		for interpolation in ( "Vertex", "Varying", "FaceVarying" ) :
+
+			p = IECore.PointsPrimitive( IECore.V3fVectorData( 10 ) )
+			p["myPrimVar"] = IECore.PrimitiveVariable( getattr( IECore.PrimitiveVariable.Interpolation, interpolation ), IECore.IntVectorData( range( 0, 10 ) ) )
+
+			self.assertTrue( p.arePrimitiveVariablesValid() )
+
+			with IECoreArnold.UniverseBlock() :
+
+				n = IECoreArnold.NodeAlgo.convert( p )
+				a = arnold.AiNodeGetArray( n, "user:myPrimVar" )
+				self.assertEqual( a.contents.nelements, 10 )
+				for i in range( 0, 10 ) :
+					self.assertEqual( arnold.AiArrayGetInt( a, i ), i )
 
 	def testBooleanPrimitiveVariable( self ) :
 

--- a/src/IECore/Primitive.cpp
+++ b/src/IECore/Primitive.cpp
@@ -257,6 +257,8 @@ bool Primitive::isPrimitiveVariableValid( const PrimitiveVariable &pv ) const
 	// SimpleTypedData should be accepted in the rare case that variableSize==1, but we're rejecting that
 	// argument on the grounds that it makes for a whole bunch of special cases with no gain - the general
 	// cases all require arrays so that's what we require.
+	/// \todo This is not correct in the case of CurvesPrimitives, where uniform interpolation should be
+	/// treated the same as constant.
 	size_t sz = variableSize( pv.interpolation );
 	ValidateArraySize func( sz );
 	return despatchTypedData<ValidateArraySize, TypeTraits::IsVectorTypedData, ReturnFalseErrorHandler>( pv.data.get(), func );


### PR DESCRIPTION
- Fixed broken treatment of uniform primitive variables on PointsPrimitives
- Added support for per-vertex primitive variables on PointsPrimitives
- Stopped outputting per-vertex CurvesPrimitive variables, since Arnold doesn't appear to support them