### PR TITLE
Make m_stream in OStreamMessageHandler protected

### DIFF
--- a/include/IECore/OStreamMessageHandler.h
+++ b/include/IECore/OStreamMessageHandler.h
@@ -83,11 +83,12 @@ class IECORE_API OStreamMessageHandler : public MessageHandler
 
 		virtual ~OStreamMessageHandler();
 
+		std::ostream *m_stream;
+
 
 	private :
 
 		bool m_ownStream;
-		std::ostream *m_stream;
 
 };
 

--- a/src/IECore/OStreamMessageHandler.cpp
+++ b/src/IECore/OStreamMessageHandler.cpp
@@ -44,12 +44,12 @@ using namespace IECore;
 ///////////////////////////////////////////////////////////////////////////////////////
 
 OStreamMessageHandler::OStreamMessageHandler( std::ostream &stream )
-	:	m_ownStream( false ), m_stream( &stream )
+	:	m_stream( &stream ), m_ownStream( false )
 {
 }
 
 OStreamMessageHandler::OStreamMessageHandler( std::ostream *stream )
-	:	m_ownStream( true ), m_stream( stream )
+	:	m_stream( stream ), m_ownStream( true )
 {
 }
 


### PR DESCRIPTION
This PR changes m_stream in OStreamMessageHandler protected so that subclasses can write to it
