### PR TITLE
IECoreRI : Added support for render:sampleMotion option

### DIFF
--- a/src/IECoreRI/RendererImplementation.cpp
+++ b/src/IECoreRI/RendererImplementation.cpp
@@ -278,6 +278,18 @@ void IECoreRI::RendererImplementation::setOption( const std::string &name, IECor
 		return;
 	}
 
+
+	if( name == "sampleMotion" )
+	{
+		if( m_options->readable().find( "ri:hider:samplemotion" ) == m_options->readable().end() )
+		{
+			// If we aren't specifying the specific RenderMan sample motion option, then drive it
+			// from the general setting ( if the specific setting comes after it will override )
+			m_options->writable()["ri:hider:samplemotion"] = value->copy();
+		}
+		return;
+	}
+	
 	// we need to group related options together into a single RiOption or RiHider call, so we
 	// just accumulate the options until worldBegin() where we'll emit them.
 	m_options->writable()[name] = value->copy();

--- a/test/IECoreRI/Renderer.py
+++ b/test/IECoreRI/Renderer.py
@@ -841,6 +841,46 @@ class RendererTest( IECoreRI.TestCase ) :
 		# Both node types should be shader
 		self.assertEqual( set( x[1] for x in nodes ), { "shader" } )
 
+	def testSampleMotion( self ) :
+	
+		with CapturingMessageHandler() as mh :
+			r = IECoreRI.Renderer( "test/IECoreRI/output/test.rib" )
+			with WorldBlock( r ) :
+				pass
+
+		self.assertEqual( len( mh.messages ), 0 )
+		self.assertFalse( "sampleMotion" in  file( "test/IECoreRI/output/test.rib" ).read() )
+
+		with CapturingMessageHandler() as mh :
+			r = IECoreRI.Renderer( "test/IECoreRI/output/test.rib" )
+			r.setOption( "sampleMotion", False )
+			with WorldBlock( r ) :
+				pass
+
+		self.assertEqual( len( mh.messages ), 0 )
+		self.assertTrue( "\"int samplemotion\" [ 0 ]" in  file( "test/IECoreRI/output/test.rib" ).read() )
+
+		with CapturingMessageHandler() as mh :
+			r = IECoreRI.Renderer( "test/IECoreRI/output/test.rib" )
+			r.setOption( "sampleMotion", False )
+			r.setOption( "ri:hider:samplemotion", True )
+			with WorldBlock( r ) :
+				pass
+
+		self.assertEqual( len( mh.messages ), 0 )
+		self.assertTrue( "\"int samplemotion\" [ 1 ]" in  file( "test/IECoreRI/output/test.rib" ).read() )
+
+		with CapturingMessageHandler() as mh :
+			r = IECoreRI.Renderer( "test/IECoreRI/output/test.rib" )
+			r.setOption( "ri:hider:samplemotion", True )
+			r.setOption( "sampleMotion", False )
+			with WorldBlock( r ) :
+				pass
+
+		self.assertEqual( len( mh.messages ), 0 )
+		self.assertTrue( "\"int samplemotion\" [ 1 ]" in  file( "test/IECoreRI/output/test.rib" ).read() )
+
+
 	def tearDown( self ) :
 
 		IECoreRI.TestCase.tearDown( self )


### PR DESCRIPTION
Hopefully this looks about right?  The more complex part of this functionality is in a Gaffer pull request that will go up shortly.