### PR TITLE
IECoreArnold Camera screenWindow

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/CameraAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/CameraAlgo.cpp
@@ -89,8 +89,17 @@ AtNode *CameraAlgo::convert( const IECore::Camera *camera )
 	const Imath::V2i &resolution = cameraCopy->parametersData()->member<V2iData>( "resolution", true )->readable();
 	const float pixelAspectRatio = cameraCopy->parametersData()->member<FloatData>( "pixelAspectRatio", true )->readable();
 	float aspect = pixelAspectRatio * (float)resolution.x / (float)resolution.y;
-	AiNodeSetPnt2( result, "screen_window_min", screenWindow.min.x, screenWindow.min.y * aspect );
-	AiNodeSetPnt2( result, "screen_window_max", screenWindow.max.x, screenWindow.max.y * aspect );
+
+	if ( aspect < 1.0f )
+	{
+		AiNodeSetPnt2( result, "screen_window_min", screenWindow.min.x, screenWindow.min.y * aspect );
+		AiNodeSetPnt2( result, "screen_window_max", screenWindow.max.x, screenWindow.max.y * aspect );
+	}
+	else
+	{
+		AiNodeSetPnt2( result, "screen_window_min", screenWindow.min.x / aspect, screenWindow.min.y );
+		AiNodeSetPnt2( result, "screen_window_max", screenWindow.max.x / aspect, screenWindow.max.y );
+	}
 
 	// Set any Arnold-specific parameters
 


### PR DESCRIPTION
Hello,

We are in the process of evaluating gaffer for our lighting team.
We mainly work with Arnold and we couldn't get gaffer renders to match maya's one.
Looking into details, it seems the values of the screen window on the arnold camera node do not match.
By default, arnold uses normalized values on both axis, [-1, 1] and [-1, 1] and that's what we get out of maya.
Gaffer on its side is outputting [-aspect, aspect] on both axis when the aspect is above 1.0. Below 1.0, gaffer does output the expected [-1, 1]
In the code, it seems that IECore compute values so that only one of the two axis is normalize while the other uses [-1/aspect, 1/aspect]. Which axis is set to [-1, 1]
depends on the aspect value being below or above zero.
Then, further on, it seems that IECoreArnold is trying to modify those values so that both axis are normalized to match arnold's behavior.
The problem is that it systemically tries to re-normalize the same axis, independently of the aspect value.
We don't know if it is the intended behavior or it this is a bug that just went through unnoticed.
Here is our fix just in case.

Thanks,
Gaetan Guidet, Sol Kim