### PR TITLE
added 'tx' support for IECore.TIFFImageReader

### DIFF
--- a/src/IECore/TIFFImageReader.cpp
+++ b/src/IECore/TIFFImageReader.cpp
@@ -64,7 +64,7 @@ using namespace std;
 
 IE_CORE_DEFINERUNTIMETYPED( TIFFImageReader );
 
-const Reader::ReaderDescription<TIFFImageReader> TIFFImageReader::m_readerDescription("tiff tif tdl");
+const Reader::ReaderDescription<TIFFImageReader> TIFFImageReader::m_readerDescription("tiff tif tdl tx");
 
 TIFFImageReader::TIFFImageReader()
 		:	ImageReader( "Reads Tagged Image File Format (TIFF) files" ),

--- a/test/IECore/Reader.py
+++ b/test/IECore/Reader.py
@@ -43,11 +43,11 @@ class TestReader(unittest.TestCase):
 		for ee in e :
 			self.assert_( type( ee ) is str )
 
-		expectedExtensions = [ "exr", "pdc", "cin", "dpx", "cob", "sgi", "bw", "rgba", "rgb", "tdl" ]
+		expectedExtensions = [ "exr", "pdc", "cin", "dpx", "cob", "sgi", "bw", "rgba", "rgb" ]
 		if IECore.withASIO() :
 			expectedExtensions += [ "obj" ]
 		if IECore.withTIFF() :
-			expectedExtensions += [ "tif", "tiff" ]
+			expectedExtensions += [ "tif", "tiff", "tdl", "tx" ]
 		if IECore.withJPEG() :
 			expectedExtensions += [ "jpg", "jpeg" ]
 		if IECore.withPNG() :
@@ -59,9 +59,9 @@ class TestReader(unittest.TestCase):
 		e = IECore.Reader.supportedExtensions( IECore.TypeId.ImageReader )
 		for ee in e :
 			self.assert_( type( ee ) is str )
-		expectedImageReaderExtensions = [ "exr", "cin", "dpx", "sgi", "bw", "rgba", "rgb", "tdl", "tga" ]
+		expectedImageReaderExtensions = [ "exr", "cin", "dpx", "sgi", "bw", "rgba", "rgb", "tga" ]
 		if IECore.withTIFF() :
-			expectedImageReaderExtensions += [ "tif", "tiff" ]
+			expectedImageReaderExtensions += [ "tif", "tiff" , "tdl", "tx"]
 		if IECore.withJPEG() :
 			expectedImageReaderExtensions += [ "jpg", "jpeg" ]
 		if IECore.withPNG() :


### PR DESCRIPTION
#### core
- [#528]TIFFImageReader:
 - We need support for 'tx' file format when using Arnold.
Since it's just another wrapping for Tiff file format,
doing the same trick than for 'tdl' seems to work fine.