### PR TITLE
Fix render procedural houdini16

### DIFF
--- a/contrib/IECoreMantra/include/IECoreMantra/ProceduralPrimitive.h
+++ b/contrib/IECoreMantra/include/IECoreMantra/ProceduralPrimitive.h
@@ -37,15 +37,31 @@
 #ifndef IECOREMANTRA_PROCEDURALPRIMITIVE_H
 #define IECOREMANTRA_PROCEDURALPRIMITIVE_H
 
-#include "VRAY/VRAY_Procedural.h"
 #include "UT/UT_Version.h"
+#include "VRAY/VRAY_Procedural.h"
+#if UT_MAJOR_VERSION_INT >=16
+#include "VRAY/VRAY_ProceduralFactory.h"
+#endif
 
 #include "IECore/VisibleRenderable.h"
 
 
 namespace IECoreMantra
 {
-	
+#if UT_MAJOR_VERSION_INT >= 16
+template <typename ProceduralType>
+class VRAY_ieProcDefinition : public VRAY_ProceduralFactory::ProcDefinition
+{
+public:
+	VRAY_ieProcDefinition()
+		: VRAY_ProceduralFactory::ProcDefinition(ProceduralType::ieProceduralName)
+	{
+	}
+	virtual VRAY_Procedural     *create() const { return new ProceduralType(); }
+	virtual VRAY_ProceduralArg  *arguments() const { return ProceduralType::theArgs; }
+};
+#endif
+
 IE_CORE_FORWARDDECLARE( RendererImplementation )
 
 class ProceduralPrimitive : public VRAY_Procedural
@@ -81,7 +97,7 @@ class ProceduralPrimitive : public VRAY_Procedural
 		fpreal m_fps;
 		fpreal m_preBlur, m_postBlur;
 #endif
-
+		static const UT_StringHolder ieProceduralName;
 	
     private:
 		void applySettings(VRAY_ProceduralChildPtr child);

--- a/contrib/IECoreMantra/include/IECoreMantra/ProceduralPrimitive.h
+++ b/contrib/IECoreMantra/include/IECoreMantra/ProceduralPrimitive.h
@@ -68,17 +68,23 @@ class ProceduralPrimitive : public VRAY_Procedural
 		virtual void getBoundingBox( UT_BoundingBox &box );
 		virtual void render();
 		// cortex types interface
-		virtual void addChild( ProceduralPrimitive *proc );
 		virtual void addVisibleRenderable ( IECore::VisibleRenderablePtr renderable );
 		
         // mantra data for procedurals
 		Imath::Box3f m_bound;
+#if UT_MAJOR_VERSION_INT >= 16
+		fpreal64 m_cameraShutter[2];
+		fpreal64 m_fps;
+		fpreal64 m_preBlur, m_postBlur;
+#else
 		fpreal m_cameraShutter[2];
 		fpreal m_fps;
 		fpreal m_preBlur, m_postBlur;
+#endif
+
 	
     private:
-		void applySettings();
+		void applySettings(VRAY_ProceduralChildPtr child);
 		// cortex data
 		RendererImplementationPtr m_renderer;
 		IECore::Renderer::ProceduralPtr m_procedural;

--- a/contrib/IECoreMantra/src/IECoreMantra/ProceduralPrimitive.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/ProceduralPrimitive.cpp
@@ -34,6 +34,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include <UT/UT_DSOVersion.h>
+
 #include "IECore/MeshPrimitive.h"
 #include "IECore/PointsPrimitive.h"
 #include "IECore/MessageHandler.h"

--- a/contrib/IECoreMantra/src/IECoreMantra/RendererImplementation.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/RendererImplementation.cpp
@@ -201,6 +201,7 @@ IECoreMantra::RendererImplementation::~RendererImplementation()
 			if ( pclose(m_fpipe) == -1 )
 			{
 				msg( Msg::Error, "IECoreMantra::RendererImplementation::~RendererImplementation()", "pclose error" );
+				m_fpipe = NULL;
 			}
 		}
 		else if ( m_mode == IfdGen )
@@ -208,6 +209,7 @@ IECoreMantra::RendererImplementation::~RendererImplementation()
 			if ( fclose(m_fpipe) != 0 )
 			{
 				msg( Msg::Error, "IECoreMantra::RendererImplementation::~RendererImplementation()", "fclose error" );
+				m_fpipe = NULL;
 			}
 		}
 	}
@@ -567,6 +569,7 @@ void IECoreMantra::RendererImplementation::worldEnd()
 	{	
 		msg( Msg::Error, "IECoreMantra::RendererImplementation::worldEnd", "pclose error" );
 	}
+	m_fpipe = NULL;
 }
 
 void IECoreMantra::RendererImplementation::transformBegin()

--- a/contrib/IECoreMantra/src/IECoreMantra/RendererImplementation.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/RendererImplementation.cpp
@@ -70,7 +70,11 @@ IECoreMantra::RendererImplementation::AttributeState::AttributeState( const Attr
 
 IECore::ConstDataPtr IECoreMantra::RendererImplementation::getShutterOption( const std::string &name ) const
 {
-	float shutter[2];
+#if UT_MAJOR_VERSION_INT >= 16
+	fpreal64 shutter[2];
+#else
+	fpreal shutter[2];
+#endif
 	if ( m_vrayproc->import("camera:shutter", shutter, 2) )
 	{
 		return new V2fData( V2f(shutter[0], shutter[1]) );
@@ -80,7 +84,11 @@ IECore::ConstDataPtr IECoreMantra::RendererImplementation::getShutterOption( con
 
 IECore::ConstDataPtr IECoreMantra::RendererImplementation::getResolutionOption( const std::string &name ) const
 {
-	float res[2];
+#if UT_MAJOR_VERSION_INT >= 16
+	fpreal64 res[2];
+#else
+	fpreal res[2];
+#endif
 	if ( m_vrayproc->import("image:resolution", res, 2) )
 	{
 		return new V2fData( V2f(res[0], res[1]) );
@@ -90,10 +98,18 @@ IECore::ConstDataPtr IECoreMantra::RendererImplementation::getResolutionOption( 
 
 IECore::ConstDataPtr IECoreMantra::RendererImplementation::getVelocityBlurAttribute( const std::string &name ) const
 {
+#if UT_MAJOR_VERSION_INT >= 16
+	fpreal64 v;
+#else
 	int v;
+#endif
 	if ( m_vrayproc->import("object:velocityblur", &v, 1) )
 	{
+#if UT_MAJOR_VERSION_INT >= 16
+		return new FloatData( v );
+#else
 		return new IntData( v );
+#endif
 	}
 	return 0;
 }
@@ -988,7 +1004,8 @@ void IECoreMantra::RendererImplementation::procedural( IECore::Renderer::Procedu
 	bound = transform(bound, m_transformStack.top() );
 	renderer->m_vrayproc->m_bound = bound;
 	// add the new VRAY procedural to it's parent
-	m_vrayproc->addChild( renderer->m_vrayproc );
+	VRAY_ProceduralChildPtr child = m_vrayproc->createChild();
+	child->addProcedural( renderer->m_vrayproc );
 }
 
 void IECoreMantra::RendererImplementation::instanceBegin( const std::string &name, const IECore::CompoundDataMap &parameters )

--- a/contrib/IECoreMantra/src/IECoreMantra/procedural/Procedural.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/procedural/Procedural.cpp
@@ -34,9 +34,14 @@
 
 #include "boost/python.hpp"
 
+#include <UT/UT_Version.h>
+#include <UT/UT_DSOVersion.h>
 #include <UT/UT_WorkArgs.h>
 #include <UT/UT_String.h>
 #include <GU/GU_Detail.h>
+#if UT_MAJOR_VERSION_INT >= 16
+#include <VRAY/VRAY_ProceduralFactory.h>
+#endif
 
 #include "IECore/MessageHandler.h"
 #include "IECore/ParameterisedProcedural.h"
@@ -95,11 +100,13 @@ public:
 	int m_classVersion;
 	UT_String m_parameterString;
 #endif
-
+	static VRAY_ProceduralArg theArgs[];
+	static const UT_StringHolder ieProceduralName;
 };
 
-static VRAY_ProceduralArg theArgs[] = {
-	VRAY_ProceduralArg("className", "string", "read"), 
+const UT_StringHolder VRAY_ieProcedural::ieProceduralName("VRAY_ieProcedural");
+VRAY_ProceduralArg VRAY_ieProcedural::theArgs[] = {
+	VRAY_ProceduralArg("className", "string", "read"),
 	VRAY_ProceduralArg("classVersion", "int", "1"),
 	VRAY_ProceduralArg("parameterString", "string", ""),
 	VRAY_ProceduralArg()
@@ -114,7 +121,7 @@ allocProcedural(const char *)
 const VRAY_ProceduralArg *
 getProceduralArgs(const char *)
 {
-	return theArgs;
+	return VRAY_ieProcedural::theArgs;
 }
 
 VRAY_ieProcedural::VRAY_ieProcedural()
@@ -139,6 +146,13 @@ const char *VRAY_ieProcedural::getClassName()
 	return "VRAY_ieProcedural";
 }
 
+#endif
+
+#if UT_MAJOR_VERSION_INT >= 16
+void registerProcedural(VRAY_ProceduralFactory *factory)
+{
+    factory->insert(new IECoreMantra::VRAY_ieProcDefinition<VRAY_ieProcedural>());
+}
 #endif
 
 // The initialize method is called when the procedural is created. 

--- a/contrib/IECoreMantra/src/IECoreMantra/procedural/Procedural.cpp
+++ b/contrib/IECoreMantra/src/IECoreMantra/procedural/Procedural.cpp
@@ -114,7 +114,7 @@ public:
 	virtual void	 render();
 #if UT_MAJOR_VERSION_INT >= 16
 	UT_StringHolder m_className;
-	int64 m_classVersion;
+	int32 m_classVersion;
 	UT_StringHolder m_parameterString;
 #else 
 	UT_String m_className;

--- a/contrib/IECoreMantra/test/IECoreMantra/RendererTest.py
+++ b/contrib/IECoreMantra/test/IECoreMantra/RendererTest.py
@@ -152,8 +152,8 @@ class RendererTest( unittest.TestCase ):
 		p = subprocess.Popen( ['mantra', '-V8'], stdin=open('/dev/null'), stdout=subprocess.PIPE )
 		out = p.communicate()[0]
 		self.assertTrue( out )
-		self.failUnless( "Registering procedural 'ieprocedural'" in out )
-		self.failUnless( "Registering procedural 'ieworld'" in out )
+		self.failUnless( "Registering procedural 'ieprocedural'" in out or "adding procedural 'ieprocedural'" in out )
+		self.failUnless( "Registering procedural 'ieworld'" in out or "adding procedural 'ieworld'" in out )
 
 	def testOptions( self ):
 		ifd = _dir + "/output/testOptions.ifd"
@@ -196,12 +196,13 @@ class RendererTest( unittest.TestCase ):
 		self.assertTrue( world )
 		self.assertEquals( world.typeId(), IECore.Group.staticTypeId() )
 		self.assertTrue( world.state() )
-		self.assertEquals( 
-			world.state()[0].attributes[':surface'], 
-			IECore.StringData( 'testshader p2 1.234 p3 "hello" p1 11 p4 1 2 3 p5 1 0 0 ')
+		self.assertItemsEqual(
+			world.state()[0].attributes[':surface'].value.split(" "),
+			IECore.StringData( 'testshader p2 1.234 p3 "hello" p1 11 p4 1 2 3 p5 1 0 0 ').value.split(" ")
 		)
 	
 	def tearDown( self ):
+
 		files = [
 				_dir + "/output/testGeometry.tif",
 				_dir + "/output/testWorldMesh.tif",
@@ -216,7 +217,7 @@ class RendererTest( unittest.TestCase ):
 		for f in files:
 			if os.path.exists( f ):
 				os.remove( f )
-
+	
 if __name__ == "__main__":
 	unittest.main()
 				

--- a/contrib/IECoreMantra/test/IECoreMantra/RendererTest.py
+++ b/contrib/IECoreMantra/test/IECoreMantra/RendererTest.py
@@ -33,15 +33,26 @@
 ##########################################################################
 
 import os
+import re
 import subprocess
 import unittest
 
-import IECore 
+import IECore
 import IECoreMantra
 
 _dir = os.path.dirname( __file__ )
 
 class RendererTest( unittest.TestCase ):
+	
+	@classmethod
+	def setUpClass(cls):
+		if os.path.exists( _dir + "/output/" ) is False:
+			os.makedirs( _dir + "/output/" )
+	
+	@classmethod
+	def tearDownClass(cls):
+		if os.path.exists( _dir + "/output/" ):
+			os.rmdir( _dir + "/output/" )
 	
 	def __greenSquare( self, r ):
 		r.shader( "surface", "constant", { "Cd": IECore.V3fData( IECore.V3f( 0, 1, 0 ) ) } )
@@ -196,13 +207,36 @@ class RendererTest( unittest.TestCase ):
 		self.assertTrue( world )
 		self.assertEquals( world.typeId(), IECore.Group.staticTypeId() )
 		self.assertTrue( world.state() )
-		self.assertItemsEqual(
-			world.state()[0].attributes[':surface'].value.split(" "),
-			IECore.StringData( 'testshader p2 1.234 p3 "hello" p1 11 p4 1 2 3 p5 1 0 0 ').value.split(" ")
+		# check the shader parameters
+		expectedValues = {
+			'p1': '11',
+			'p2': '1.234',
+			'p3': '"hello"',
+			'p4': '1 2 3',
+			'p5': '1 0 0'
+		}
+		self.assertDictEqual(
+			RendererTest._parseShaderString( world.state()[0].attributes[':surface'].value, expectedValues.keys() ),
+			expectedValues
 		)
-	
-	def tearDown( self ):
+		
+	@staticmethod
+	def _parseShaderString( shaderString, keys ):
+		"""
+		parse a string and based on keys. This will work even if the parameters get set in different orders
+		@param shaderString string to parse
+		@param keys list of strings with the strings being what the parameter names are
+		@return dict, with the key being the parameter name, and the value being the value of this parameter
+		"""
+		# remove the initial shader name
+		shaderParams = " ".join( shaderString.split( " " )[1:] )
+		# split based on the keys, but capture the name of the key
+		flatParameters = filter( None, re.split( "(" + "|".join(keys) + ")", shaderParams ) )
+		# convert the result into a dictionary and remove the whitespace
+		return dict( [ ( key.strip(), val.strip() ) for key, val in zip( *( iter( flatParameters ), )*2 ) ] )
+			
 
+	def tearDown( self ):
 		files = [
 				_dir + "/output/testGeometry.tif",
 				_dir + "/output/testWorldMesh.tif",
@@ -217,7 +251,7 @@ class RendererTest( unittest.TestCase ):
 		for f in files:
 			if os.path.exists( f ):
 				os.remove( f )
-	
+
 if __name__ == "__main__":
 	unittest.main()
 				


### PR DESCRIPTION
Mantra was still crashing when rendering. This was caused by allocateGeometry being removed from the HDK instead of deprecated. The tests are now loading, but the testMantra tests that compare images fail because the generated images are slightly different, the edges look a bit blurry in the test generated images, so something is not working 100% correctly. This is still better than crashing, but any suggestions as to how to look into regarding the slightly bigger/blurrier test generated images would be great too. 