### PR TITLE
Curves primitive to maya converter

### DIFF
--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -36,6 +36,7 @@
 #define IE_COREMAYA_SCENESHAPEINTERFACE_H
 
 #include "IECore/SceneInterface.h"
+#include "IECore/CompoundParameter.h"
 
 #include <map>
 #include "OpenEXR/ImathMatrix.h"
@@ -146,6 +147,14 @@ class SceneShapeInterface: public MPxComponentShape
 		static MObject aQuerySpace;
 		static MObject aSceneQueries;
 		static MObject aAttributeQueries;
+		/// Read convert parameters.
+		/**
+		Some ToMaya*Converters have parameters to be used when converting objects.
+		In case of ToMayaCurveConverter, it takes an int parameter "index" that controls which one of curves it should convert to Maya nurbs curve.
+		queryConvertParameters lets you specify some of these paramters.
+		Converter parameters are updated with a string value held in aConvertParamQueries with IECore.ParameterParser.
+		**/
+		static MObject aConvertParamQueries;
 		
 		static MObject aAttributeValues;
 		
@@ -208,6 +217,8 @@ class SceneShapeInterface: public MPxComponentShape
 		Imath::Box3d componentBound( int idx );
 
 		void recurseCopyGroup( const IECoreGL::Group *srcGroup, IECoreGL::Group *trgGroup, const std::string &namePrefix );
+
+		bool readConvertParam( IECore::CompoundParameterPtr parameters, int attrIndex ) const;
 
 		typedef std::map< IECore::InternedString,  std::pair< unsigned int, IECoreGL::GroupPtr> > NameToGroupMap;
 		typedef std::vector< IECore::InternedString > IndexToNameMap;

--- a/mel/IECoreMaya/ieSceneShapeUI.mel
+++ b/mel/IECoreMaya/ieSceneShapeUI.mel
@@ -58,6 +58,7 @@ global proc AEieSceneShapeTemplate( string $nodeName )
 			editorTemplate -addControl "querySpace";
 			editorTemplate -addControl "queryPaths";
 			editorTemplate -addControl "queryAttributes";
+			editorTemplate -addControl "queryConvertParameters";
 			
 		editorTemplate -endLayout;
 		

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -38,6 +38,9 @@
 #include "IECore/TransformationMatrixData.h"
 #include "IECore/Primitive.h"
 #include "IECore/NullObject.h"
+#include "IECore/CurvesMergeOp.h"
+#include "IECore/MeshMergeOp.h"
+#include "IECore/MessageHandler.h"
 
 #include "IECoreMaya/LiveScene.h"
 #include "IECoreMaya/FromMayaPlugConverter.h"
@@ -47,6 +50,8 @@
 #include "IECoreMaya/FromMayaCameraConverter.h"
 #include "IECoreMaya/Convert.h"
 #include "IECoreMaya/SceneShape.h"
+#include "IECoreMaya/FromMayaCurveConverter.h"
+#include "IECoreMaya/FromMayaMeshConverter.h"
 
 #include "maya/MFnDagNode.h"
 #include "maya/MFnTransform.h"
@@ -512,6 +517,175 @@ void LiveScene::writeTags( const NameList &tags )
 	throw Exception( "IECoreMaya::LiveScene::writeTags not supported" );
 }
 
+
+namespace
+{
+
+template<int MFnType>
+struct PrimMergerTraits;
+
+template<>
+struct PrimMergerTraits<MFn::kNurbsCurve>
+{
+	typedef FromMayaCurveConverter ConverterType;
+	typedef CurvesMergeOp MergeOpType;
+	static CurvesPrimitiveParameter * primParameter( MergeOpType* mop )
+	{
+		return mop->curvesParameter();
+	}
+};
+
+template<>
+struct PrimMergerTraits<MFn::kMesh>
+{
+	typedef FromMayaMeshConverter ConverterType;
+	typedef MeshMergeOp MergeOpType;
+	static MeshPrimitiveParameter * primParameter( MergeOpType* mop )
+	{
+		return mop->meshParameter();
+	}
+};
+
+template<int MFnType>
+class PrimMerger
+{
+		typedef typename PrimMergerTraits<MFnType>::ConverterType ConverterType;
+		typedef typename PrimMergerTraits<MFnType>::MergeOpType MergeOpType;
+		typedef typename MergeOpType::PrimitiveType PrimitiveType;
+
+	public:
+
+		static void createMergeOp( MDagPath &childDag, IECore::ModifyOpPtr &op )
+		{
+			typename ConverterType::Ptr converter = runTimeCast<ConverterType>( ConverterType::create( childDag ) );
+			if( ! converter )
+			{
+				throw Exception( ( boost::format( "Creating merge op failed! " ) % childDag.fullPathName().asChar() ).str() );
+			}
+			typename PrimitiveType::Ptr cprim = runTimeCast<PrimitiveType>( converter->convert() );
+			op = new MergeOpType;
+			op->copyParameter()->setTypedValue( false );
+			op->inputParameter()->setValue( cprim );
+		}
+
+		static void mergePrim( MDagPath &childDag, IECore::ModifyOpPtr &op )
+		{
+			typename ConverterType::Ptr converter = runTimeCast<ConverterType>( ConverterType::create( childDag ) );
+			if( ! converter )
+			{
+				throw Exception( ( boost::format( "Merging primitive failed! " ) % childDag.fullPathName().asChar() ).str() );
+			}
+			typename PrimitiveType::Ptr prim = runTimeCast<PrimitiveType>( converter->convert() );
+			MergeOpType *mop = runTimeCast<MergeOpType>( op.get() );
+			PrimMergerTraits<MFnType>::primParameter( mop )->setValue( const_cast<PrimitiveType*>( prim.get() ) );
+			op->operate();
+		}
+
+};
+
+bool hasMergeableObjects( const MDagPath &p )
+{
+	// When there are multiple child shapes that can be merged, readMergedObject() returns an object that has all the shapes merged in it.
+	// This is because multiple Maya shapes can be converted to one IECore primitive eg. nurbs curves -> IECore::CurvesPrimitive.
+	// We want to have multiple shape nodes in Maya, and want it to be one primitive if viewed through IECoreMaya::LiveScene.
+	unsigned int childCount = p.childCount();
+
+	// At least two shapes need to exist to merge.
+	if( childCount < 2 )
+	{
+		return false;
+	}
+
+	bool isMergeable = false;
+	MFn::Type foundType = MFn::kInvalid;
+	for ( unsigned int c = 0; c < childCount; c++ )
+	{
+		MObject childObject = p.child( c );
+		MFn::Type type = childObject.apiType();
+
+		if( type == MFn::kMesh || type == MFn::kNurbsCurve )
+		{
+			if( MFnDagNode( childObject ).isIntermediateObject() )
+			{
+				continue;
+			}
+
+			if( foundType == MFn::kInvalid )
+			{
+				foundType = type;
+			}
+			else if( foundType == type )
+			{
+				isMergeable = true;
+			}
+			else
+			{
+				msg( Msg::Warning, p.fullPathName().asChar(), "Found multiple shape types under the same transform!" );
+				return false;
+			}
+		}
+	}
+
+	return isMergeable;
+
+}
+
+ConstObjectPtr readMergedObject( const MDagPath &p )
+{
+	unsigned int childCount = p.childCount();
+
+	IECore::ModifyOpPtr op = NULL;
+
+	for ( unsigned int c = 0; c < childCount; c++ )
+	{
+		MObject childObject = p.child( c );
+		MFn::Type type = childObject.apiType();
+
+		if( type != MFn::kNurbsCurve && type != MFn::kMesh )
+		{
+			continue;
+		}
+
+		MFnDagNode fnChildDag( childObject );
+		if( fnChildDag.isIntermediateObject() )
+		{
+			continue;
+		}
+
+		MDagPath childDag;
+		fnChildDag.getPath( childDag );
+
+		if( ! op )
+		{
+			if( type == MFn::kNurbsCurve )
+			{
+				PrimMerger<MFn::kNurbsCurve>::createMergeOp( childDag, op );
+			}
+			else
+			{
+				PrimMerger<MFn::kMesh>::createMergeOp( childDag, op );
+			}
+		}
+		else
+		{
+			if( type == MFn::kNurbsCurve )
+			{
+				PrimMerger<MFn::kNurbsCurve>::mergePrim( childDag, op );
+			}
+			else
+			{
+				PrimMerger<MFn::kMesh>::mergePrim( childDag, op );
+			}
+		}
+
+	}
+
+	assert( op );
+	return op->inputParameter()->getValue();
+}
+
+} // anonymous namespace.
+
 bool LiveScene::hasObject() const
 {
 	tbb::mutex::scoped_lock l( s_mutex );
@@ -523,6 +697,11 @@ bool LiveScene::hasObject() const
 	else if( m_dagPath.length() == 0 && !m_isRoot )
 	{
 		throw Exception( "IECoreMaya::LiveScene::hasObject: Dag path no longer exists!" );
+	}
+
+	if( hasMergeableObjects( m_dagPath ) )
+	{
+		return true;
 	}
 
 	for ( std::vector< CustomReader >::const_reverse_iterator it = customObjectReaders().rbegin(); it != customObjectReaders().rend(); it++ )
@@ -577,6 +756,11 @@ ConstObjectPtr LiveScene::readObject( double time ) const
 	if( fabs( MAnimControl::currentTime().as( MTime::kSeconds ) - time ) > 1.e-4 )
 	{
 		throw Exception( "IECoreMaya::LiveScene::readObject: time must be the same as on the maya timeline!" );
+	}
+
+	if ( hasMergeableObjects( m_dagPath ) )
+	{
+		return readMergedObject( m_dagPath );
 	}
 
 	for ( std::vector< CustomReader >::const_reverse_iterator it = customObjectReaders().rbegin(); it != customObjectReaders().rend(); it++ )

--- a/src/IECoreMaya/ToMayaMeshConverter.cpp
+++ b/src/IECoreMaya/ToMayaMeshConverter.cpp
@@ -39,6 +39,7 @@
 #include "maya/MDagPath.h"
 #include "maya/MFnMeshData.h"
 #include "maya/MFnMesh.h"
+#include "maya/MFnDependencyNode.h"
 #include "maya/MPointArray.h"
 #include "maya/MFloatPointArray.h"
 #include "maya/MFloatVectorArray.h"
@@ -486,7 +487,7 @@ bool ToMayaMeshConverter::doConversion( IECore::ConstObjectPtr from, MObject &to
 bool ToMayaMeshConverter::setMeshInterpolationAttribute( MObject &object, std::string interpolation )
 {
 	MStatus st;
-	MFnMesh fnMesh(object, &st);
+	MFnDependencyNode fnDep(object, &st);
 	if ( !st )
 	{
 		return false;
@@ -516,7 +517,7 @@ bool ToMayaMeshConverter::setMeshInterpolationAttribute( MObject &object, std::s
 		}
 	}
 
-	MPlug interpPlug = fnMesh.findPlug( "ieMeshInterpolation", &st );
+	MPlug interpPlug = fnDep.findPlug( "ieMeshInterpolation", &st );
 	
 	if ( !st )
 	{
@@ -539,12 +540,12 @@ bool ToMayaMeshConverter::setMeshInterpolationAttribute( MObject &object, std::s
 		}
 
 		// looks like the attribute does not exist yet..
-		st = fnMesh.addAttribute( newAttr );
+		st = fnDep.addAttribute( newAttr );
 		if ( !st )
 		{
 			return false;
 		}
-		interpPlug = fnMesh.findPlug( "ieMeshInterpolation", &st );
+		interpPlug = fnDep.findPlug( "ieMeshInterpolation", &st );
 		if ( !st )
 		{
 			return false;

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -313,7 +313,49 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		
 		fn.selectComponentNames( ['/', '/1', '/1/child/3'] )
 		self.assertEqual( fn.selectedComponentNames(), set( ['/', '/1', '/1/child/3'] ) )
+
+	def testQuery( self ):
 		
+		maya.cmds.file( new=True, f=True )
+
+		def createSceneFile():
+		    scene = IECore.SceneCache( FnSceneShapeTest.__testFile, IECore.IndexedIO.OpenMode.Write )
+		    sc = scene.createChild( str(1) )
+		    curves = IECore.CurvesPrimitive.createBox(IECore.Box3f(IECore.V3f(0),IECore.V3f(1))) # 6 curves.
+		    sc.writeObject( curves, 0.0 )
+		    matrix = IECore.M44d.createTranslated( IECore.V3d( 0, 0, 0 ) )
+		    sc.writeTransform( IECore.M44dData( matrix ), 0.0 )
+
+		createSceneFile()
+
+		node = maya.cmds.createNode( "ieSceneShape" )
+		maya.cmds.setAttr( node+'.file', FnSceneShapeTest.__testFile,type='string' )
+		maya.cmds.setAttr( node+'.root', '/',type='string' )
+		fn = IECoreMaya.FnSceneShape( node )
+
+		self.assertEqual( maya.cmds.getAttr(fn.fullPathName()+".outObjects[0]", type=True), None )
+		self.assertEqual( maya.cmds.getAttr(fn.fullPathName()+".outObjects[1]", type=True), None )
+
+		maya.cmds.setAttr( fn.fullPathName()+".queryPaths[0]" , "/1", type="string")
+		maya.cmds.setAttr( fn.fullPathName()+".queryPaths[1]" , "/1", type="string")
+
+		maya.cmds.setAttr( fn.fullPathName()+".queryConvertParameters[0]", "-index 0", type="string" ) # Set it to output 0 th box curve.
+		maya.cmds.setAttr( fn.fullPathName()+".queryConvertParameters[1]", "-index 1", type="string" ) # Set it to output 1 th box curve.
+
+		self.assertEqual( maya.cmds.getAttr(fn.fullPathName()+".outObjects[0]", type=True), "nurbsCurve" )
+		self.assertEqual( maya.cmds.getAttr(fn.fullPathName()+".outObjects[1]", type=True), "nurbsCurve" )
+
+		curveShape0 = maya.cmds.createNode( "nurbsCurve" )
+		curveShape1 = maya.cmds.createNode( "nurbsCurve" )
+		maya.cmds.connectAttr( fn.fullPathName()+ ".outObjects[0]", curveShape0 + '.create' )
+		maya.cmds.connectAttr( fn.fullPathName()+ ".outObjects[1]", curveShape1 + '.create' )
+
+		self.assertNotEqual( maya.cmds.pointPosition(curveShape0 + '.cv[0]' ), maya.cmds.pointPosition(curveShape1 + '.cv[0]' ) )
+
+		maya.cmds.setAttr( fn.fullPathName()+".queryConvertParameters[1]", "-index 0", type="string" )
+
+		self.assertEqual( maya.cmds.pointPosition(curveShape0 + '.cv[0]' ), maya.cmds.pointPosition(curveShape1 + '.cv[0]' ) )
+
 	def tearDown( self ) :
 		
 		if os.path.exists( FnSceneShapeTest.__testFile ) :

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -990,6 +990,43 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		maya.cmds.setAttr( envShape + ".visibility", False )
 		self.assertEqual( envScene.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 	
+	def testMultiCurves( self ) :
+
+		maya.cmds.createNode( "transform", name="sharedParent" )
+
+		maya.cmds.curve( d=1, p=[ ( 0, 0, 0 ), ( 1, 0, 0 ) ], k=( 0, 1 ), n="curve1" )
+		maya.cmds.curve( d=1, p=[ ( 0, 0, 0 ), ( 0, 0, 1 ) ], k=( 0, 1 ), n="curve2" )
+		maya.cmds.curve( d=1, p=[ ( 0, 0, 0 ), ( 0, 0, 1 ) ], k=( 0, 1 ), n="curve2" )
+
+		maya.cmds.select( "curveShape1", "curveShape2", "curveShape3", "sharedParent")
+		maya.cmds.parent( s=True, r=True )
+
+		maya.cmds.setAttr( "curveShape3.intermediateObject", 1 )
+
+		scene = IECoreMaya.LiveScene()
+		scene = scene.child('sharedParent')
+		maya.cmds.currentTime( "0.0sec" )
+		mergedCurves = scene.readObject( 0 )
+		self.assertEqual( mergedCurves.numCurves(), 2 )
+
+	def testMultiMeshes( self ) :
+
+		maya.cmds.createNode( "transform", name="sharedParent" )
+
+		maya.cmds.polyPyramid()
+		maya.cmds.polyPyramid()
+		maya.cmds.polyPyramid()
+
+		maya.cmds.select( "pPyramidShape1", "pPyramidShape2", "pPyramidShape3", "sharedParent" )
+		maya.cmds.parent( s=True, r=True )
+
+		maya.cmds.setAttr( "pPyramidShape3.intermediateObject", 1 )
+
+		scene = IECoreMaya.LiveScene()
+		scene = scene.child('sharedParent')
+		maya.cmds.currentTime( "0.0sec" )
+		mergedMeshes = scene.readObject( 0 )
+		self.assertEqual( mergedMeshes.numFaces(), 10 )
 	
 if __name__ == "__main__":
 	IECoreMaya.TestProgram( plugins = [ "ieCore" ] )


### PR DESCRIPTION
A bunch of modifications to convert CurvesPrimitive from/to maya shapes. In the Maya scene curves converted from a single CurvesPrimitive share the same transform parent.

**SceneShape node**:

To have ieSceneShape node output different curves in a CurvesPrimitive, a new query attribute "queryConvertParameters" was created.

script to for outObjects[ i ] to output j's curve of the CurvesPrimitive is,
  maya.cmds.setAttr( "mySceneShape.queryConvertParameters[ i ]", "-index %d" % j, type="string" )
You also need to set a valid path to the i'th queryPaths element.

**IECoreMaya::LiveScene**:

If there are more than one curve found in a parent, it merges them using CurvesMergeOp.

**FnSceneShape.convertObjectToGeometry**:

It creates multiple curve shapes using the new queryConvertParameters query attribute.

**Confirm dialog for the user**:

If the user tries to convert more than SceneShapeUI.minimumExpandConfirmCount (==1000) geometries, a confirm dialog pops up.
