### PR TITLE
Curves prim to maya converter fix

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -480,7 +480,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 			curvesPrimitive = self.sceneInterface().readObject( 0.0 )
 			numShapes = curvesPrimitive.numCurves()
 			for shapeId in range( numShapes ):
-				self.__findOrCreateShape( transformNode, shapeName + str( shapeId ), shapeType )
+				nameId = '' if numShapes == 1 else str( shapeId ) # Do not add number to the name if there's only one curve, for backward compatibility.
+				self.__findOrCreateShape( transformNode, shapeName + nameId, shapeType )
 
 		else:
 			self.__findOrCreateShape( transformNode, shapeName, shapeType )
@@ -560,7 +561,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 						del parameters[ "src" ]
 					self.__setConvertParams( arrayIndex, parameters )
 
-				self.__connectShape( pathToShape + str( shapeId ), plugStr, arrayIndex )
+				nameId = '' if numShapes == 1 else str( shapeId )
+				self.__connectShape( pathToShape + nameId, plugStr, arrayIndex )
 
 		else:
 			# Connect this node to one shape.

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -416,7 +416,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		queryConvertParametersPlug = self.findPlug( "queryConvertParameters" )
 		convertParamIndices = maya.OpenMaya.MIntArray()
 		queryConvertParametersPlug.getExistingArrayAttributeIndices( convertParamIndices )
-		values = queryConvertParametersPlug.elementByLogicalIndex( index ).asString()
+		values = queryConvertParametersPlug.elementByLogicalIndex( index ).asString().split()
+		values = [ str(x) for x in values ] # unicode to str
 		IECore.ParameterParser().parse( values, parameters )
 
 	## Set queryConvertParameters attribute from a parametrized object.


### PR DESCRIPTION
A bug fix https://github.com/ImageEngine/cortex/pull/516 introduced to FnSceneShape::convertObjectToGeometry().

- parameter parsing was not working
- it was using a different naming convention from before when there's only one curve in the object
 