### PR TITLE
IECoreArnold/ParameterAlgo: avoid warnings when redeclaring attributes

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -319,7 +319,10 @@ void setParameter( AtNode *node, const char *name, const IECore::Data *value )
 				typeString += "ARRAY ";
 			}
 			typeString += AiParamGetTypeName( type );
-			AiNodeDeclare( node, name, typeString.c_str() );
+			if( !AiNodeLookUpUserParameter( node, name ) )
+			{
+				AiNodeDeclare( node, name, typeString.c_str() );
+			}
 			setParameterInternal( node, name, type, array, value );
 		}
 		else


### PR DESCRIPTION
Hey John,

unless I'm missing something we don't check whether a user parameter already exists when handing it off to Arnold. A user sent me a list of warnings today that I was able to replicate by creating a sphere, adding a custom attribute, starting an IPR and then changing the value of the attribute:

`00:03:41   535MB WARNING | cannot declare constant STRING user:bla on /group/sphere - name already in use`


