### PR TITLE
Spline Fixes

### DIFF
--- a/include/IECore/CubicBasis.h
+++ b/include/IECore/CubicBasis.h
@@ -111,6 +111,15 @@ class CubicBasis
 		inline S integral( typename S::BaseType t0, typename S::BaseType t1, const S p[4] ) const;
 		//@}
 
+		//! @name Critical points
+		/// Methods for computing the critical points with respect to 't', which for a
+		/// curve are points where it may change direction
+		////////////////////////////////////////////////////////////////////////////////////////
+		//@{
+		template<class S>
+		inline bool criticalPoints( const S p[4], S &p0, S &p1 ) const;
+		//@}
+
 		bool operator==( const CubicBasis &rhs ) const;
 		bool operator!=( const CubicBasis &rhs ) const;
 

--- a/include/IECore/CubicBasis.h
+++ b/include/IECore/CubicBasis.h
@@ -61,6 +61,8 @@ class CubicBasis
 		template<class S>
 		inline void coefficients( S t, S c[4] ) const;
 
+		inline int numCoefficients() const;
+
 		template<class S>
 		inline S operator() ( S t, S p0, S p1, S p2, S p3 ) const;
 		template<class S>

--- a/include/IECore/CubicBasis.inl
+++ b/include/IECore/CubicBasis.inl
@@ -239,6 +239,25 @@ inline S CubicBasis<T>::integral( typename S::BaseType t0, typename S::BaseType 
 }
 
 template<typename T>
+template<class S>
+inline bool CubicBasis<T>::criticalPoints( const S p[4], S &out0, S &out1 ) const
+{
+	// Quadratic formula applied to derivatives
+	S a = S(3.0) * ( p[0] * matrix[0][0] + p[1] * matrix[0][1] + p[2] * matrix[0][2] + p[3] * matrix[0][3] );
+	S b = S(2.0) * ( p[0] * matrix[1][0] + p[1] * matrix[1][1] + p[2] * matrix[1][2] + p[3] * matrix[1][3] );
+	S c =            p[0] * matrix[2][0] + p[1] * matrix[2][1] + p[2] * matrix[2][2] + p[3] * matrix[2][3];
+
+	S determinant = b * b - S(4.0) * a * c;	
+	if( determinant < 0 ) return false;
+
+	S sqrtDet = sqrt( determinant );	
+	out0 = ( -b - ( a > S(0.0) ? S(1.0) : S(-1.0) ) * sqrtDet ) / ( S(2.0) * a );
+	out1 = ( -b + ( a > S(0.0) ? S(1.0) : S(-1.0) ) * sqrtDet ) / ( S(2.0) * a );
+
+	return true;
+}
+
+template<typename T>
 bool CubicBasis<T>::operator==( const CubicBasis &rhs ) const
 {
 	return step==rhs.step && matrix==rhs.matrix;

--- a/include/IECore/CubicBasis.inl
+++ b/include/IECore/CubicBasis.inl
@@ -93,6 +93,20 @@ inline S CubicBasis<T>::operator() ( typename S::BaseType t, const S &p0, const 
 }
 
 template<typename T>
+inline int CubicBasis<T>::numCoefficients() const
+{
+	int result = 0;
+	for( int i = 0; i < 4; ++i )
+	{
+		if( matrix[0][i] != 0 || matrix[1][i] != 0 || matrix[2][i] != 0 || matrix[3][i] != 0 )
+		{
+			result = i + 1;
+		}
+	}
+	return result;
+}
+
+template<typename T>
 template<class S>
 inline S CubicBasis<T>::operator() ( typename S::BaseType t, const S p[4] ) const
 {

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -124,40 +124,42 @@ inline X Spline<X,Y>::solve( X x, typename PointContainer::const_iterator &segme
 
 	typedef typename PointContainer::const_iterator It;
 
-	// find the first segment where seg( 0 ) > x. the segment before that is the one we're interested in.
+	// find the first segment where seg( 1 ) > x. this segment should contain x.
+	// If we hit the end of the points while searching, return the end point of the last valid segment
 	// this is just a linear search right now - it should be possible to optimise this using points.lower_bound
 	// to quickly find a better start point for the search.
 	X co[4];
-	basis.coefficients( X( 0 ), co );
+	basis.coefficients( X( 1 ), co );
 	X xp[4] = { X(0), X(0), X(0), X(0) };
 
-	It testSegment = points.begin();
-	do
+	segment = points.begin();
+	for( int pointNum = 0;; pointNum += basis.step )
 	{
-		segment = testSegment;
-		for( unsigned i=0; i<basis.step; i++ )
-		{
-			testSegment++;
-		}
-
-		bool overrun = false;
-		It xIt( testSegment );
+		It xIt( segment );
 		for( unsigned i=0; i<coefficientsNeeded; i++ )
 		{
-			if( xIt==points.end() )
-			{
-				overrun = true;
-				break;
-			}
 			xp[i] = xIt->first;
 			xIt++;
 		}
-		if( overrun )
+
+		if( xp[0] * co[0] + xp[1] * co[1] + xp[2] * co[2] + xp[3] * co[3] > x )
 		{
 			break;
 		}
 
-	} while( xp[0] * co[0] + xp[1] * co[1] + xp[2] * co[2] + xp[3] * co[3] < x );
+		if( pointNum + basis.step  + coefficientsNeeded - 1 >= points.size() )
+		{
+			// We're on the last valid segment, but we haven't reached  x
+			// Just return the end of the last valid segment
+			return X( 1 );
+		}
+
+		for( unsigned i=0; i<basis.step; i++ )
+		{
+			segment++;
+		}
+	}
+
 	// get the x values of the control values for the segment in question
 	It xIt( segment );
 	for( unsigned i=0; i<coefficientsNeeded; i++ )

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -186,7 +186,7 @@ template<typename X, typename Y>
 inline X Spline<X,Y>::solve( X x, Y segment[4] ) const
 {
 	typename PointContainer::const_iterator s;
-	float t = solve( x, s );
+	X t = solve( x, s );
 	segment[0] = (*s++).second;
 	segment[1] = (*s++).second;
 	segment[2] = (*s++).second;

--- a/test/IECore/SplineTest.py
+++ b/test/IECore/SplineTest.py
@@ -255,6 +255,13 @@ class SplineTest( unittest.TestCase ) :
 		( integral, summedArea ) = computeIntegrals(s, [12,20])
 		self.assertAlmostEqual( integral, summedArea, 3 )
 
+		# testing linear basis integral with 4 control points
+		s = IECore.Splineff( IECore.CubicBasisf.linear(), ( ( 0, 1 ), ( 10, 2 ), ( 20, 0 ), ( 21, 2 ) ) )
+		( integral, summedArea ) = computeIntegrals(s)
+		self.assertAlmostEqual( integral, summedArea, 2 )
+		# Test against a quick analytic integration by hand
+		self.assertAlmostEqual( integral, 0.5 * ( ( 10 - 0 ) * ( 1 + 2 ) + ( 20 - 10 ) * ( 2 + 0 ) + ( 21 - 20 ) * ( 0 + 2 ) ), 7 )
+
 if __name__ == "__main__":
     unittest.main()
 


### PR DESCRIPTION
So, I'm trying to address this one:

https://github.com/GafferHQ/gaffer/issues/590

Along the way, I also made it not require as many CVs when using a cubic basis function where some of the CV coefficients are 0.  Previously, when using a linear basis, the last two segments wouldn't render unless you doubled up the endpoints, which seems undesirable?

The tricky bit though, is how to handle non-monotonic relationships between t and x.  This can happen pretty easily with the catmullRom basis.  The knot values are guaranteed to be monotonic, but the resulting curve is not.  What to do in these cases is pretty ill-defined - the actual curve has a little overlap in it, so there are multiple possible values to return.  I could have tried to think about what would be expected by a user who has set up a weird curve like this, but the simplest option is to observe that we want interoperability with OSL, so it would be great if our splines just matched OSL.  Using the invert function from OIIO like OSL does gives better results for the curve from that old issue, and means that Gaffer user will get consistent results if they use the ramp editor to set up OSL ramps.

If this looks good to you, the main thing left would be some fixes and cleaning up tests.  There are still some bugs here for me to finish off ( supporting linear segments properly touches a lot of these functions, would you rather I just duplicate endpoints on linear curves?  Seems a bit sloppy. )  What about tests though?  We don't want to make Cortex depend on OSL for testing do we?  Should I build the tests for the new behaviour on the Gaffer side?  Is it good enough to get the old tests passing?