### PR TITLE
DisplayDriverServer : Support automatic selection of free port.

### DIFF
--- a/include/IECore/DisplayDriverServer.h
+++ b/include/IECore/DisplayDriverServer.h
@@ -51,7 +51,7 @@ namespace IECore
 
 /// Server class that receives images from ClientDisplayDriver connections and forwards the data to local display drivers.
 /// The type of the local display drivers is defined by the 'remoteDisplayType' parameter.
-/// 
+///
 /// The server object creates a thread to control the socket connection. The thread dies when the object is destroyed.
 /// \ingroup renderingGroup
 class IECORE_API DisplayDriverServer : public RunTimeTyped
@@ -60,8 +60,13 @@ class IECORE_API DisplayDriverServer : public RunTimeTyped
 
 		IE_CORE_DECLARERUNTIMETYPED( DisplayDriverServer, RunTimeTyped );
 
-		DisplayDriverServer( int portNumber );
+		/// A port number of 0 causes a free port to be chosen
+		/// automatically. Call `portNumber()` after construction
+		/// to retrieve the actual number.
+		DisplayDriverServer( int portNumber = 0 );
 		virtual ~DisplayDriverServer();
+
+		int portNumber();
 
 	private:
 

--- a/src/IECore/DisplayDriverServer.cpp
+++ b/src/IECore/DisplayDriverServer.cpp
@@ -78,9 +78,9 @@ class DisplayDriverServer::Session : public RefCounted
 
 class DisplayDriverServer::PrivateData : public RefCounted
 {
-	
+
 	public :
-	
+
 		bool m_success;
 		boost::asio::ip::tcp::endpoint m_endpoint;
 		boost::asio::io_service m_service;
@@ -141,6 +141,11 @@ DisplayDriverServer::~DisplayDriverServer()
 {
 }
 
+int DisplayDriverServer::portNumber()
+{
+	return m_data->m_acceptor.local_endpoint().port();
+}
+
 void DisplayDriverServer::serverThread()
 {
 	try
@@ -165,8 +170,8 @@ void DisplayDriverServer::handleAccept( DisplayDriverServer::SessionPtr session,
 	}
 }
 
-/* 
- * DisplayDriverServer::Session functions 
+/*
+ * DisplayDriverServer::Session functions
  */
 
 DisplayDriverServer::Session::Session( boost::asio::io_service& io_service ) :
@@ -319,7 +324,7 @@ void DisplayDriverServer::Session::handleReadOpenParameters( const boost::system
 		// send the result back.
 		sendResult( DisplayDriverServerHeader::imageOpen, sizeof(scanLineOrder) );
 		m_socket.send( boost::asio::buffer( &scanLineOrder, sizeof(scanLineOrder) ) );
-		
+
 		sendResult( DisplayDriverServerHeader::imageOpen, sizeof(acceptsRepeatedData) );
 		m_socket.send( boost::asio::buffer( &acceptsRepeatedData, sizeof(acceptsRepeatedData) ) );
 

--- a/src/IECorePython/DisplayDriverServerBinding.cpp
+++ b/src/IECorePython/DisplayDriverServerBinding.cpp
@@ -51,7 +51,8 @@ void bindDisplayDriverServer()
 	using boost::python::arg;
 
 	RunTimeTypedClass<DisplayDriverServer>()
-		.def( init< int >( ( arg( "portNumber" ) ) ) )
+		.def( init< int >( ( arg( "portNumber" ) = 0 ) ) )
+		.def( "portNumber", &DisplayDriverServer::portNumber )
 	;
 
 }

--- a/test/IECore/All.py
+++ b/test/IECore/All.py
@@ -254,6 +254,7 @@ from RefCountedTest import RefCountedTest
 from ExternalProceduralTest import ExternalProceduralTest
 from ClippingPlaneTest import ClippingPlaneTest
 from DataAlgoTest import DataAlgoTest
+from DisplayDriverServerTest import DisplayDriverServerTest
 
 if IECore.withDeepEXR() :
 	from EXRDeepImageReaderTest import EXRDeepImageReaderTest

--- a/test/IECore/DisplayDriverServerTest.py
+++ b/test/IECore/DisplayDriverServerTest.py
@@ -1,0 +1,62 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+class DisplayDriverServerTest( unittest.TestCase ) :
+
+	def testPortNumber( self ) :
+
+		s1 = IECore.DisplayDriverServer( 1559 )
+		self.assertEqual( s1.portNumber(), 1559 )
+
+		self.assertRaises( RuntimeError, IECore.DisplayDriverServer, 1559 )
+
+		s2 = IECore.DisplayDriverServer( 0 )
+		self.assertNotEqual( s2.portNumber(), 0 )
+		self.assertNotEqual( s2.portNumber(), s1.portNumber() )
+
+		s3 = IECore.DisplayDriverServer( 0 )
+		self.assertNotEqual( s3.portNumber(), 0 )
+		self.assertNotEqual( s3.portNumber(), s2.portNumber() )
+
+		s4 = IECore.DisplayDriverServer()
+		self.assertNotEqual( s4.portNumber(), 0 )
+		self.assertNotEqual( s4.portNumber(), s3.portNumber() )
+
+if __name__ == "__main__":
+	unittest.main()
+


### PR DESCRIPTION
Passing an explicit port number is error prone; even when a free port is searched for prior to construction, race conditions can mean the port is no longer free when the constructor runs. We now encourage passing a port number of 0 to select a free port internally, and provide a `portNumber()` method to retrieve the port chosen.