### PR TITLE
IECore::Camera : Added support for negative clipping planes

### DIFF
--- a/src/IECore/Camera.cpp
+++ b/src/IECore/Camera.cpp
@@ -303,16 +303,10 @@ void Camera::addStandardParameters()
 	}
 
 	// clipping planes
-	V2f clippingPlanes( -1.0f );
 	CompoundDataMap::const_iterator clippingIt=parameters().find( "clippingPlanes" );
-	if( clippingIt != parameters().end() && clippingIt->second->isInstanceOf( V2fDataTypeId ) )
+	if( !( clippingIt != parameters().end() && clippingIt->second->isInstanceOf( V2fDataTypeId ) ) )
 	{
-		clippingPlanes = boost::static_pointer_cast<V2fData>( clippingIt->second )->readable();
-	}
-	if( clippingPlanes[0] < 0.0f || clippingPlanes[1] < 0.0f )
-	{
-		clippingPlanes = V2f( 0.01f, 100000.0f );
-		parameters()["clippingPlanes"] = new V2fData( clippingPlanes );
+		parameters()["clippingPlanes"] = new V2fData( V2f( 0.01f, 100000.0f ) );
 	}
 
 	// shutter

--- a/test/IECore/Camera.py
+++ b/test/IECore/Camera.py
@@ -104,6 +104,12 @@ class TestCamera( unittest.TestCase ) :
 		self.assertEqual( c.parameters()["clippingPlanes"].value, V2f( 1, 1000 ) )
 		self.assertEqual( c.parameters()["shutter"].value, V2f( 1, 2 ) )
 
+		# Negative clip planes on ortho cameras should be supported
+		c = Camera()
+		c.parameters()["clippingPlanes"] = V2fData( V2f( -1000, 1000 ) )
+		c.addStandardParameters()
+		self.assertEqual( c.parameters()["clippingPlanes"].value, V2f( -1000, 1000 ) )
+
 	def testHash( self ) :
 	
 		c = Camera()


### PR DESCRIPTION
For ortho cameras, it totally makes sense to request a negative clip plane, so it doesn't seem like we should always reject negative values.