### PR TITLE
ParameterAlgo: add manual conversion from BoolVectorData to AtArray.

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -441,6 +441,19 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 			return NULL;
 		}
 	}
+	// bools are a special case because of how the STL implements vector<bool>.
+	// Since the base for vector<bool> are not actual booleans, we need to manually
+	// convert to an AtArray here.
+	else if( aiType == AI_TYPE_BOOLEAN )
+	{
+		const vector<bool> &booleans = static_cast<const BoolVectorData *>( data )->readable();
+		vector<bool>::size_type booleansSize = booleans.size();
+		AtArray* array = AiArrayAllocate( booleansSize, 1, AI_TYPE_BOOLEAN );
+		for(vector<bool>::size_type i = 0; i < booleansSize; ++i){
+			AiArraySetBool(array, i, booleans[i]);
+		}
+		return array;
+	}
 
 	const void *dataAddress = despatchTypedData<TypedDataAddress, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( data ) );
 	size_t dataSize = despatchTypedData<TypedDataSize, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( data ) );

--- a/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
@@ -243,6 +243,24 @@ class MeshTest( unittest.TestCase ) :
 			v = arnold.AiNodeGetArray( node, "vectors" )
 			self.assertEqual( v.contents.type, arnold.AI_TYPE_VECTOR )
 
+	def testBoolVectorPrimitiveVariables( self ) :
+
+		m = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
+		m["myBoolPrimVar"] = IECore.PrimitiveVariable(
+			IECore.PrimitiveVariable.Interpolation.Vertex,
+			IECore.BoolVectorData( [ True, False, True, False ] )
+		)
+
+		with IECoreArnold.UniverseBlock() :
+
+			n = IECoreArnold.NodeAlgo.convert( m )
+			a = arnold.AiNodeGetArray( n, "myBoolPrimVar" )
+
+			self.assertEqual( a.contents.nelements, 4 )
+			self.assertEqual( arnold.AiArrayGetBool( a, 0 ), True )
+			self.assertEqual( arnold.AiArrayGetBool( a, 1 ), False )
+			self.assertEqual( arnold.AiArrayGetBool( a, 2 ), True )
+			self.assertEqual( arnold.AiArrayGetBool( a, 3 ), False )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hey John,

I assume you had something like this in mind regarding the conversion from BoolVectorData to AtArray? The corresponding function that deals with motion samples should already work if I interpret the despatchTypedData calls correctly?

Thanks,

Matti.