### PR TITLE
IECoreMaya: RefreshDisabled and UndoChunk added

### DIFF
--- a/python/IECoreMaya/RefreshDisabled.py
+++ b/python/IECoreMaya/RefreshDisabled.py
@@ -1,0 +1,49 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import maya.cmds
+
+## A context object intended for use with python's "with" syntax. It ensures
+# that all operations in the with block are performed with maya's refresh disabled,
+# and that refresh turned back on when the block exits.
+class RefreshDisabled :
+
+	def __enter__( self ) :
+
+		## \todo: get initial state to revert to
+		maya.cmds.refresh( suspend=True )
+
+	def __exit__( self, type, value, traceBack ) :
+
+		maya.cmds.refresh( suspend=False )

--- a/python/IECoreMaya/UndoChunk.py
+++ b/python/IECoreMaya/UndoChunk.py
@@ -1,0 +1,55 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import maya.cmds
+
+## A context object intended for use with python's "with" syntax. It ensures
+# that all operations in the with block are performed within a new Undo Chunk
+# and that the chunk is being closed when the block exits.
+class UndoChunk:
+
+	def __init__(self, chunkName):
+
+		self.__chunkName = chunkName
+
+	def __enter__( self ) :
+
+		maya.cmds.undoInfo( stateWithoutFlush=True )
+		self.__prevState = maya.cmds.undoInfo( q=True, state=True )
+		maya.cmds.undoInfo( chunkName=self.__chunkName, openChunk=True )
+
+	def __exit__( self, type, value, traceBack ) :
+
+		maya.cmds.undoInfo( chunkName=self.__chunkName, closeChunk=True )
+		maya.cmds.undoInfo( stateWithoutFlush=self.__prevState )

--- a/python/IECoreMaya/__init__.py
+++ b/python/IECoreMaya/__init__.py
@@ -98,3 +98,5 @@ from Collapsible import Collapsible
 import Menus
 import SceneShapeUI
 from FnSceneShape import FnSceneShape
+from RefreshDisabled import RefreshDisabled
+from UndoChunk import UndoChunk

--- a/test/IECoreMaya/All.py
+++ b/test/IECoreMaya/All.py
@@ -83,6 +83,7 @@ from SceneShapeTest import SceneShapeTest
 from FnSceneShapeTest import FnSceneShapeTest
 from FromMayaLocatorConverterTest import FromMayaLocatorConverterTest
 from ToMayaLocatorConverterTest import ToMayaLocatorConverterTest
+from UndoTest import UndoTest
 
 IECoreMaya.TestProgram(
 

--- a/test/IECoreMaya/UndoTest.py
+++ b/test/IECoreMaya/UndoTest.py
@@ -1,0 +1,61 @@
+##########################################################################
+#
+#  Copyright (c) 2016, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import maya.cmds
+import maya.mel
+
+import IECore
+import IECoreMaya
+
+class UndoTest( IECoreMaya.TestCase ) :
+
+	def test( self ) :
+
+		maya.cmds.undoInfo(stateWithoutFlush=True )
+
+		with IECoreMaya.UndoChunk('test1'):
+			cube = maya.cmds.createNode('polyCube')
+			sphere = maya.cmds.createNode('polySphere')
+
+		with IECoreMaya.UndoDisabled():
+			plane = maya.cmds.createNode('polyPlane')
+
+		maya.cmds.undo()
+
+		self.assertFalse( maya.cmds.objExists( cube ) )
+		self.assertFalse( maya.cmds.objExists( sphere ) )
+		self.assertTrue( maya.cmds.objExists( plane ) )
+
+if __name__ == "__main__":
+	IECoreMaya.TestProgram()


### PR DESCRIPTION
Added two context objects, RefreshDisabled and UndoChunk to IECoreMaya so we can execute code with disabled scene refresh or safely create a new maya undo-chunk without the danger of breaking the undo history.