### PR TITLE
ParameterAlgo: include node name in warning.

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -177,7 +177,13 @@ void setParameterInternal( AtNode *node, const char *name, int parameterType, bo
 				break;
 			default :
 			{
-				msg( Msg::Warning, "setParameter", boost::format( "Arnold parameter \"%s\" has unsupported type \"%s\"." ) % name % AiParamGetTypeName( parameterType ) );
+				std::string nodeStr = AiNodeGetName( node );
+				if( nodeStr == "" )
+				{
+					nodeStr = AiNodeEntryGetName( AiNodeGetNodeEntry( node ) );
+				}
+
+				msg( Msg::Warning, "setParameter", boost::format( "Arnold parameter \"%s\" on node \"%s\" has unsupported type \"%s\"." ) % name % nodeStr % AiParamGetTypeName( parameterType ) );
 			}
 		}
 	}


### PR DESCRIPTION
@johnhaddon Any reason why this would be a bad idea? :) Would help us narrow down some of the warnings we're getting.