### PR TITLE
Disable MeshTangentsOp axis flipping

### DIFF
--- a/include/IECore/MeshTangentsOp.h
+++ b/include/IECore/MeshTangentsOp.h
@@ -72,6 +72,10 @@ class IECORE_API MeshTangentsOp : public MeshPrimitiveOp
 		StringParameter * vTangentPrimVarNameParameter();
 		const StringParameter * vTangentPrimVarNameParameter() const;
 
+		BoolParameter * normalVecDirCheckParameter();
+		const BoolParameter * normalVecDirCheckParameter() const;
+
+
 		IE_CORE_DECLARERUNTIMETYPED( MeshTangentsOp, MeshPrimitiveOp );
 
 	protected:


### PR DESCRIPTION
Add a parameter to on/off checking if the normal vector direction is towards the cross product of uTangent and vTangent.
This check was already there for a while but we found a case where sudden change of uTangent vector can cause a problem during animation.
We can skip this check when uTangent flipping causes more problem than normal vector direction.