### PR TITLE
EXRImageWriter: add DreamWorks compression methods

### DIFF
--- a/src/IECore/EXRImageWriter.cpp
+++ b/src/IECore/EXRImageWriter.cpp
@@ -100,6 +100,10 @@ void EXRImageWriter::constructCommon()
 	compressionPresets.push_back( IntParameter::Preset( "pxr24", PXR24_COMPRESSION ) );
 	compressionPresets.push_back( IntParameter::Preset( "b44", B44_COMPRESSION ) );
 	compressionPresets.push_back( IntParameter::Preset( "b44a", B44A_COMPRESSION ) );
+#if OPENEXR_VERSION_HEX >= 0x02020000
+	compressionPresets.push_back( IntParameter::Preset( "dwaa", DWAA_COMPRESSION ) );
+	compressionPresets.push_back( IntParameter::Preset( "dwab", DWAB_COMPRESSION ) );
+#endif // OPENEXR_VERSION_HEX
 
 	IntParameterPtr compressionParameter = new IntParameter(
 	        "compression",


### PR DESCRIPTION
Those two are defined in the OpenEXR project [0] and have been there since June 2014. I'm just assuming that we compile against an openEXR version more recent than that?

Thanks :)

[0] https://github.com/openexr/openexr/blob/develop/OpenEXR/IlmImf/ImfCompression.h#L69