### PR TITLE
TypedData : Move template specialisations into IECore namespace

### DIFF
--- a/src/IECore/CompoundDataBase.cpp
+++ b/src/IECore/CompoundDataBase.cpp
@@ -207,7 +207,7 @@ void SimpleDataHolder<CompoundDataMap>::hash( MurmurHash &h ) const
 	}
 }
 
-} // namespace IECore
-
 // Instantiate that bad boy.
 template class IECORE_API TypedData<CompoundDataMap>;
+
+} // namespace IECore

--- a/src/IECore/CubeColorLookupData.cpp
+++ b/src/IECore/CubeColorLookupData.cpp
@@ -131,8 +131,8 @@ IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( CubeColorLookupdData, CubeColo
 SPECIALISE( CubeColorLookupfData )
 SPECIALISE( CubeColorLookupdData )
 
-}
-
 // Instantiations
 template class IECORE_API TypedData<CubeColorLookupf>;
 template class IECORE_API TypedData<CubeColorLookupd>;
+
+}

--- a/src/IECore/SplineData.cpp
+++ b/src/IECore/SplineData.cpp
@@ -139,10 +139,10 @@ SPECIALISE( SplineddData, double, 1 )
 SPECIALISE( SplinefColor3fData, float, 3 )
 SPECIALISE( SplinefColor4fData, float, 4 )
 
-}
-
 // Instantiations
 template class IECORE_API TypedData<Splineff>;
 template class IECORE_API TypedData<Splinedd>;
 template class IECORE_API TypedData<SplinefColor3f>;
 template class IECORE_API TypedData<SplinefColor4f>;
+
+}


### PR DESCRIPTION
This is needed to fix the std=c++11 build on OSX.