### PR TITLE
Fix mantra crash with procedural for Houdini 16

### DIFF
--- a/contrib/IECoreMantra/src/IECoreMantra/procedural/World.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/procedural/World.cpp
@@ -75,10 +75,12 @@ public:
 	virtual void	 render();
 #if UT_MAJOR_VERSION_INT >= 16
 	UT_StringHolder m_worldFileName;
+	int32 m_remove;
 #else
 	UT_String m_worldFileName;
-#endif
 	int m_remove;
+#endif
+
 };
 
 static VRAY_ProceduralArg theArgs[] = {


### PR DESCRIPTION
Change in H16 from int to int32 in VRAY/VRAY_Procedural.h in the import function, which was causing mantra to crash unless the procedural was never loaded.
http://www.sidefx.com/docs/hdk16.0/_v_r_a_y___procedural_8h_source.html