### PR TITLE
Lazy Arnold universe management

### DIFF
--- a/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
@@ -64,7 +64,6 @@ class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 	private :
 
 		void init( bool writable );
-		void loadMetadata( const std::string &pluginPaths );
 
 };
 

--- a/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
@@ -42,9 +42,9 @@
 namespace IECoreArnold
 {
 
-/// Wraps Arnold universe creation and destruction. This is
-/// problematic because there can be only one instance at a time,
-/// but many applications have need for more than one.
+/// Manages the Arnold universe. This is problematic because there
+/// can be only one instance at a time, but many applications have
+/// need for more than one.
 class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 {
 
@@ -53,12 +53,15 @@ class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 		/// \deprecated
 		UniverseBlock();
 		/// Ensures that the Arnold universe has been created and
-		/// that all plugins on the ARNOLD_PLUGIN_PATH have been
-		/// loaded. If writable is true, then throws if there is
-		/// already a writer.
+		/// that all plugins and metadata files on the ARNOLD_PLUGIN_PATH
+		/// have been loaded. If writable is true, then throws if
+		/// there is already a writer.
 		UniverseBlock( bool writable );
-		/// Destroys the Arnold universe when the last active
-		/// UniverseBlock is destructed.
+		/// "Releases" the universe. Currently we only actually
+		/// call `AiEnd()` for writable universes, because it is
+		/// essential to clean them up properly. We leave readable
+		/// universes active to avoid the startup cost the next
+		/// time around.
 		~UniverseBlock();
 
 	private :

--- a/contrib/IECoreArnold/src/IECoreArnold/RendererImplementation.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/RendererImplementation.cpp
@@ -139,7 +139,7 @@ void IECoreArnold::RendererImplementation::constructCommon( Mode mode )
 	m_mode = mode;
 	if( mode != Procedural )
 	{
-		m_universe = boost::shared_ptr<UniverseBlock>( new UniverseBlock() );
+		m_universe = boost::shared_ptr<UniverseBlock>( new UniverseBlock( /* writable = */ true ) );
 		m_instancingConverter = new InstancingConverter;
 
 		/// \todo Control with an option

--- a/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
@@ -34,6 +34,8 @@
 
 #include "ai.h"
 
+#include "tbb/spin_mutex.h"
+
 #include "boost/tokenizer.hpp"
 #include "boost/filesystem/operations.hpp"
 
@@ -46,6 +48,7 @@
 using namespace IECore;
 using namespace IECoreArnold;
 
+static tbb::spin_mutex g_mutex;
 static int g_count = 0;
 static bool g_haveWriter = false;
 static ClassData<UniverseBlock, bool> g_writable;
@@ -65,6 +68,8 @@ UniverseBlock::UniverseBlock( bool writable )
 
 void UniverseBlock::init( bool writable )
 {
+	tbb::spin_mutex::scoped_lock lock( g_mutex );
+
 	if( writable )
 	{
 		if( g_haveWriter )
@@ -96,6 +101,8 @@ void UniverseBlock::init( bool writable )
 
 UniverseBlock::~UniverseBlock()
 {
+	tbb::spin_mutex::scoped_lock lock( g_mutex );
+
 	if( g_writable[this] )
 	{
 		g_haveWriter = false;

--- a/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
@@ -43,7 +43,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertPerspective( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert(
 				IECore.Camera(
@@ -64,7 +64,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertCustomProjection( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert(
 				IECore.Camera(

--- a/contrib/IECoreArnold/test/IECoreArnold/CurvesTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/CurvesTest.py
@@ -57,7 +57,7 @@ class CurvesTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ IECore.V3f( 2 ) ] * 4 ),
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( [ c1, c2 ], [ -0.25, 0.25 ] )
 
@@ -84,7 +84,7 @@ class CurvesTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ IECore.V3f( x, 0, 0 ) for x in range( 0, 4 ) ] )
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			# No N - should be a ribbon
 

--- a/contrib/IECoreArnold/test/IECoreArnold/InstancingConverterTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/InstancingConverterTest.py
@@ -48,7 +48,7 @@ class InstancingConverterTest( unittest.TestCase ) :
 
 	def test( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			c = IECoreArnold.InstancingConverter()
 
@@ -68,7 +68,7 @@ class InstancingConverterTest( unittest.TestCase ) :
 
 	def testThreading( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			converter = IECoreArnold.InstancingConverter()
 
@@ -118,7 +118,7 @@ class InstancingConverterTest( unittest.TestCase ) :
 
 	def testUserSuppliedHash( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			c = IECoreArnold.InstancingConverter()
 
@@ -145,7 +145,7 @@ class InstancingConverterTest( unittest.TestCase ) :
 
 	def testMotion( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			c = IECoreArnold.InstancingConverter()
 

--- a/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
@@ -50,7 +50,7 @@ class MeshTest( unittest.TestCase ) :
 		m = IECore.MeshPrimitive.createPlane( IECore.Box2f( IECore.V2f( -1 ), IECore.V2f( 1 ) ) )
 		s, t = m["s"].data, m["t"].data
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( m )
 
@@ -73,7 +73,7 @@ class MeshTest( unittest.TestCase ) :
 		s, t = m["s"].data, m["t"].data
 
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( m )
 
@@ -129,7 +129,7 @@ class MeshTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ IECore.V3f( v ) for v in range( 0, 4 ) ] )
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( m )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
@@ -152,7 +152,7 @@ class MeshTest( unittest.TestCase ) :
 			IECore.FloatVectorData( range( 0, 16 ) )
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( m )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
@@ -173,7 +173,7 @@ class MeshTest( unittest.TestCase ) :
 		m2["P"].data[1] -= IECore.V3f( 0, 0, 1 )
 		IECore.MeshNormalsOp()( input = m2, copyInput = False )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			node = IECoreArnold.NodeAlgo.convert( [ m1, m2 ], [ -0.25, 0.25 ] )
 
@@ -214,7 +214,7 @@ class MeshTest( unittest.TestCase ) :
 
 		expectedMsg = 'Primitive variable "name" will be ignored because it clashes with Arnold\'s built-in parameters'
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 			msg = IECore.CapturingMessageHandler()
 			with msg :
 				IECoreArnold.NodeAlgo.convert( m )
@@ -235,7 +235,7 @@ class MeshTest( unittest.TestCase ) :
 		IECore.setGeometricInterpretation( vectors, IECore.GeometricData.Interpretation.Vector )
 		m["vectors"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Vertex, vectors )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 			node = IECoreArnold.NodeAlgo.convert( m )
 			p = arnold.AiNodeGetArray( node, "points" )
 			self.assertEqual( p.contents.type, arnold.AI_TYPE_POINT )
@@ -251,7 +251,7 @@ class MeshTest( unittest.TestCase ) :
 			IECore.BoolVectorData( [ True, False, True, False ] )
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( m )
 			a = arnold.AiNodeGetArray( n, "myBoolPrimVar" )

--- a/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
@@ -45,7 +45,7 @@ class PointsTest( unittest.TestCase ) :
 
 	def testConverterResultType( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			p = IECore.PointsPrimitive( IECore.V3fVectorData( [ IECore.V3f( i ) for i in range( 0, 10 ) ] ) )
 			n = IECoreArnold.NodeAlgo.convert( p )
@@ -54,7 +54,7 @@ class PointsTest( unittest.TestCase ) :
 
 	def testMode( self ) :
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			p = IECore.PointsPrimitive( IECore.V3fVectorData( [ IECore.V3f( i ) for i in range( 0, 10 ) ] ) )
 
@@ -120,7 +120,7 @@ class PointsTest( unittest.TestCase ) :
 		p = IECore.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.IntData( 10 ) )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
 			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
@@ -130,7 +130,7 @@ class PointsTest( unittest.TestCase ) :
 		p = IECore.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.IntVectorData( range( 0, 10 ) ) )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
@@ -143,7 +143,7 @@ class PointsTest( unittest.TestCase ) :
 		p = IECore.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Uniform, IECore.IntData( 10 ) )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
 			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
@@ -157,7 +157,7 @@ class PointsTest( unittest.TestCase ) :
 
 			self.assertTrue( p.arePrimitiveVariablesValid() )
 
-			with IECoreArnold.UniverseBlock() :
+			with IECoreArnold.UniverseBlock( writable = True ) :
 
 				n = IECoreArnold.NodeAlgo.convert( p )
 				a = arnold.AiNodeGetArray( n, "myPrimVar" )
@@ -171,7 +171,7 @@ class PointsTest( unittest.TestCase ) :
 		p["truePrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 		p["falsePrimVar"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( False ) )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( p )
 			self.assertEqual( arnold.AiNodeGetBool( n, "truePrimVar" ), True )
@@ -191,7 +191,7 @@ class PointsTest( unittest.TestCase ) :
 			IECore.FloatVectorData( [ 2 ] * 10 ),
 		)
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( [ p1, p2 ], [ -0.25, 0.25 ] )
 

--- a/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
@@ -44,7 +44,7 @@ class SphereAlgoTest( unittest.TestCase ) :
 	def testConvert( self ) :
 
 		s = IECore.SpherePrimitive( 0.25 )
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( s )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( n ) ), "sphere" )
@@ -54,7 +54,7 @@ class SphereAlgoTest( unittest.TestCase ) :
 
 		s = [ IECore.SpherePrimitive( 0.25 ), IECore.SpherePrimitive( 0.5 ) ]
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( s, [ 0, 1 ] )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( n ) ), "sphere" )
@@ -78,7 +78,7 @@ class SphereAlgoTest( unittest.TestCase ) :
 		s["f"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, 2.5 )
 		s["m"] = IECore.PrimitiveVariable( IECore.PrimitiveVariable.Interpolation.Constant, IECore.M44f( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) )
 
-		with IECoreArnold.UniverseBlock() :
+		with IECoreArnold.UniverseBlock( writable = True ) :
 
 			n = IECoreArnold.NodeAlgo.convert( s )
 			self.assertEqual( arnold.AiNodeGetVec( n, "v" ), arnold.AtVector( 1, 2, 3 ) )

--- a/contrib/IECoreArnold/test/IECoreArnold/UniverseBlockTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/UniverseBlockTest.py
@@ -59,11 +59,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 			self.failUnless( arnold.AiUniverseIsActive() )
 
-		self.failIf( arnold.AiUniverseIsActive() )
-
 	def testWritable( self ) :
-
-		self.failIf( arnold.AiUniverseIsActive() )
 
 		def createBlock( writable ) :
 
@@ -88,6 +84,8 @@ class UniverseBlockTest( unittest.TestCase ) :
 	def testMetadataLoading( self ) :
 
 		os.environ["ARNOLD_PLUGIN_PATH"] = os.path.join( os.path.dirname( __file__ ), "metadata" )
+		with IECoreArnold.UniverseBlock( writable = True ) :
+			pass
 
 		with IECoreArnold.UniverseBlock( writable = False ) :
 
@@ -107,6 +105,17 @@ class UniverseBlockTest( unittest.TestCase ) :
 
 			arnold.AiMetaDataGetInt( e, "AA_samples", "cortex.testInt", i )
 			self.assertEqual( i.value, 12 )
+
+	def testReadOnlyUniverseDoesntPreventWritableUniverseCleanup( self ) :
+
+		with IECoreArnold.UniverseBlock( writable = False ) :
+
+			with IECoreArnold.UniverseBlock( writable = True ) :
+
+				node = arnold.AiNode( "polymesh" )
+				arnold.AiNodeSetStr( node, "name", "test" )
+
+			self.assertEqual( arnold.AiNodeLookUpByName( "test" ), None )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This alters the behaviour of the IECoreArnold UniverseBlock so that it takes a lazy approach to shutting down Arnold, only shutting down when absolutely essential - to clean up after a writable block has been used to describe a scene. This gives us big speedups when loading Gaffer scripts, because those create and destroy a UniverseBlock for each shader node loaded - before each shader load started Arnold up and shut it down, and now we start it up once and then call it good. This also fixes an old problem whereby a long-lived read-only UniverseBlock would prevent the shutdown of a short-lived writable UniverseBlock, allowing state to leak from one to the next. Unfortunately it trades that fix for a potential threading issue which I've documented in the comments, but don't expect to be an issue in practice (because I believe our universe management currently always occurs on the main thread). Really, we're just papering over cracks here; what we really need is a better underlying API.
