### PR TITLE
Support for metadata on ImageDisplayDrivers

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -254,6 +254,21 @@ IECore::DataPtr getParameterInternal( AtNode *node, const char *name, int parame
 			return new FloatData( AiNodeGetFlt( node, name ) );
 		case AI_TYPE_STRING :
 			return new StringData( AiNodeGetStr( node, name ) );
+		case AI_TYPE_RGB :
+		{
+			AtRGB rgb = AiNodeGetRGB( node, name );
+			return new Color3fData( Imath::Color3f( rgb.r, rgb.g, rgb.b ) );
+		}
+		case AI_TYPE_RGBA :
+		{
+			AtRGBA rgba = AiNodeGetRGBA( node, name );
+			return new Color4fData( Imath::Color4f( rgba.r, rgba.g, rgba.b, rgba.a ) );
+		}
+		case AI_TYPE_VECTOR :
+		{
+			AtVector vector = AiNodeGetVec( node, name );
+			return new V3fData( Imath::V3f( vector.x, vector.y, vector.z ));
+		}
 		case AI_TYPE_ARRAY :
 			return arrayToData( AiNodeGetArray( node, name ) );
 	}

--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -398,6 +398,9 @@ int parameterType( IECore::TypeId dataType, bool &array )
 		case Color3fDataTypeId :
 			array = false;
 			return AI_TYPE_RGB;
+		case Color4fDataTypeId :
+			array = false;
+			return AI_TYPE_RGBA;
 		case BoolDataTypeId :
 			array = false;
 			return AI_TYPE_BOOLEAN;

--- a/include/IECore/ImageDisplayDriver.h
+++ b/include/IECore/ImageDisplayDriver.h
@@ -67,7 +67,7 @@ class IECORE_API ImageDisplayDriver : public DisplayDriver
 		/// Access to the image being created. This should always be valid for reading, even
 		/// before imageClose() has been called.
 		ConstImagePrimitivePtr image() const;
-		
+
 		//! @name Image pool
 		/// It can be useful to store the images created by ImageDisplayDrivers for
 		/// later retrieval. Images can be stored by passing a StringData
@@ -83,13 +83,13 @@ class IECORE_API ImageDisplayDriver : public DisplayDriver
 		/// the image, or 0 if no such image existed.
 		static ConstImagePrimitivePtr removeStoredImage( const std::string &handle );
 		//@}
-		
+
 	private:
 
 		static const DisplayDriverDescription<ImageDisplayDriver> g_description;
-		
+
 		ImagePrimitivePtr m_image;
-		
+
 };
 
 IE_CORE_DECLAREPTR( ImageDisplayDriver )

--- a/src/IECore/ImageDisplayDriver.cpp
+++ b/src/IECore/ImageDisplayDriver.cpp
@@ -34,6 +34,8 @@
 
 #include "tbb/mutex.h"
 
+#include "boost/algorithm/string/predicate.hpp"
+
 #include "IECore/ImageDisplayDriver.h"
 
 using namespace boost;
@@ -59,14 +61,19 @@ ImageDisplayDriver::ImageDisplayDriver( const Box2i &displayWindow, const Box2i 
 	}
 	if( parameters )
 	{
+		// Add all entries that follow our 'header:' metadata convention to the blindData.
+		// Other entries are omitted.
 		CompoundDataMap &xData = m_image->blindData()->writable();
 		const CompoundDataMap &yData = parameters->readable();
 		CompoundDataMap::const_iterator iterY = yData.begin();
 		for ( ; iterY != yData.end(); iterY++ )
 		{
-			xData[iterY->first] = iterY->second->copy();
+			if( starts_with( iterY->first.string(), "header:" ) )
+			{
+				xData[ iterY->first.string().substr( 7 ) ] = iterY->second->copy();
+			}
 		}
-	
+
 		ConstStringDataPtr handle = parameters->member<StringData>( "handle" );
 		if( handle )
 		{

--- a/test/IECore/DisplayDriverTest.py
+++ b/test/IECore/DisplayDriverTest.py
@@ -87,11 +87,11 @@ class TestImageDisplayDriver(unittest.TestCase):
 		gc.collect()
 		RefCounted.collectGarbage()
 		self.assertEqual( RefCounted.numWrappedInstances(), 0 )
-		
+
 	def testImagePool( self ) :
-	
+
 		img = Reader.create( "test/IECore/data/tiff/bluegreen_noise.400x300.tif" )()
-		
+
 		idd = DisplayDriver.create(
 			"ImageDisplayDriver",
 			img.displayWindow,
@@ -101,7 +101,7 @@ class TestImageDisplayDriver(unittest.TestCase):
 				"handle" : StringData( "myHandle" )
 			}
 		)
-		
+
 		red = img['R'].data
 		green = img['G'].data
 		blue = img['B'].data
@@ -116,25 +116,25 @@ class TestImageDisplayDriver(unittest.TestCase):
 		self.assertEqual( ImageDisplayDriver.storedImage( "myHandle" ), idd.image() )
 		self.assertEqual( ImageDisplayDriver.removeStoredImage( "myHandle" ), idd.image() )
 		self.assertEqual( ImageDisplayDriver.storedImage( "myHandle" ), None )
-		
+
 	def testAcceptsRepeatedData( self ) :
-	
+
 		window = Box2i( V2i( 0 ), V2i( 15 ) )
-	
+
 		dd = ImageDisplayDriver( window, window, [ "Y" ], CompoundData() )
 		self.assertEqual( dd.acceptsRepeatedData(), True )
-		
+
 		y = FloatVectorData( [ 1 ] * 16 * 16 )
 		dd.imageData( window, y )
-		
+
 		y = FloatVectorData( [ 0.5 ] * 16 * 16 )
 		dd.imageData( window, y )
-		
+
 		dd.imageClose()
-		
+
 		i = dd.image()
 		self.assertEqual( i["Y"].data, y )
-		
+
 class TestClientServerDisplayDriver(unittest.TestCase):
 
 	def setUp( self ):
@@ -158,8 +158,8 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 			buf[3*i+2] = red[i+offset]
 
 	def testUsedPortException( self ):
-		
-		self.assertRaises( RuntimeError, lambda : DisplayDriverServer( 1559 ) ) 
+
+		self.assertRaises( RuntimeError, lambda : DisplayDriverServer( 1559 ) )
 
 	def testTransfer( self ):
 
@@ -182,7 +182,7 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 			self.__prepareBuf( buf, width, i*width, red, green, blue )
 			idd.imageData( Box2i( V2i( img.dataWindow.min.x, i + img.dataWindow.min.y ), V2i( img.dataWindow.max.x, i + img.dataWindow.min.y) ), buf )
 		idd.imageClose()
-		
+
 		newImg = ImageDisplayDriver.removeStoredImage( "myHandle" )
 		params["clientPID"] = IntData( os.getpid() )
 		self.assertEqual( newImg.blindData(), params )
@@ -192,7 +192,7 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 		self.assertEqual( newImg, img )
 
 	def testWrongSocketException( self ) :
-	
+
 		parameters = CompoundData( {
 			"displayHost" : "localhost",
 			"displayPort" : "1560", # wrong port
@@ -206,11 +206,11 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 			ClientDisplayDriver( dw, dw, [ "R", "G", "B" ], parameters )
 		except Exception, e :
 			pass
-	
+
 		self.failUnless( "Could not connect to remote display driver server : Connection refused" in str( e ) )
 
 	def testWrongHostException( self ) :
-	
+
 		parameters = CompoundData( {
 			"displayHost" : "thisHostDoesNotExist",
 			"displayPort" : "1559", # wrong port
@@ -224,13 +224,13 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 			ClientDisplayDriver( dw, dw, [ "R", "G", "B" ], parameters )
 		except Exception, e :
 			pass
-			
+
 		self.failUnless( "Could not connect to remote display driver server : Host not found" in str( e ) )
 
 	def testAcceptsRepeatedData( self ) :
-	
+
 		window = Box2i( V2i( 0 ), V2i( 15 ) )
-	
+
 		dd = ClientDisplayDriver(
 			window, window,
 			[ "Y" ],
@@ -241,24 +241,24 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 				"handle" : "myHandle"
 			} )
 		)
-	
+
 		self.assertEqual( dd.acceptsRepeatedData(), True )
-		
+
 		y = FloatVectorData( [ 1 ] * 16 * 16 )
 		dd.imageData( window, y )
-		
+
 		y = FloatVectorData( [ 0.5 ] * 16 * 16 )
 		dd.imageData( window, y )
-		
+
 		dd.imageClose()
-		
+
 		i = ImageDisplayDriver.removeStoredImage( "myHandle" )
 		self.assertEqual( i["Y"].data, y )
 
 	def tearDown( self ):
-		
+
 		self.server = None
-		
+
 		# test if all symbols are gone after the tests.
 		gc.collect()
 		RefCounted.collectGarbage()
@@ -266,4 +266,3 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 
 if __name__ == "__main__":
 	unittest.main()
-

--- a/test/IECore/DisplayDriverTest.py
+++ b/test/IECore/DisplayDriverTest.py
@@ -175,6 +175,7 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 		params['displayPort'] = StringData( '1559' )
 		params["remoteDisplayType"] = StringData( "ImageDisplayDriver" )
 		params["handle"] = StringData( "myHandle" )
+		params["header:myMetadata"] = StringData( "Metadata!" )
 		idd = ClientDisplayDriver( img.displayWindow, img.dataWindow, list( img.channelNames() ), params )
 
 		buf = FloatVectorData( width * 3 )
@@ -185,7 +186,10 @@ class TestClientServerDisplayDriver(unittest.TestCase):
 
 		newImg = ImageDisplayDriver.removeStoredImage( "myHandle" )
 		params["clientPID"] = IntData( os.getpid() )
-		self.assertEqual( newImg.blindData(), params )
+
+		# only data prefixed by 'header:' will come through as blindData/metadata
+		self.assertEqual( newImg.blindData(), CompoundData({"myMetadata": StringData( "Metadata!" )}) )
+
 		# remove blindData for comparison
 		newImg.blindData().clear()
 		img.blindData().clear()


### PR DESCRIPTION
We need something like this added to be able to read metadata in our `NukeDisplayDriver` which inherits from `ImageDisplayDriver`.

The main commit here is about supporting the same "header:" metadata convention that we came up with for gaffer when storing data that we want to end up in exr's. I'm stripping off the prefix and then check for possible clashes here. Not sure if that's the best way to do it, but after talking to @andrewkaufman and @danieldresser this is what we came up with. Any thoughts? :) To get the metadata added as actual parameters on the Arnold nodes, we will need a change in Gaffer too [0].

The other commits are just about supporting more data types when talking to Arnold. I think we should discuss this a bit though because using the Gaffer PR [0] we will get these warnings if we add a metadata entry for each of the standard data types in Gaffer:
```

WARNING : setParameter : Unsupported data type "V2fData" for name "header:nukeV2f"
WARNING : setParameter : Unsupported data type "V3iData" for name "header:nukeV3i"
WARNING : setParameter : Unsupported data type "V2iData" for name "header:nukeV2i"

```

Those are not supported at the moment and I guess my first question is if and how we would want to support them. Those are a little less obvious than the ones I have added in this PR, because there's no direct equivalent among Arnold's AtTypes.

Also, I guess we would like exr's coming from Arnold to look the same as the one's we push through our `NukeDisplayDriver` in terms of metadata. On the Arnold side we convert a whole bunch of data types to strings, though. We do that because that `custom_attributes` feature on `exr_driver` nodes does not support all data types that we want (Color3f, Color4f...). We could do the same here where we handle the prefixed parameters and convert some of them to strings, but that's a bit of a shame isn't it? I guess I would like to keep them as their proper data type as long as possible and maybe do that string conversion in the `NukeDisplayDriver` instead? If we do that, we would need a separation of normal parameters and metadata entries, though. Are you open to adding something like that to `ImagePrimitives` and then changing `OutputDriver` to split up parameters and metadata? I guess the downside to that approach is that we wouldn't guarantee data type consistency between exr's from Arnold and the data on `ImageDisplayDrivers` and the place where we fix it for our pipeline is IE only.

Thanks! :)

[0] https://github.com/GafferHQ/gaffer/pull/1967