### PR TITLE
Add option to convert scene tags to groups in Houdini

### DIFF
--- a/include/IECoreHoudini/OBJ_SceneCacheTransform.h
+++ b/include/IECoreHoudini/OBJ_SceneCacheTransform.h
@@ -106,6 +106,7 @@ class OBJ_SceneCacheTransform : public OBJ_SceneCacheNode<OBJ_SubNet>
 			UT_String tagFilterStr;
 			UT_StringMMPattern tagFilter;
 			UT_String fullPathName;
+			bool tagGroups;
 		};
 		
 		/// Called by expandHierarchy() and doExpandChildren() when the SceneCache contains an object.

--- a/include/IECoreHoudini/SOP_SceneCacheSource.h
+++ b/include/IECoreHoudini/SOP_SceneCacheSource.h
@@ -82,7 +82,7 @@ class SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 			std::string fullPathName;
 			UT_StringMMPattern shapeFilter;
 			UT_StringMMPattern tagFilter;
-			
+			bool tagGroups;
 			bool hasAnimatedTopology;
 			bool hasAnimatedPrimVars;
 			std::vector<IECore::InternedString> animatedPrimVars;

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -66,6 +66,7 @@ class SceneCacheNode : public BaseType
 		static PRM_Name pAttributeFilter;
 		static PRM_Name pAttributeCopy;
 		static PRM_Name pTagFilter;
+		static PRM_Name pTagGroups;
 		static PRM_Name pShapeFilter;
 		static PRM_Name pFullPathName;
 		
@@ -80,7 +81,7 @@ class SceneCacheNode : public BaseType
 		static PRM_ChoiceList attributeCopyMenu;
 		static PRM_ChoiceList tagFilterMenu;
 		static PRM_ChoiceList shapeFilterMenu;
-		
+
 		static int sceneParmChangedCallback( void *data, int index, float time, const PRM_Template *tplate );
 		static int reloadButtonCallback( void *data, int index, float time, const PRM_Template *tplate );
 		static void buildRootMenu( void *data, PRM_Name *menu, int maxSize, const PRM_SpareData *, const PRM_Parm * );
@@ -120,6 +121,8 @@ class SceneCacheNode : public BaseType
 		void getTagFilter( UT_String &filter ) const;
 		void getTagFilter( UT_StringMMPattern &filter ) const;
 		void setTagFilter( const UT_String &filter );
+		bool getTagGroups() const;
+		void setTagGroups( bool tagGroups );
 		void getShapeFilter( UT_String &filter ) const;
 		void getShapeFilter( UT_StringMMPattern &filter ) const;
 		void setShapeFilter( const UT_String &filter );

--- a/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
@@ -98,6 +98,7 @@ void OBJ_SceneCacheGeometry::expandHierarchy( const SceneInterface *scene )
 void OBJ_SceneCacheGeometry::pushToHierarchy()
 {
 	UT_String attribFilter, attribCopy, tagFilter, shapeFilter, fullPathName;
+	bool tagGroups = getTagGroups();
 	getAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
 	getTagFilter( tagFilter );
@@ -113,6 +114,7 @@ void OBJ_SceneCacheGeometry::pushToHierarchy()
 		sop->setAttributeFilter( attribFilter );
 		sop->setAttributeCopy( attribCopy );
 		sop->setTagFilter( tagFilter );
+		sop->setTagGroups( tagGroups );
 		sop->setShapeFilter( shapeFilter );
 		sop->setFullPathName( fullPathName );
 		sop->setGeometryType( (SOP_SceneCacheSource::GeometryType)geomType );
@@ -144,6 +146,7 @@ void OBJ_SceneCacheGeometry::doExpandGeometry( const SceneInterface *scene )
 	sop->setAttributeCopy( attribCopy );
 	getTagFilter( tagFilter );
 	sop->setTagFilter( tagFilter );
+	sop->setTagGroups( getTagGroups() );
 	getShapeFilter( shapeFilter );
 	sop->setShapeFilter( shapeFilter );
 	getFullPathName( fullPathName );

--- a/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
@@ -138,6 +138,7 @@ void OBJ_SceneCacheTransform::expandHierarchy( const SceneInterface *scene )
 	params.geometryType = getGeometryType();
 	params.depth = (Depth)evalInt( pDepth.getToken(), 0, 0 );
 	params.hierarchy = (Hierarchy)evalInt( pHierarchy.getToken(), 0, 0 );
+	params.tagGroups = getTagGroups();
 	getAttributeFilter( params.attributeFilter );
 	getAttributeCopy( params.attributeCopy );
 	getShapeFilter( params.shapeFilter );
@@ -223,6 +224,7 @@ OBJ_Node *OBJ_SceneCacheTransform::doExpandObject( const SceneInterface *scene, 
 	if ( visible )
 	{
 		geo->setTagFilter( params.tagFilterStr );
+		geo->setTagGroups( params.tagGroups );
 	}
 	
 	geo->setDisplay( visible );
@@ -346,6 +348,7 @@ void OBJ_SceneCacheTransform::doExpandChildren( const SceneInterface *scene, OP_
 void OBJ_SceneCacheTransform::pushToHierarchy()
 {
 	UT_String attribFilter, attribCopy, shapeFilter, fullPathName;
+	bool tagGroups = getTagGroups();
 	getAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
 	getShapeFilter( shapeFilter );
@@ -376,6 +379,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 			{
 				visible = true;
 				xform->setTagFilter( tagFilterStr );
+				xform->setTagGroups( tagGroups );
 			}
 		}
 		
@@ -403,6 +407,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 			if ( visible )
 			{
 				geo->setTagFilter( tagFilterStr );
+				geo->setTagGroups( tagGroups );
 			}
 		}
 		
@@ -426,6 +431,7 @@ OBJ_SceneCacheTransform::Parameters::Parameters( const Parameters &other )
 	shapeFilter = other.shapeFilter;
 	tagFilterStr = other.tagFilterStr;
 	tagFilter.compile( tagFilterStr );
+	tagGroups = other.tagGroups;
 	fullPathName = other.fullPathName;
 }
 

--- a/src/IECoreHoudini/SceneCacheNode.cpp
+++ b/src/IECoreHoudini/SceneCacheNode.cpp
@@ -88,6 +88,9 @@ template<typename BaseType>
 PRM_Name SceneCacheNode<BaseType>::pTagFilter( "tagFilter", "Tag Filter" );
 
 template<typename BaseType>
+PRM_Name SceneCacheNode<BaseType>::pTagGroups( "tagGroups", "Convert Tags to Groups" );
+
+template<typename BaseType>
 PRM_Name SceneCacheNode<BaseType>::pShapeFilter( "shapeFilter", "Shape Filter" );
 
 template<typename BaseType>
@@ -194,7 +197,7 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 	static PRM_Template *thisTemplate = 0;
 	if ( !thisTemplate )
 	{
-		thisTemplate = new PRM_Template[7];
+		thisTemplate = new PRM_Template[8];
 		
 		thisTemplate[0] = PRM_Template(
 			PRM_INT, 1, &pGeometryType, &geometryTypeDefault, &geometryTypeList, 0, 0, 0, 0,
@@ -232,6 +235,11 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 		);
 		
 		thisTemplate[5] = PRM_Template(
+			PRM_TOGGLE, 1, &pTagGroups, 0, 0, 0, 0, 0, 0,
+			"Convert SCC tags into Houdini primitive groups."
+		);
+
+		thisTemplate[6] = PRM_Template(
 			PRM_STRING, 1, &pFullPathName, 0, 0, 0, 0, 0, 0,
 			"Load the full path of the object as a primitive attribute with this name. This is for user "
 			"convenience and has no meaning in terms of processing or exporting SceneCaches. If left empty, "
@@ -507,6 +515,18 @@ template<typename BaseType>
 void SceneCacheNode<BaseType>::setTagFilter( const UT_String &filter )
 {
 	this->setString( filter, CH_STRING_LITERAL, pTagFilter.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+bool SceneCacheNode<BaseType>::getTagGroups() const
+{
+	return this->evalInt( pTagGroups.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::setTagGroups( bool tagGroups )
+{
+	return this->setInt( pTagGroups.getToken(), 0, 0, tagGroups );
 }
 
 template<typename BaseType>


### PR DESCRIPTION
Added two parameters on SOP/ieSceneCacheSource:

- tagGroups - toggles the tag conversion to group on and off (off by default)
- tagGroupsPrefix - add a custom prefix to the groups created by the ieSceneCacheSource (nothing by default)