### PR TITLE
SConstruct : Support extra suffix on version ...

### DIFF
--- a/config/ie/buildAll
+++ b/config/ie/buildAll
@@ -19,7 +19,6 @@ def build( extraArgs = [] ) :
 	release = False
 	if "RELEASE=1" in sysArgs :
 		release = True
-		sysArgs.remove( "RELEASE=1" )
 	
 	if "J=" in " ".join( sysArgs ) :
 		sysArgs = " ".join( sysArgs ).replace( "J=", "-j " ).split( " " )

--- a/config/ie/options
+++ b/config/ie/options
@@ -237,6 +237,11 @@ if PYTHON_LINK_FLAGS=="" :
 # get the installation locations right
 INSTALL_PREFIX = getOption( "INSTALL_PREFIX", os.path.expanduser( "~" ) )
 installPrefix = os.path.join( "$INSTALL_PREFIX", "apps", "cortex", "$IECORE_MAJORMINORPATCH_VERSION", platform )
+
+# add the dev suffix to local builds
+if getOption( "RELEASE", "0" )!="1" :
+	installPrefix = os.path.join( "$INSTALL_PREFIX", "apps", "cortex", "${IECORE_MAJORMINORPATCH_VERSION}dev", platform )
+
 basePrefix = os.path.join( installPrefix, "base" )
 if targetApp :
 	appPrefix = os.path.join( installPrefix, targetApp, targetAppMajorVersion )


### PR DESCRIPTION
... used by ie/options to set dev suffix for local installs

This brings how Cortex local builds work at IE more in line with Gaffer builds, and prevents getting a confusing mix of locally and centrally installed files.