### PR TITLE
MeshAlgo, ShapeAlgo, ParameterAlgo: support Pref in Arnold

### DIFF
--- a/contrib/IECoreArnold/include/IECoreArnold/ParameterAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/ParameterAlgo.h
@@ -62,6 +62,7 @@ IECOREARNOLD_API void getParameters( AtNode *node, IECore::CompoundDataMap &valu
 /// or false depending on whether or not the Arnold type will be an
 /// array. Returns AI_TYPE_NONE if there is no suitable Arnold type.
 IECOREARNOLD_API int parameterType( IECore::TypeId dataType, bool &array );
+IECOREARNOLD_API int parameterType( const IECore::Data *data, bool &array );
 
 /// If the equivalent Arnold type for the data is already known, then it may be passed directly.
 /// If not it will be inferred using parameterType().

--- a/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
@@ -301,7 +301,7 @@ AtNode *convertCommon( const IECore::MeshPrimitive *mesh )
 	// Finally, do a generic conversion of anything that remains.
 	for( PrimitiveVariableMap::iterator it = variablesToConvert.begin(), eIt = variablesToConvert.end(); it != eIt; ++it )
 	{
-		ShapeAlgo::convertPrimitiveVariable( mesh, it->second, result, ( "user:" + it->first ).c_str() );
+		ShapeAlgo::convertPrimitiveVariable( mesh, it->second, result, it->first.c_str() );
 	}
 
 	return result;

--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -37,7 +37,7 @@
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 #include "IECore/DespatchTypedData.h"
-
+#include "IECore/DataAlgo.h"
 #include "IECoreArnold/ParameterAlgo.h"
 
 using namespace std;
@@ -403,6 +403,23 @@ int parameterType( IECore::TypeId dataType, bool &array )
 		default :
 			return AI_TYPE_NONE;
 	}
+}
+
+int parameterType( const IECore::Data *data, bool &array )
+{
+	int type = parameterType( data->typeId(), array );
+
+	// if we have data of type vector, its interpretation matters
+	if( type == AI_TYPE_VECTOR )
+	{
+		GeometricData::Interpretation interpretation = getGeometricInterpretation( data );
+		if( interpretation == GeometricData::Point )
+		{
+			type = AI_TYPE_POINT;
+		}
+	}
+
+	return type;
 }
 
 AtArray *dataToArray( const IECore::Data *data, int aiType )

--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -306,11 +306,7 @@ void convertPrimitiveVariables( const IECore::Primitive *primitive, AtNode *shap
 			}
 		}
 
-		// we prefix all the names, as otherwise the chance of a conflict between
-		// an arbitrary primitive variable name and an existing arnold parameter name
-		// seems too great.
-		string prefixedName = "user:" + it->first;
-		convertPrimitiveVariable( primitive, it->second, shape, prefixedName.c_str() );
+		convertPrimitiveVariable( primitive, it->second, shape, it->first.c_str() );
 	}
 }
 

--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -181,7 +181,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 	if ( AiNodeEntryLookUpParameter(	entry, name ) != NULL ){
 		msg(
 			Msg::Warning,
-			"ToArnoldShapeConverter::convertPrimitiveVariable",
+			"ShapeAlgo::convertPrimitiveVariable",
 			boost::format( "Primitive variable \"%s\" will be ignored because it clashes with Arnold's built-in parameters" ) % name
 		);
 		return;
@@ -229,7 +229,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 	{
 		msg(
 			Msg::Warning,
-			"ToArnoldShapeConverter::convertPrimitiveVariable",
+			"ShapeAlgo::convertPrimitiveVariable",
 			boost::format( "Unable to create user parameter \"%s\" because primitive variable has unsupported interpolation" ) % name
 		);
 		return;
@@ -265,7 +265,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 	{
 		msg(
 			Msg::Warning,
-			"ToArnoldShapeConverter::convertPrimitiveVariable",
+			"ShapeAlgo::convertPrimitiveVariable",
 			boost::format( "Unable to create user parameter \"%s\" for primitive variable of type \"%s\"" ) % name % primitiveVariable.data->typeName()
 		);
 		return;
@@ -290,7 +290,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 	{
 		msg(
 			Msg::Warning,
-			"ToArnoldShapeConverter::convertPrimitiveVariable",
+			"ShapeAlgo::convertPrimitiveVariable",
 			boost::format( "Failed to create array for parameter \"%s\" from data of type \"%s\"" ) % name % primitiveVariable.data->typeName()
 		);
 	}

--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -176,6 +176,17 @@ void convertRadius( const std::vector<const IECore::Primitive *> &samples, AtNod
 void convertPrimitiveVariable( const IECore::Primitive *primitive, const PrimitiveVariable &primitiveVariable, AtNode *shape, const char *name )
 {
 
+	// make sure the primitive variable doesn't clash with built-ins
+	const AtNodeEntry *entry = AiNodeGetNodeEntry( shape );
+	if ( AiNodeEntryLookUpParameter(	entry, name ) != NULL ){
+		msg(
+			Msg::Warning,
+			"ToArnoldShapeConverter::convertPrimitiveVariable",
+			boost::format( "Primitive variable \"%s\" will be ignored because it clashes with Arnold's built-in parameters" ) % name
+		);
+		return;
+	}
+
 	// Arnold has "constant", "uniform", "varying" and "indexed" interpolation,
 	// whereas Cortex has Constant, Uniform, Varying, Vertex and FaceVarying.
 	// The conversion between the two depends on the type of the primitive.

--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -249,7 +249,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 	// Now deal with more complex cases with array data.
 
 	bool isArray = false;
-	int type = ParameterAlgo::parameterType( primitiveVariable.data->typeId(), isArray );
+	int type = ParameterAlgo::parameterType( primitiveVariable.data.get(), isArray );
 	if( type == AI_TYPE_NONE || !isArray )
 	{
 		msg(
@@ -262,7 +262,7 @@ void convertPrimitiveVariable( const IECore::Primitive *primitive, const Primiti
 
 	std::string typeString = arnoldInterpolation + " " + AiParamGetTypeName( type );
 	AiNodeDeclare( shape, name, typeString.c_str() );
-	AtArray *array = ParameterAlgo::dataToArray( primitiveVariable.data.get() );
+	AtArray *array = ParameterAlgo::dataToArray( primitiveVariable.data.get(), type );
 	if( array )
 	{
 		AiNodeSetArray( shape, name, array );

--- a/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
@@ -123,7 +123,7 @@ class PointsTest( unittest.TestCase ) :
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
-			self.assertEqual( arnold.AiNodeGetInt( n, "user:myPrimVar" ), 10 )
+			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
 
 	def testConstantArrayPrimitiveVariable( self ) :
 
@@ -133,7 +133,7 @@ class PointsTest( unittest.TestCase ) :
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
-			a = arnold.AiNodeGetArray( n, "user:myPrimVar" )
+			a = arnold.AiNodeGetArray( n, "myPrimVar" )
 			self.assertEqual( a.contents.nelements, 10 )
 			for i in range( 0, 10 ) :
 				self.assertEqual( arnold.AiArrayGetInt( a, i ), i )
@@ -146,7 +146,7 @@ class PointsTest( unittest.TestCase ) :
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
-			self.assertEqual( arnold.AiNodeGetInt( n, "user:myPrimVar" ), 10 )
+			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
 
 	def testVertexPrimitiveVariable( self ) :
 
@@ -160,7 +160,7 @@ class PointsTest( unittest.TestCase ) :
 			with IECoreArnold.UniverseBlock() :
 
 				n = IECoreArnold.NodeAlgo.convert( p )
-				a = arnold.AiNodeGetArray( n, "user:myPrimVar" )
+				a = arnold.AiNodeGetArray( n, "myPrimVar" )
 				self.assertEqual( a.contents.nelements, 10 )
 				for i in range( 0, 10 ) :
 					self.assertEqual( arnold.AiArrayGetInt( a, i ), i )
@@ -174,8 +174,8 @@ class PointsTest( unittest.TestCase ) :
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
-			self.assertEqual( arnold.AiNodeGetBool( n, "user:truePrimVar" ), True )
-			self.assertEqual( arnold.AiNodeGetBool( n, "user:falsePrimVar" ), False )
+			self.assertEqual( arnold.AiNodeGetBool( n, "truePrimVar" ), True )
+			self.assertEqual( arnold.AiNodeGetBool( n, "falsePrimVar" ), False )
 
 	def testMotion( self ) :
 

--- a/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
@@ -81,15 +81,15 @@ class SphereAlgoTest( unittest.TestCase ) :
 		with IECoreArnold.UniverseBlock() :
 
 			n = IECoreArnold.NodeAlgo.convert( s )
-			self.assertEqual( arnold.AiNodeGetVec( n, "user:v" ), arnold.AtVector( 1, 2, 3 ) )
-			self.assertEqual( arnold.AiNodeGetRGB( n, "user:c" ), arnold.AtColor( 1, 2, 3 ) )
-			self.assertEqual( arnold.AiNodeGetStr( n, "user:s" ), "test" )
-			self.assertEqual( arnold.AiNodeGetInt( n, "user:i" ), 11 )
-			self.assertEqual( arnold.AiNodeGetBool( n, "user:b" ), True )
-			self.assertEqual( arnold.AiNodeGetFlt( n, "user:f" ), 2.5 )
+			self.assertEqual( arnold.AiNodeGetVec( n, "v" ), arnold.AtVector( 1, 2, 3 ) )
+			self.assertEqual( arnold.AiNodeGetRGB( n, "c" ), arnold.AtColor( 1, 2, 3 ) )
+			self.assertEqual( arnold.AiNodeGetStr( n, "s" ), "test" )
+			self.assertEqual( arnold.AiNodeGetInt( n, "i" ), 11 )
+			self.assertEqual( arnold.AiNodeGetBool( n, "b" ), True )
+			self.assertEqual( arnold.AiNodeGetFlt( n, "f" ), 2.5 )
 
 			m = arnold.AtMatrix()
-			arnold.AiNodeGetMatrix( n, "user:m", m )
+			arnold.AiNodeGetMatrix( n, "m", m )
 			self.assertEqual(
 				[ getattr( m, f[0] ) for f in m._fields_ ],
 				[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 ],


### PR DESCRIPTION
In order to support Pref for Arnold, we need to remove the 'user:'
prefix and be able to distinguish between vector and point types.

Hey @johnhaddon, Is this roughly what you had in mind when we talked about it in Shotgun? I'll add the 'onHold' label because I should probably change a whole bunch of tests that seem to use the prefix.