### PR TITLE
LRUCache improvements

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -101,12 +101,6 @@ o.Add(
 )
 
 o.Add(
-	"TESTCXXFLAGS",
-	"The extra flags to pass to the C++ compiler during compilation of unit tests.",
-	[ "-pipe", "-Wall", "-O0" ]
-)
-
-o.Add(
 	"LINKFLAGS",
 	"The extra flags to pass to the linker.",
 	[]
@@ -1270,8 +1264,6 @@ if pythonModuleEnv["PLATFORM"]=="darwin" :
 ###########################################################################################
 
 testEnv = env.Clone()
-testEnv.Replace( CXXFLAGS = env.subst("$TESTCXXFLAGS") )
-testEnv.Prepend( CXXFLAGS = " ".join( dependencyIncludes ) )
 
 testEnvLibPath = ":".join( testEnv["LIBPATH"] )
 if testEnv["TEST_LIBPATH"] != "" :

--- a/config/ie/options
+++ b/config/ie/options
@@ -147,11 +147,6 @@ withAsserts = getOption( "WITH_ASSERTS", withAsserts )
 if not withAsserts :
 	CXXFLAGS += [ "-DNDEBUG", "-DBOOST_DISABLE_ASSERTS" ]
 
-TESTCXXFLAGS = copy.copy( CXXFLAGS )
-
-# Special workaround for suspected gcc issue - see BoostUnitTestTest for more information
-TESTCXXFLAGS += [ "-O0" ]
-
 if not debug :
 
 	CXXFLAGS += [ "-O2" ]

--- a/include/IECore/LRUCache.h
+++ b/include/IECore/LRUCache.h
@@ -47,7 +47,7 @@ namespace IECore
 /// A mapping from keys to values, where values are computed from keys using a user
 /// supplied function. Recently computed values are stored in the cache to accelerate
 /// subsequent lookups. Each value has a cost associated with it, and the cache has
-/// a maximum total cost above which it will remove the least recently accessed items. 
+/// a maximum total cost above which it will remove the least recently accessed items.
 ///
 /// The Key type must have a tbb_hasher implementation.
 ///
@@ -61,9 +61,9 @@ template<typename Key, typename Value>
 class LRUCache : private boost::noncopyable
 {
 	public:
-	
+
 		typedef size_t Cost;
-		
+
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
 		/// any reason. It is unsafe to access the LRUCache itself from the GetterFunction.
@@ -116,7 +116,7 @@ class LRUCache : private boost::noncopyable
 		Cost currentCost() const;
 
 	private :
-		
+
 		// Data
 		//////////////////////////////////////////////////////////////////////////
 
@@ -133,7 +133,7 @@ class LRUCache : private boost::noncopyable
 			TooCostly, // entry cost exceeds m_maxCost and therefore isn't stored
 			Failed // m_getter failed when computing entry
 		};
-		
+
 		// The type used to store a single cached item.
 		struct CacheEntry;
 
@@ -156,10 +156,10 @@ class LRUCache : private boost::noncopyable
 		{
 			CacheEntry(); // status == New, previous == next == NULL
 			CacheEntry( const CacheEntry &other );
-			
+
 			Value value; // value for this item
 			Cost cost; // the cost for this item
-			
+
 			// Pointers to previous and next items
 			// in the LRU list. We use the CacheEntries
 			// themselves to store the list because it is
@@ -173,7 +173,7 @@ class LRUCache : private boost::noncopyable
 			// at any given moment.
 			MapValue *previous;
 			MapValue *next;
-			
+
 			char status; // status of this item
 			// Mutex - must be held before accessing any
 			// fields other than the list fields (previous
@@ -187,13 +187,13 @@ class LRUCache : private boost::noncopyable
 		// from the start when we need to reduce costs.
 		MapValue m_listStart;
 		MapValue m_listEnd;
-	
+
 		// The list is inherently a serial data structure, so we must
 		// protect all accesses with this mutex. The mutex _must_ be held
 		// before the list fields of _any_ MapValue may be accessed.
 		typedef tbb::spin_mutex ListMutex;
 		ListMutex m_listMutex;
-		
+
 		// Total cost. We store the current cost atomically so it can be updated
 		// concurrently by multiple threads.
 		typedef tbb::atomic<Cost> AtomicCost;
@@ -215,7 +215,7 @@ class LRUCache : private boost::noncopyable
 		// exceeded the maximum cost. The mutex for the CacheEntry must be held by
 		// the caller.
 		bool setInternal( MapValue *mapValue, const Value &value, Cost cost );
-		
+
 		// Sets the status for the cache entry to Erased, removes any
 		// previously Cached value, updates m_currentCost and removes
 		// the entry from the LRU list. The caller must hold m_listMutex, and

--- a/include/IECore/LRUCache.h
+++ b/include/IECore/LRUCache.h
@@ -131,10 +131,8 @@ class LRUCache : private boost::noncopyable
 		// Status of each item in the cache.
 		enum Status
 		{
-			New, // brand new unpopulated entry
-			Cached, // entry complete with value
-			Erased, // entry once had value but it was removed to meet cost limits
-			TooCostly, // entry cost exceeds m_maxCost and therefore isn't stored
+			Uncached, // entry without valid value
+			Cached, // entry with valid value
 			Failed // m_getter failed when computing entry
 		};
 
@@ -158,7 +156,7 @@ class LRUCache : private boost::noncopyable
 		// CacheEntry implementation - a single item of the cache.
 		struct CacheEntry
 		{
-			CacheEntry(); // status == New, previous == next == NULL
+			CacheEntry(); // status == Uncached, previous == next == NULL
 			CacheEntry( const CacheEntry &other );
 
 			Value value; // value for this item
@@ -220,7 +218,7 @@ class LRUCache : private boost::noncopyable
 		// the caller.
 		bool setInternal( MapValue *mapValue, const Value &value, Cost cost );
 
-		// Sets the status for the cache entry to Erased, removes any
+		// Sets the status for the cache entry to Uncached, removes any
 		// previously Cached value, updates m_currentCost and removes
 		// the entry from the LRU list. The caller must hold m_listMutex, and
 		// must _not_ hold the mutex for the cache entry.

--- a/include/IECore/LRUCache.h
+++ b/include/IECore/LRUCache.h
@@ -35,9 +35,6 @@
 #ifndef IECORE_LRUCACHE_H
 #define IECORE_LRUCACHE_H
 
-#include "tbb/spin_mutex.h"
-#include "tbb/concurrent_unordered_map.h"
-
 #include "boost/noncopyable.hpp"
 #include "boost/function.hpp"
 #include "boost/variant.hpp"
@@ -45,36 +42,55 @@
 namespace IECore
 {
 
+namespace LRUCachePolicy
+{
+
+/// Not threadsafe. Either use from only a single thread
+/// or protect with an external mutex. Key type must have
+/// a `hash_value` implementation as described in the boost
+/// documentation.
+template<typename LRUCache>
+class Serial;
+
+/// Threadsafe, `get()` blocks if another thread is already
+/// computing the value. Key type must have a `hash_value`
+/// implementation as described in the boost documentation.
+template<typename LRUCache>
+class Parallel;
+
+} // namespace LRUCachePolicy
+
 /// A mapping from keys to values, where values are computed from keys using a user
 /// supplied function. Recently computed values are stored in the cache to accelerate
 /// subsequent lookups. Each value has a cost associated with it, and the cache has
 /// a maximum total cost above which it will remove the least recently accessed items.
 ///
-/// The Key type must have a tbb_hasher implementation.
-///
 /// The Value type must be default constructible, copy constructible and assignable.
 /// Note that Values are returned by value, and erased by assigning a default constructed
 /// value. In practice this means that a smart pointer is the best choice of Value.
+///
+/// The Policy determines the thread safety, eviction and performance characteristics
+/// of the cache. See the documentation for each individual policy in the LRUCachePolicy
+/// namespace.
 ///
 ///	The GetterKey may be used where the GetterFunction requires some auxiliary information
 /// in addition to the Key. It must be implicitly castable to Key, and all GetterKeys
 /// which yield the same Key must also yield the same results from the GetterFunction.
 ///
-/// \threading It is safe to call the methods of LRUCache from concurrent threads.
 /// \ingroup utilityGroup
-template<typename Key, typename Value, typename GetterKey=Key>
+template<typename Key, typename Value, template <typename> class Policy=LRUCachePolicy::Parallel, typename GetterKey=Key>
 class LRUCache : private boost::noncopyable
 {
 	public:
 
 		typedef size_t Cost;
+		typedef Key KeyType;
 
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
-		/// any reason. It is unsafe to access the LRUCache itself from the GetterFunction.
+		/// any reason.
 		typedef boost::function<Value ( const GetterKey &key, Cost &cost )> GetterFunction;
 		/// The optional RemovalCallback is called whenever an item is discarded from the cache.
-		///  It is unsafe to access the LRUCache itself from the RemovalCallback.
 		typedef boost::function<void ( const Key &key, const Value &data )> RemovalCallback;
 
 		LRUCache( GetterFunction getter );
@@ -125,6 +141,9 @@ class LRUCache : private boost::noncopyable
 		// Data
 		//////////////////////////////////////////////////////////////////////////
 
+		// Give Policy access to CacheEntry definitions.
+		friend class Policy<LRUCache>;
+
 		// A function for computing values, and one for notifying of removals.
 		GetterFunction m_getter;
 		RemovalCallback m_removalCallback;
@@ -138,27 +157,9 @@ class LRUCache : private boost::noncopyable
 		};
 
 		// The type used to store a single cached item.
-		struct CacheEntry;
-
-		// Map from keys to items - this forms the basis of
-		// our cache. The concurrent_unordered_map has the
-		// following pertinent properties :
-		//
-		// - find(), insert() and traversal may be invoked concurrently
-		// - erase() may _not_ be invoked concurrently (hence we don't use it)
-		// - value access is not locked in any way (we are responsible for
-		// our own locking when accessing the CacheEntry).
-		typedef tbb::concurrent_unordered_map<Key, CacheEntry> Map;
-		typedef typename Map::iterator MapIterator;
-		typedef typename Map::const_iterator ConstMapIterator;
-		typedef typename Map::value_type MapValue;
-		Map m_map;
-
-		// CacheEntry implementation - a single item of the cache.
 		struct CacheEntry
 		{
-			CacheEntry(); // status == Uncached, previous == next == NULL
-			CacheEntry( const CacheEntry &other );
+			CacheEntry();
 
 			// We use a boost::variant to compactly store
 			// a union of the data needed for each Status.
@@ -171,85 +172,30 @@ class LRUCache : private boost::noncopyable
 			State state;
 			Cost cost; // the cost for this item
 
-			// Pointers to previous and next items
-			// in the LRU list. We use the CacheEntries
-			// themselves to store the list because it is
-			// quicker than using an external structure
-			// like a std::list. Note that although the
-			// purpose of the list is to track items where
-			// status==Cached, the two are not updated
-			// atomically, so it may _not_ be assumed
-			// that status==Cached implies previous!=NULL
-			// or status!=Cached implies previous==NULL
-			// at any given moment.
-			MapValue *previous;
-			MapValue *next;
-
-			// Mutex - must be held before accessing any
-			// fields other than the list fields (previous
-			// and next). To access the list fields, m_listMutex
-			// must be held instead.
-			tbb::spin_mutex mutex;
-
 			Status status() const;
 
 		};
 
-		// Dummy MapValues to represent the start and end of our LRU list.
-		// Items are moved to the end when they are accessed, and removed
-		// from the start when we need to reduce costs.
-		MapValue m_listStart;
-		MapValue m_listEnd;
+		// Policy. This is responsible for
+		// the internal storage for the cache.
+		Policy<LRUCache> m_policy;
 
-		// The list is inherently a serial data structure, so we must
-		// protect all accesses with this mutex. The mutex _must_ be held
-		// before the list fields of _any_ MapValue may be accessed.
-		typedef tbb::spin_mutex ListMutex;
-		ListMutex m_listMutex;
-
-		// Total cost. We store the current cost atomically so it can be updated
-		// concurrently by multiple threads.
-		typedef tbb::atomic<Cost> AtomicCost;
-		AtomicCost m_currentCost;
 		Cost m_maxCost;
 
 		// Methods
-		//
-		// Note that great care must be taken to properly handle the
-		// CacheEntry and list mutexes to avoid deadlock. If both m_listMutex
-		// and a CacheEntry::mutex must be held, the list mutex must be acquired
-		// _first_, and the CacheEntry::mutex _second_. Pay attention to the
-		// documentation for each method, to ensure that the right locks are held
-		// at the right times.
-		//////////////////////////////////////////////////////////////////////////
+		// =======
 
-		// Updates the cache entry with the new value and updates m_currentCost
-		// appropriately. Returns true if the value was stored and false if it
-		// exceeded the maximum cost. The mutex for the CacheEntry must be held by
-		// the caller.
-		bool setInternal( MapValue *mapValue, const Value &value, Cost cost );
+		// Updates the cached value and updates the current
+		// total cost.
+		bool setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost );
 
-		// Sets the status for the cache entry to Uncached, removes any
-		// previously Cached value, updates m_currentCost and removes
-		// the entry from the LRU list. The caller must hold m_listMutex, and
-		// must _not_ hold the mutex for the cache entry.
-		bool eraseInternal( MapValue *mapValue );
+		// Removes any cached value and updates the current total
+		// cost.
+		bool eraseInternal( const Key &key, CacheEntry &cacheEntry );
 
-		// Caller must not hold any locks.
-		void limitCost();
-
-		// Either erases the item from the list, or moves it to
-		// the end, depending on whether or not it is cached.
-		// Caller must not hold any locks.
-		void updateListPosition( MapValue *mapValue );
-
-		// If the item is in the list, erases it, otherwise
-		// does nothing. Caller must hold m_listMutex.
-		void listErase( MapValue *mapValue );
-		// Inserts the item at the end of the list - the
-		// item must _not_ already be in the list.
-		// Caller must hold m_listMutex.
-		void listInsertAtEnd( MapValue *mapValue );
+		// Removes items from the cache until the current cost is
+		// at or below the specified limit.
+		void limitCost( Cost cost );
 
 		static void nullRemovalCallback( const Key &key, const Value &value );
 

--- a/include/IECore/LRUCache.h
+++ b/include/IECore/LRUCache.h
@@ -55,9 +55,13 @@ namespace IECore
 /// Note that Values are returned by value, and erased by assigning a default constructed
 /// value. In practice this means that a smart pointer is the best choice of Value.
 ///
+///	The GetterKey may be used where the GetterFunction requires some auxiliary information
+/// in addition to the Key. It must be implicitly castable to Key, and all GetterKeys
+/// which yield the same Key must also yield the same results from the GetterFunction.
+///
 /// \threading It is safe to call the methods of LRUCache from concurrent threads.
 /// \ingroup utilityGroup
-template<typename Key, typename Value>
+template<typename Key, typename Value, typename GetterKey=Key>
 class LRUCache : private boost::noncopyable
 {
 	public:
@@ -67,7 +71,7 @@ class LRUCache : private boost::noncopyable
 		/// The GetterFunction is responsible for computing the value and cost for a cache entry
 		/// when given the key. It should throw a descriptive exception if it can't get the data for
 		/// any reason. It is unsafe to access the LRUCache itself from the GetterFunction.
-		typedef boost::function<Value ( const Key &key, Cost &cost )> GetterFunction;
+		typedef boost::function<Value ( const GetterKey &key, Cost &cost )> GetterFunction;
 		/// The optional RemovalCallback is called whenever an item is discarded from the cache.
 		///  It is unsafe to access the LRUCache itself from the RemovalCallback.
 		typedef boost::function<void ( const Key &key, const Value &data )> RemovalCallback;
@@ -82,7 +86,7 @@ class LRUCache : private boost::noncopyable
 		/// cache at any time by operations on another thread, or may not
 		/// even be stored in the cache if it exceeds the maximum cost.
 		/// Throws if the item can not be computed.
-		Value get( const Key &key );
+		Value get( const GetterKey &key );
 
 		/// Adds an item to the cache directly, bypassing the GetterFunction.
 		/// Returns true for success and false on failure - failure can occur

--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -689,6 +689,8 @@ bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &
 	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
 	bool result = setInternal( key, handle.writable(), value, cost );
 	m_policy.push( handle );
+	handle.release();
+	limitCost( m_maxCost );
 	return result;
 }
 

--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -38,117 +38,605 @@
 
 #include <cassert>
 #include <iostream>
+#include <tuple>
+
+#include "tbb/spin_mutex.h"
+#include "tbb/spin_rw_mutex.h"
+#include "tbb/tbb_thread.h"
+
+#include "boost/multi_index_container.hpp"
+#include "boost/multi_index/hashed_index.hpp"
+#include "boost/multi_index/sequenced_index.hpp"
+#include "boost/multi_index/member.hpp"
+#include "boost/unordered_map.hpp"
 
 #include "IECore/Exception.h"
 
 namespace IECore
 {
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::CacheEntry::CacheEntry()
-	:	state( boost::blank() ), cost( 0 ), previous( NULL ), next( NULL ), mutex()
+// Policies
+// =======================================================================
+//
+// The policies are responsible for implementing the principle
+// data structures of the cache. Conceptually they contain a mapping from
+// Key to CacheEntry and a separate list sorted in least-recently-used order.
+// In practice, any data structure can be used provided the interface
+// described below is presented. The required interface is documented
+// on the Serial policy only for simplicity.
+namespace LRUCachePolicy
+{
+
+enum AcquireMode
+{
+	FindReadable,
+	FindWritable,
+	// Writability of handle is determined
+	// by CacheEntry status - writable if
+	// Uncached and read only otherwise.
+	Insert,
+	InsertWritable
+};
+
+
+// Uses a boost::multi_index_container to implement a map
+// and list in a single container. This gives much improved
+// performance over separate containers because it halves the
+// allocations needed, and moving items within the list doesn't
+// require any allocation at all. We keep the list in exact LRU
+// order.
+template<typename LRUCache>
+class Serial
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+
+		struct Item
+		{
+			Item( const Key &key )
+				:	key( key ), hasHandle( false )
+			{
+			}
+
+			Key key;
+			// multi_index_containers have const elements
+			// so you can't modify something being used as
+			// as key. we know that cacheEntry is not used
+			// as a key, so can safely make it mutable to
+			// get non-const access to it.
+			mutable CacheEntry cacheEntry;
+			mutable bool hasHandle;
+		};
+
+		typedef boost::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// First index is equivalent to std::unordered_map,
+				// using Item::key as the key.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>,
+				// Second index is equivalent to std::list.
+				boost::multi_index::sequenced<>
+			>
+		> MapAndList;
+
+		typedef typename MapAndList::iterator MapIterator;
+		typedef typename MapAndList::template nth_index<1>::type List;
+
+		Serial()
+			:	currentCost( 0 )
+		{
+		}
+
+		// The Handle class provides controlled access to
+		// a CacheEntry stored within the policy. Handles
+		// provide read and possibly write access to the
+		// CacheEntry, depending on how they have been
+		// acquired. The Handle must be kept alive for as
+		// long as the CacheEntry is accessed.
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_inited( false )
+			{
+			}
+
+			~Handle()
+			{
+				release();
+			}
+
+			// Read access to the underlying cache entry.
+			const CacheEntry &readable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			// Write access to the underlying cache entry.
+			// Note that write access is not always permitted
+			// - see documentation for `acquire()` and
+			// AcquireMode.
+			CacheEntry &writable()
+			{
+				return m_it->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_inited )
+				{
+					m_it->hasHandle = false;
+				}
+			}
+
+			private :
+
+				void init( MapIterator it )
+				{
+					assert( !m_inited );
+					m_it = it;
+					assert( !m_it->hasHandle );
+					m_it->hasHandle = true;
+					m_inited = true;
+				}
+
+				friend class Serial;
+				MapIterator m_it;
+				bool m_inited;
+
+		};
+
+		// Acquires a handle for the given key. Whether the
+		// handle is writable or not is determined by the AcquireMode.
+		// Returns true on success and false if no entry was
+		// found.
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			if( mode == Insert || mode == InsertWritable )
+			{
+				// Inserting via the map index automatically puts the new item
+				// at the back of the list.
+				std::pair<MapIterator, bool> i = m_mapAndList.insert( Item( key ) );
+				handle.init( i.first );
+				return true;
+			}
+			else
+			{
+				assert( mode == FindReadable || mode == FindWritable );
+				MapIterator it = m_mapAndList.find( key );
+				if( it == m_mapAndList.end() )
+				{
+					return false;
+				}
+				handle.init( it );
+				return true;
+			}
+		}
+
+		// Marks the CacheEntry referred to by the handle as recently
+		// used.
+		void push( Handle &handle )
+		{
+			List &list = m_mapAndList.template get<1>();
+			list.relocate( list.end(), list.iterator_to( *(handle.m_it) ) );
+		}
+
+		// Pops a copy of the least recently used CacheEntry from the policy,
+		// removing it from the internal storage. Returns true for success
+		// and false for failure.
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			List &list = m_mapAndList.template get<1>();
+
+			// Find the first item that doesn't have a handle
+			// referring to it. Although we don't support threaded
+			// access, there may still be existing handles if the
+			// GetterFunction has reentered the cache with a call
+			// to `get( someOtherKey )`, and this inner call has
+			// then entered `limitCost()`.
+			typename List::iterator it = list.begin();
+			while( it != list.end() && it->hasHandle )
+			{
+				++it;
+			}
+
+			if( it == list.end() )
+			{
+				return false;
+			}
+
+			const Item &item = *it;
+
+			key = item.key;
+			cacheEntry = item.cacheEntry;
+
+			list.erase( it );
+
+			return true;
+		}
+
+		typename LRUCache::Cost currentCost;
+
+	private :
+
+		MapAndList m_mapAndList;
+
+};
+
+// Uses a binned map to allow concurrent map operations, and
+// uses a second-chance algorithm to avoid the serial operations
+// associated with managing an LRU list.
+template<typename LRUCache>
+class Parallel
+{
+
+	public :
+
+		typedef typename LRUCache::CacheEntry CacheEntry;
+		typedef typename LRUCache::KeyType Key;
+		typedef tbb::atomic<typename LRUCache::Cost> AtomicCost;
+
+		struct Item
+		{
+			Item() : recentlyUsed() {}
+			Item( const Key &key ) : key( key ), recentlyUsed() {}
+			Item( const Item &other ) : key( other.key ), cacheEntry( other.cacheEntry ), recentlyUsed() {}
+			Key key;
+			mutable CacheEntry cacheEntry;
+			// Mutex to protect cacheEntry.
+			typedef tbb::spin_rw_mutex Mutex;
+			mutable Mutex mutex;
+			// Flag used in second-chance algorithm.
+			mutable tbb::atomic<bool> recentlyUsed;
+		};
+
+		// We would love to use one of TBB's concurrent containers as
+		// our map, but we need the ability to insert, erase and iterate
+		// concurrently. The concurrent_unordered_map doesn't provide
+		// concurrent erase, and the concurrent_hash_map doesn't provide
+		// concurrent iteration. Instead we choose a non-threadsafe
+		// container, but split our storage into multiple bins with a
+		// container in each bin. This way concurrent operations do not
+		// contend on a lock unless they happen to target the same bin.
+		typedef boost::multi_index::multi_index_container<
+			Item,
+			boost::multi_index::indexed_by<
+				// Equivalent to std::unordered_map, using Item::key
+				// as the key. This actually has a couple of benefits
+				// over std::unordered_map :
+				//
+				// - Insertion does not invalidate existing iterators.
+				//   This allows us to store m_popIterator.
+				// - Lookup can be performed using types other than the
+				//   key. This provides the possibility of creating a
+				//   prehashed key prior to taking a Bin lock, although
+				//   this is not implemented here yet.
+				boost::multi_index::hashed_unique<
+					boost::multi_index::member<Item, Key, &Item::key>
+				>
+			>
+		> Map;
+
+		typedef typename Map::iterator MapIterator;
+
+		struct Bin
+		{
+			Bin() {}
+			Bin( const Bin &other ) : map( other.map ) {}
+			Bin &operator = ( const Bin &other ) { map = other.map; return *this; }
+			Map map;
+			typedef tbb::spin_rw_mutex Mutex;
+			Mutex mutex;
+		};
+
+		typedef std::vector<Bin> Bins;
+
+		Parallel()
+		{
+			m_bins.resize( tbb::tbb_thread::hardware_concurrency() );
+			m_popBinIndex = 0;
+			m_popIterator = m_bins[0].map.begin();
+			currentCost = 0;
+		}
+
+		struct Handle : private boost::noncopyable
+		{
+
+			Handle()
+				:	m_item( NULL ), m_writable( false )
+			{
+			}
+
+			~Handle()
+			{
+			}
+
+			const CacheEntry &readable()
+			{
+				return m_item->cacheEntry;
+			}
+
+			CacheEntry &writable()
+			{
+				assert( m_writable );
+				return m_item->cacheEntry;
+			}
+
+			void release()
+			{
+				if( m_item )
+				{
+					m_itemLock.release();
+					m_item = NULL;
+				}
+			}
+
+			private :
+
+				bool acquire( Bin &bin, const Key &key, AcquireMode mode )
+				{
+					assert( !m_item );
+
+					// Acquiring a handle requires taking two
+					// locks, first the lock for the Bin, and
+					// second the lock for the Item. We must be
+					// careful to avoid deadlock in the case of
+					// a GetterFunction which reenters the cache.
+
+					typename Bin::Mutex::scoped_lock binLock;
+					while( true )
+					{
+						// Acquire a lock on the bin, and get an iterator
+						// from the key. We optimistically assume the item
+						// may already be in the cache and first do a find()
+						// using a bin read lock. This gives us much better
+						// performance when many threads contend for items
+						// that are already in the cache.
+						binLock.acquire( bin.mutex, /* write = */ false );
+						MapIterator it = bin.map.find( key );
+						bool inserted = false;
+						if( it == bin.map.end() )
+						{
+							if( mode != Insert && mode != InsertWritable )
+							{
+								return false;
+							}
+							binLock.upgrade_to_writer();
+							std::tie<MapIterator, bool>( it, inserted ) = bin.map.insert( Item( key ) );
+						}
+						// Now try to get a lock on the item we want to
+						// acquire. When we've just inserted a new item
+						// we take a write lock directly, because we know
+						// we'll need to write to the new item. When insertion
+						// found a pre-existing item we optimistically take
+						// just a read lock, because it is faster when
+						// many threads just need to read from the same
+						// cached item.
+						m_writable = inserted || mode == FindWritable || mode == InsertWritable;
+
+						if( m_itemLock.try_acquire( it->mutex, /* write = */ m_writable ) )
+						{
+							if( !m_writable && mode == Insert && it->cacheEntry.status() == LRUCache::Uncached )
+							{
+								// We found an old item that doesn't have
+								// a value. This can either be because it
+								// was erased but hasn't been popped yet,
+								// or because the item was too big to fit
+								// in the cache. Upgrade to writer status
+								// so it can be updated in get().
+								m_itemLock.upgrade_to_writer();
+								m_writable = true;
+							}
+							// Success!
+							m_item = &*it;
+							return true;
+						}
+						else
+						{
+							// The Item lock is held by another thread.
+							// We must release the Bin lock and retry. This
+							// avoids deadlock when the GetterFunction holding
+							// the Item lock calls back into the cache and tries to
+							// access another item in the same Bin.
+							binLock.release();
+						}
+					}
+				}
+
+				friend class Parallel;
+
+				const Item *m_item;
+				typename Item::Mutex::scoped_lock m_itemLock;
+				bool m_writable;
+
+		};
+
+		bool acquire( const Key &key, Handle &handle, AcquireMode mode )
+		{
+			return handle.acquire( bin( key ), key, mode );
+		}
+
+		void push( Handle &handle )
+		{
+			// Simply mark the item as having been used
+			// recently. We will then give it a second chance
+			// in pop(), so it will not be evicted immediately.
+			// We don't need the handle to be writable to write
+			// here, because `recentlyUsed` is atomic.
+			handle.m_item->recentlyUsed = true;
+		}
+
+		bool pop( Key &key, CacheEntry &cacheEntry )
+		{
+			// Popping works by iterating the map until an item
+			// that has not been recently used is found. We store
+			// the current iteration position as m_popIterator and
+			// protect it with m_popMutex, taking the position that
+			// it is sufficient for only one thread to be limiting
+			// cost at any given time.
+			PopMutex::scoped_lock lock;
+			if( !lock.try_acquire( m_popMutex ) )
+			{
+				return false;
+			}
+
+			Bin *bin = &m_bins[m_popBinIndex];
+			typename Bin::Mutex::scoped_lock binLock( bin->mutex );
+
+			typename Item::Mutex::scoped_lock itemLock;
+			while( true )
+			{
+				// If we're at the end of this bin, advance to
+				// the next non-empty one.
+				while( m_popIterator == bin->map.end() )
+				{
+					binLock.release();
+					m_popBinIndex = ( m_popBinIndex + 1 ) % m_bins.size();
+					bin = &m_bins[m_popBinIndex];
+					binLock.acquire( bin->mutex );
+					m_popIterator = bin->map.begin();
+				}
+
+				if( itemLock.try_acquire( m_popIterator->mutex ) )
+				{
+					if( !m_popIterator->recentlyUsed )
+					{
+						// Pop this item.
+						key = m_popIterator->key;
+						cacheEntry = m_popIterator->cacheEntry;
+						// Now erase it from the bin.
+						// We must release the lock on the Item before erasing it,
+						// because we cannot release a lock on a mutex that is
+						// already destroyed. We know that no other thread can
+						// gain access to the item though, because they must
+						// acquire the Bin lock to do so, and we still hold the
+						// Bin lock.
+						itemLock.release();
+						m_popIterator = bin->map.erase( m_popIterator );
+						return true;
+					}
+					else
+					{
+						// Item has been used recently. Flag it so we
+						// can pop it next time round, unless another
+						// thread resets the flag.
+						m_popIterator->recentlyUsed = false;
+						itemLock.release();
+					}
+				}
+				else
+				{
+					// Failed to acquire the item lock. Some other
+					// thread is busy with this item, so we consider
+					// it to be recently used and just skip over it.
+				}
+
+				++m_popIterator;
+			}
+		}
+
+		AtomicCost currentCost;
+
+	private :
+
+		Bins m_bins;
+
+		Bin &bin( const Key &key )
+		{
+			size_t binIndex = boost::hash<Key>()( key ) % m_bins.size();
+			return m_bins[binIndex];
+		};
+
+		typedef tbb::spin_mutex PopMutex;
+		PopMutex m_popMutex;
+		size_t m_popBinIndex;
+		MapIterator m_popIterator;
+
+};
+
+} // namespace LRUCachePolicy
+
+// CacheEntry
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::CacheEntry()
+	:	cost( 0 )
 {
 }
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::CacheEntry::CacheEntry( const CacheEntry &other )
-	:	state( other.state ), cost( other.cost ), previous( other.previous ), next( other.next ), mutex()
-{
-}
-
-template<typename Key, typename Value, typename GetterKey>
-typename LRUCache<Key, Value, GetterKey>::Status LRUCache<Key, Value, GetterKey>::CacheEntry::status() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Status LRUCache<Key, Value, Policy, GetterKey>::CacheEntry::status() const
 {
 	return static_cast<Status>( state.which() );
 }
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::LRUCache( GetterFunction getter )
+// LRUCache
+// =======================================================================
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter )
 	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( 500 )
 {
-	m_currentCost = 0;
-
-	m_listStart.second.previous = NULL;
-	m_listStart.second.next = &m_listEnd;
-
-	m_listEnd.second.previous = &m_listStart;
-	m_listEnd.second.next = NULL;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::LRUCache( GetterFunction getter, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( nullRemovalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-
-	m_listStart.second.previous = NULL;
-	m_listStart.second.next = &m_listEnd;
-
-	m_listEnd.second.previous = &m_listStart;
-	m_listEnd.second.next = NULL;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::LRUCache( GetterFunction getter, RemovalCallback removalCallback, Cost maxCost )
 	:	m_getter( getter ), m_removalCallback( removalCallback ), m_maxCost( maxCost )
 {
-	m_currentCost = 0;
-
-	m_listStart.second.previous = NULL;
-	m_listStart.second.next = &m_listEnd;
-
-	m_listEnd.second.previous = &m_listStart;
-	m_listEnd.second.next = NULL;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-LRUCache<Key, Value, GetterKey>::~LRUCache()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+LRUCache<Key, Value, Policy, GetterKey>::~LRUCache()
 {
 }
 
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::clear()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::clear()
 {
-	ListMutex::scoped_lock listLock( m_listMutex );
-	for( typename Map::iterator it = m_map.begin(); it != m_map.end(); ++it )
-	{
-		eraseInternal( &*it );
-	}
+	limitCost( 0 );
 }
 
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::setMaxCost( Cost maxCost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::setMaxCost( Cost maxCost )
 {
 	m_maxCost = maxCost;
-	limitCost();
+	limitCost( maxCost );
 }
 
-template<typename Key, typename Value, typename GetterKey>
-typename LRUCache<Key, Value, GetterKey>::Cost LRUCache<Key, Value, GetterKey>::getMaxCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::getMaxCost() const
 {
 	return m_maxCost;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-typename LRUCache<Key, Value, GetterKey>::Cost LRUCache<Key, Value, GetterKey>::currentCost() const
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+typename LRUCache<Key, Value, Policy, GetterKey>::Cost LRUCache<Key, Value, Policy, GetterKey>::currentCost() const
 {
-	return m_currentCost;
+	return m_policy.currentCost;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-Value LRUCache<Key, Value, GetterKey>::get( const GetterKey &key )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+Value LRUCache<Key, Value, Policy, GetterKey>::get( const GetterKey &key )
 {
-
-	MapIterator it = m_map.insert( MapValue( key, CacheEntry() ) ).first;
-	CacheEntry &cacheEntry = it->second;
-	tbb::spin_mutex::scoped_lock lock( cacheEntry.mutex );
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::Insert );
+	const CacheEntry &cacheEntry = handle.readable();
 	const Status status = cacheEntry.status();
 
 	if( status==Uncached )
 	{
-		assert( cacheEntry.value==Value() );
-		assert( cacheEntry.next == NULL && cacheEntry.previous == NULL );
-
 		Value value = Value();
 		Cost cost = 0;
 		try
@@ -157,32 +645,25 @@ Value LRUCache<Key, Value, GetterKey>::get( const GetterKey &key )
 		}
 		catch( ... )
 		{
-			cacheEntry.state = std::current_exception();
+			handle.writable().state = std::current_exception();
 			throw;
 		}
 
 		assert( cacheEntry.status() != Cached ); // this would indicate that another thread somehow
 		assert( cacheEntry.status() != Failed ); // loaded the same thing as us, which is not the intention.
 
-		setInternal( &*it, value, cost );
+		setInternal( key, handle.writable(), value, cost );
+		m_policy.push( handle );
 
-		lock.release();
-
-		/// \todo We might want to consider ways of avoiding having to manipulate the
-		/// list for cache hits, because we want this to be our fastest code path.
-		/// Adopting an approximate LRU heuristic like Second Chance would be one way
-		/// of doing this.
-		updateListPosition( &*it );
-		limitCost();
+		handle.release();
+		limitCost( m_maxCost );
 
 		return value;
 	}
 	else if( status==Cached )
 	{
-		Value result = boost::get<Value>( cacheEntry.state );
-		lock.release();
-		updateListPosition( &*it );
-		return result;
+		m_policy.push( handle );
+		return boost::get<Value>( cacheEntry.state );
 	}
 	else
 	{
@@ -190,155 +671,92 @@ Value LRUCache<Key, Value, GetterKey>::get( const GetterKey &key )
 	}
 }
 
-template<typename Key, typename Value, typename GetterKey>
-bool LRUCache<Key, Value, GetterKey>::set( const Key &key, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::set( const Key &key, const Value &value, Cost cost )
 {
-	MapIterator it = m_map.insert( MapValue( key, CacheEntry() ) ).first;
-	CacheEntry &cacheEntry = it->second;
-	tbb::spin_mutex::scoped_lock lock( cacheEntry.mutex );
-
-	const bool result = setInternal( &*it, value, cost );
-
-	lock.release();
-	updateListPosition( &*it );
-	limitCost();
-
+	typename Policy<LRUCache>::Handle handle;
+	m_policy.acquire( key, handle, LRUCachePolicy::InsertWritable );
+	bool result = setInternal( key, handle.writable(), value, cost );
+	m_policy.push( handle );
 	return result;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-bool LRUCache<Key, Value, GetterKey>::setInternal( MapValue *mapValue, const Value &value, Cost cost )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::setInternal( const Key &key, CacheEntry &cacheEntry, const Value &value, Cost cost )
 {
-	CacheEntry &cacheEntry = mapValue->second;
-	if( cacheEntry.status()==Cached )
-	{
-		m_removalCallback( mapValue->first, boost::get<Value>( cacheEntry.state ) );
-		m_currentCost -= cacheEntry.cost;
-		cacheEntry.state = boost::blank();
-	}
+	eraseInternal( key, cacheEntry );
 
-	bool result = true;
-	if( cost <= m_maxCost )
-	{
-		cacheEntry.state = value;
-		cacheEntry.cost = cost;
-		m_currentCost += cost;
-	}
-	else
-	{
-		cacheEntry.state = boost::blank();
-		result = false;
-	}
-
-	return result;
-}
-
-template<typename Key, typename Value, typename GetterKey>
-bool LRUCache<Key, Value, GetterKey>::cached( const Key &key ) const
-{
-	ConstMapIterator it = m_map.find( key );
-	if( it == m_map.end() )
-	{
-		return false;
-	}
-	tbb::spin_mutex::scoped_lock lock( it->second.mutex );
-	return it->second.status()==Cached;
-}
-
-template<typename Key, typename Value, typename GetterKey>
-bool LRUCache<Key, Value, GetterKey>::erase( const Key &key )
-{
-	MapIterator it = m_map.find( key );
-	if( it == m_map.end() )
+	if( cost > m_maxCost )
 	{
 		return false;
 	}
 
-	ListMutex::scoped_lock listLock( m_listMutex );
-	return eraseInternal( &*it );
+	cacheEntry.state = value;
+	cacheEntry.cost = cost;
+
+	m_policy.currentCost += cost;
+
+	return true;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-bool LRUCache<Key, Value, GetterKey>::eraseInternal( MapValue *mapValue )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::cached( const Key &key ) const
 {
-	CacheEntry &cacheEntry = mapValue->second;
-	tbb::spin_mutex::scoped_lock lock( cacheEntry.mutex );
-
-	const Status originalStatus = cacheEntry.status();
-
-	listErase( mapValue );
-
-	if( originalStatus == Cached )
+	typename Policy<LRUCache>::Handle handle;
+	// Preferring const_cast over forcing all policies to implement
+	// a ConstHandle and const acquire() variant.
+	if( !const_cast<Policy<LRUCache> &>( m_policy ).acquire( key, handle, LRUCachePolicy::FindReadable ) )
 	{
-		m_removalCallback( mapValue->first, boost::get<Value>( cacheEntry.state ) );
-		m_currentCost -= cacheEntry.cost;
+		return false;
+	}
+
+	return handle.readable().status() == Cached;
+}
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::erase( const Key &key )
+{
+	typename Policy<LRUCache>::Handle handle;
+	if( !m_policy.acquire( key, handle, LRUCachePolicy::FindWritable ) )
+	{
+		return false;
+	}
+
+	return eraseInternal( key, handle.writable() );
+}
+
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+bool LRUCache<Key, Value, Policy, GetterKey>::eraseInternal( const Key &key, CacheEntry &cacheEntry )
+{
+	const Status status = cacheEntry.status();
+	if( status == Cached )
+	{
+		m_removalCallback( key, boost::get<Value>( cacheEntry.state ) );
+		m_policy.currentCost -= cacheEntry.cost;
 	}
 
 	cacheEntry.state = boost::blank();
-	return originalStatus == Cached;
+	return status == Cached;
 }
 
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::limitCost()
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::limitCost( Cost cost )
 {
-	ListMutex::scoped_lock lock( m_listMutex );
-
-	// While we're above the cost limit, and there are still things
-	// in the list, erase the first item in the list. Note that it _is_
-	// possible for the list to become empty before we meet the cost limit,
-	// because another thread may have cached an item and incremented
-	// m_currentCost, but still be waiting to add the item to the list,
-	// because we hold m_listMutex.
-	while( m_currentCost > m_maxCost && m_listStart.second.next != &m_listEnd )
+	Key key;
+	CacheEntry cacheEntry;
+	while( m_policy.currentCost > cost )
 	{
-		eraseInternal( m_listStart.second.next );
+		if( !m_policy.pop( key, cacheEntry ) )
+		{
+			break;
+		}
+
+		eraseInternal( key, cacheEntry );
 	}
 }
 
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::updateListPosition( MapValue *mapValue )
-{
-	ListMutex::scoped_lock lock( m_listMutex );
-
-	listErase( mapValue );
-
-	tbb::spin_mutex::scoped_lock mapValueMutex( mapValue->second.mutex );
-	if( mapValue->second.status() == Cached )
-	{
-		listInsertAtEnd( mapValue );
-	}
-}
-
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::listErase( MapValue *mapValue )
-{
-	MapValue *previous = mapValue->second.previous;
-	if( !previous )
-	{
-		return;
-	}
-
-	previous->second.next = mapValue->second.next;
-	mapValue->second.next->second.previous = previous;
-	mapValue->second.next = mapValue->second.previous = NULL;
-}
-
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::listInsertAtEnd( MapValue *mapValue )
-{
-	assert( mapValue->second.previous == NULL );
-	assert( mapValue->second.next == NULL );
-
-	MapValue *previous = m_listEnd.second.previous;
-	previous->second.next = mapValue;
-	mapValue->second.previous = previous;
-
-	mapValue->second.next = &m_listEnd;
-	m_listEnd.second.previous = mapValue;
-}
-
-template<typename Key, typename Value, typename GetterKey>
-void LRUCache<Key, Value, GetterKey>::nullRemovalCallback( const Key &key, const Value &value )
+template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
+void LRUCache<Key, Value, Policy, GetterKey>::nullRemovalCallback( const Key &key, const Value &value )
 {
 }
 

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -54,7 +54,7 @@ namespace boost
 namespace python
 {
 
-inline size_t tbb_hasher( const boost::python::object &o )
+inline size_t hash_value( const boost::python::object &o )
 {
 	return PyObject_Hash( o.ptr() );
 }

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -71,32 +71,32 @@ struct LRUCacheGetter
 		:	getter( g )
 	{
 	}
-	
+
 	object operator() ( object key, LRUCache<object, object>::Cost &cost )
 	{
 		tuple t = extract<tuple>( getter( key ) );
 		cost = extract<LRUCache<object, object>::Cost>( t[1] );
 		return t[0];
 	}
-	
+
 	object getter;
 };
 
 class PythonLRUCache : public LRUCache<object, object>
 {
-	
+
 	public :
-	
+
 		PythonLRUCache( object getter, LRUCache<object, object>::Cost maxCost )
 			:	LRUCache<object, object>( LRUCacheGetter( getter ), maxCost )
 		{
 		}
-		
+
 		PythonLRUCache( object getter, object removalCallback, LRUCache<object, object>::Cost maxCost )
 			:	LRUCache<object, object>( LRUCacheGetter( getter ), removalCallback, maxCost )
 		{
 		}
-		
+
 		object get( const object &key )
 		{
 			// we must hold the GIL when entering LRUCache<object, object>::get()
@@ -123,7 +123,7 @@ class PythonLRUCache : public LRUCache<object, object>
 			// deal because all python execution is serialised anyway.
 			//
 			// see test/IECore/LRUCache.py, in particular testYieldGILInGetter().
-			
+
 			Mutex::scoped_lock lock;
 			{
 				IECorePython::ScopedGILRelease gilRelease;
@@ -133,7 +133,7 @@ class PythonLRUCache : public LRUCache<object, object>
 		}
 
 	private :
-	
+
 		typedef tbb::mutex Mutex;
 		Mutex m_getMutex;
 
@@ -152,12 +152,12 @@ static int get( int key, size_t &cost )
 struct GetFromTestCache
 {
 	public :
-	
+
 		GetFromTestCache( TestCache &cache, size_t numValues, size_t clearFrequency )
 			:	m_cache( cache ), m_numValues( numValues ), m_clearFrequency( clearFrequency )
 		{
 		}
-		
+
 		void operator()( const blocked_range<size_t> &r ) const
 		{
 			for( size_t i=r.begin(); i!=r.end(); ++i )
@@ -172,22 +172,22 @@ struct GetFromTestCache
 						)
 					);
 				}
-				
+
 				if( m_clearFrequency && (i % m_clearFrequency == 0) )
 				{
 					m_cache.clear();
 				}
 			}
 		}
-		
+
 	private :
-	
+
 		TestCache &m_cache;
 		size_t m_numValues;
 		size_t m_clearFrequency;
-		
+
 };
-	
+
 void testLRUCacheThreading( int numIterations, int numValues, int maxCost, int clearFrequency = 0 )
 {
 	// do lots of parallel cache accesses. then clear the cache in the main
@@ -196,18 +196,18 @@ void testLRUCacheThreading( int numIterations, int numValues, int maxCost, int c
 
 	TestCache cache( get, maxCost );
 	parallel_for( blocked_range<size_t>( 0, numIterations ), GetFromTestCache( cache, numValues, clearFrequency ) );
-	
+
 	if( cache.currentCost() > cache.getMaxCost() )
 	{
 		throw Exception( "LRUCache exceeds maximum cost" );
 	}
-	
+
 	cache.clear();
 	if( cache.currentCost() != 0 )
 	{
 		throw Exception( "Cost not 0 after LRUCache::clear()" );
 	}
-	
+
 	// as above, but using setMaxCost( 0 ) to clear the cache.
 
 	TestCache cache2( get, maxCost );
@@ -217,7 +217,7 @@ void testLRUCacheThreading( int numIterations, int numValues, int maxCost, int c
 	{
 		throw Exception( "LRUCache exceeds maximum cost" );
 	}
-	
+
 	cache2.setMaxCost( 0 );
 	if( cache2.currentCost() != 0 )
 	{
@@ -227,7 +227,7 @@ void testLRUCacheThreading( int numIterations, int numValues, int maxCost, int c
 
 void IECorePython::bindLRUCache()
 {
-	
+
 	class_<PythonLRUCache, boost::noncopyable>( "LRUCache", no_init )
 		.def( init<object, PythonLRUCache::Cost>( ( boost::python::arg_( "getter" ), boost::python::arg_( "maxCost" )=500  ) ) )
 		.def( init<object, object, PythonLRUCache::Cost>( ( boost::python::arg_( "getter" ), boost::python::arg_( "removalCallback" ), boost::python::arg_( "maxCost" )  ) ) )
@@ -240,7 +240,7 @@ void IECorePython::bindLRUCache()
 		.def( "set", &PythonLRUCache::set )
 		.def( "cached", &PythonLRUCache::cached )
 	;
-	
+
 	/// \todo If we create an IECoreTest module, move this into it.
 	def(
 		"testLRUCacheThreading",
@@ -252,5 +252,5 @@ void IECorePython::bindLRUCache()
 			boost::python::arg( "clearFrequency" ) = 0
 		)
 	);
-	
+
 }

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -38,6 +38,8 @@
 
 #include "tbb/tbb.h"
 
+#include "boost/format.hpp"
+
 #include "IECore/LRUCache.h"
 
 #include "IECorePython/ScopedGILRelease.h"
@@ -164,7 +166,11 @@ struct GetFromTestCache
 				const int v = m_cache.get( k );
 				if( k != v )
 				{
-					throw Exception( "Incorrect LRUCache value found" );
+					throw Exception(
+						boost::str(
+							boost::format( "Incorrect LRUCache value found (expected %d but got %d)" ) % k %v
+						)
+					);
 				}
 				
 				if( m_clearFrequency && (i % m_clearFrequency == 0) )

--- a/test/IECore/CachedReader.py
+++ b/test/IECore/CachedReader.py
@@ -88,7 +88,10 @@ class CachedReaderTest( unittest.TestCase ) :
 		# is no room for it.
 		pool.setMaxMemoryUsage( pool.memoryUsage() / 2  )
 		self.assertEqual( pool.memoryUsage(), 0 )
-		self.failIf( r.cached( "test/IECore/data/pdcFiles/particleShape1.250.pdc" ) )
+		self.failIf(
+			r.cached( "test/IECore/data/cobFiles/compoundData.cob" ) or
+			r.cached( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		)
 
 		pool.setMaxMemoryUsage( oo.memoryUsage() * 2 )
 		oo = r.read( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )

--- a/test/IECore/ComputationCacheTest.cpp
+++ b/test/IECore/ComputationCacheTest.cpp
@@ -104,25 +104,13 @@ struct ComputationCacheTest
 		BOOST_CHECK( res );
 		BOOST_CHECK_EQUAL( size_t(2), cache.cachedComputations() );
 
-		/// cache should not contain the value 2 due to memory limit (object not in ObjectPool)
-		res = cache.get( ComputationParams(2), Cache::NullIfMissing );
-		BOOST_CHECK( !res );
-		
-		// but should have the latest computed still
-		res = cache.get( ComputationParams(3), Cache::NullIfMissing );
-		BOOST_CHECK( res );
-		BOOST_CHECK_EQUAL( size_t(2), cache.cachedComputations() );
-		
-		// erase the latest result
-		cache.erase( ComputationParams(3) );
-		BOOST_CHECK_EQUAL( size_t(1), cache.cachedComputations() );
+		/// Cache should have evicted one value due to the memory limit
+		/// of the ObjectPool.
+		ConstObjectPtr res2 = cache.get( ComputationParams( 2 ), Cache::NullIfMissing );
+		ConstObjectPtr res3 = cache.get( ComputationParams( 3 ), Cache::NullIfMissing );
+		BOOST_CHECK( !(res2 && res3) );
+		BOOST_CHECK( res2 || res3 );
 
-		// confirm it's gone...
-		res = cache.get( ComputationParams(3), Cache::NullIfMissing );
-		BOOST_CHECK( !res );
-		/// again... will count as cached unfortunately...
-		BOOST_CHECK_EQUAL( size_t(2), cache.cachedComputations() );
-		
 		/// now increase memory limit to two IntData objects
 		pool->setMaxMemoryUsage( v->Object::memoryUsage() * 2 );
 
@@ -132,9 +120,10 @@ struct ComputationCacheTest
 		BOOST_CHECK_EQUAL( size_t(4), cache.cachedComputations() );
 		BOOST_CHECK( cache.get( ComputationParams(4), Cache::NullIfMissing ) );
 		BOOST_CHECK( cache.get( ComputationParams(5), Cache::NullIfMissing ) );
-		
+
 		/// clears the all values
 		cache.clear();
+		pool->clear();
 		BOOST_CHECK_EQUAL( size_t(0), cache.cachedComputations() );
 
 		// set some values on the cache

--- a/test/IECore/LRUCacheTest.py
+++ b/test/IECore/LRUCacheTest.py
@@ -232,10 +232,10 @@ class LRUCacheTest( unittest.TestCase ) :
 		self.assertEqual( removed, [] )
 
 		self.assertEqual( c.get( 6 ), 12 )
-		self.assertEqual( removed, [ ( 1, 2 ) ] )
+		self.assertEqual( len( removed ), 1 )
 
 		self.assertEqual( c.get( 7 ), 14 )
-		self.assertEqual( removed, [ ( 1, 2 ), ( 2, 4 ) ] )
+		self.assertEqual( len( removed ), 2 )
 
 		c.clear()
 

--- a/test/IECore/LRUCacheTest.py
+++ b/test/IECore/LRUCacheTest.py
@@ -298,5 +298,19 @@ class LRUCacheTest( unittest.TestCase ) :
 		self.assertFalse( c.erase( 1 ) )
 		self.assertEqual( c.currentCost(), 0 )
 
+	def testSerialRecursion( self ) :
+
+		# Cache big enough that nothing will be evicted
+		IECore.testSerialLRUCacheRecursion( 100 )
+		# Cache small enough that evictions are necessary
+		IECore.testSerialLRUCacheRecursion( 10 )
+
+	def testParallelRecursion( self ) :
+
+		# Cache big enough that nothing will be evicted
+		IECore.testParallelLRUCacheRecursion( 100000, 10000, 10000 )
+		# Cache small enough that evictions are necessary
+		IECore.testParallelLRUCacheRecursion( 100000, 1000, 100 )
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECore/LRUCacheTest.py
+++ b/test/IECore/LRUCacheTest.py
@@ -338,5 +338,18 @@ class LRUCacheTest( unittest.TestCase ) :
 		self.assertRaisesRegexp( RuntimeError, "Get failed for 10", c.get, 10 )
 		self.assertEqual( calls, [ 10, 10, 10 ] )
 
+	def testSetLimitsCost( self ) :
+
+		c = IECore.LRUCache( lambda key : key, 2 )
+
+		c.set( "a", "a", 1 )
+		self.assertEqual( c.currentCost(), 1 )
+		c.set( "b", "b", 1 )
+		self.assertEqual( c.currentCost(), 2 )
+		c.set( "c", "c", 1 )
+		self.assertEqual( c.currentCost(), 2 )
+		c.set( "d", "d", 1 )
+		self.assertEqual( c.currentCost(), 2 )
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECore/LRUCacheTest.py
+++ b/test/IECore/LRUCacheTest.py
@@ -279,5 +279,24 @@ class LRUCacheTest( unittest.TestCase ) :
 		# clearing all the time while doing concurrent lookups
 		IECore.testLRUCacheThreading( 100000, 1000, 90, 20 )
 
+	def testEraseAndCached( self ) :
+
+		def getter( key ) :
+			return ( key, 1 )
+
+		c = IECore.LRUCache( getter, 1000 )
+
+		self.assertFalse( c.cached( 1 ) )
+		self.assertEqual( c.currentCost(), 0 )
+		c.get( 1 )
+		self.assertTrue( c.cached( 1 ) )
+		self.assertEqual( c.currentCost(), 1 )
+
+		self.assertTrue( c.erase( 1 ) )
+		self.assertEqual( c.currentCost(), 0 )
+		self.assertFalse( c.cached( 1 ) )
+		self.assertFalse( c.erase( 1 ) )
+		self.assertEqual( c.currentCost(), 0 )
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECore/LRUCacheTest.py
+++ b/test/IECore/LRUCacheTest.py
@@ -43,11 +43,11 @@ class LRUCacheTest( unittest.TestCase ) :
 	def test( self ) :
 
 		self.numGetterCalls = 0
-		
+
 		def getter( key ) :
-		
+
 			self.numGetterCalls += 1
-		
+
 			return (
 				# value
 				{
@@ -65,219 +65,219 @@ class LRUCacheTest( unittest.TestCase ) :
 		self.assertEqual( c.getMaxCost(), 20 )
 		c.setMaxCost( 10 )
 		self.assertEqual( c.getMaxCost(), 10 )
-				
+
 		v = c.get( 10 )
 		self.assertEqual( v,
-			{ 
+			{
 				"same" : 10,
 				"times2" : 20,
 				"times4" : 40,
 			}
 		)
-		
+
 		self.assertEqual( c.currentCost(), 1 )
 		self.assertEqual( self.numGetterCalls, 1 )
-				
+
 		v2 = c.get( 10 )
 		self.failUnless( v2 is v )
-		
+
 		self.assertEqual( c.currentCost(), 1 )
 		self.assertEqual( self.numGetterCalls, 1 )
-				
+
 		for k in range( 11, 10000 ) :
-		
+
 			v = c.get( k )
 			self.assertEqual( v,
-				{ 
+				{
 					"same" : k,
 					"times2" : k * 2,
 					"times4" : k * 4,
 				}
 			)
-			
+
 			self.failIf( c.currentCost() > 10 )
-	
+
 	def testClearCausesReloads( self ) :
-	
+
 		self.numGetterCalls = 0
 		self.multiplier = 2
-		
+
 		def getter( key ) :
-		
+
 			self.numGetterCalls += 1
 			return ( key * self.multiplier, 1 )
-			
+
 		c = IECore.LRUCache( getter, 10 )
-		
+
 		v = c.get( 10 )
 		self.assertEqual( v, 20 )
 		self.assertEqual( self.numGetterCalls, 1 )
-		
+
 		v = c.get( 10 )
 		self.assertEqual( v, 20 )
 		self.assertEqual( self.numGetterCalls, 1 )
-		
+
 		c.clear()
 		self.multiplier = 4
 		v = c.get( 10 )
 		self.assertEqual( v, 40 )
 		self.assertEqual( self.numGetterCalls, 2 )
-		
+
 	def testThreadingAndLimitCost( self ) :
-	
+
 		def getter( key ) :
-		
+
 			return ( key * 2, 1 )
-			
+
 		c = IECore.LRUCache( getter, 10 )
-		
+
 		def thrash() :
-		
+
 			for i in range( 0, 10000 ) :
 				v = c.get( i )
 				self.assertEqual( v, i * 2 )
-		
+
 		threads = []
 		for i in range( 0, 10 ) :
 			thread = threading.Thread( target=thrash )
 			threads.append( thread )
 			thread.start()
-			
+
 		for thread in threads :
 			thread.join()
 
 	def testThreadingAndClear( self ) :
-	
+
 		def getter( key ) :
-		
+
 			return ( key * 2, 1 )
-	
+
 		c = IECore.LRUCache( getter, 100000 )
-	
+
 		def f1() :
 			for i in range( 0, 10000 ) :
 				v = c.get( i )
 				self.assertEqual( v, i * 2 )
-				
+
 		def f2() :
 			for i in range( 0, 10000 ) :
 				c.clear()
-	
+
 		t1 = threading.Thread( target=f1 )
 		t2 = threading.Thread( target=f1 )
 		t3 = threading.Thread( target=f2 )
-		
+
 		t1.start()
 		t2.start()
 		t3.start()
-		
+
 		t1.join()
 		t2.join()
 		t3.join()
-		
+
 		c.clear()
 		self.assertEqual( c.currentCost(), 0 )
 
 	def testYieldGILInGetter( self ) :
-	
+
 		def getter( key ) :
-		
+
 			# this call simulates the gil getting
 			# yielded for some reason - in the real world
 			# perhaps an Op call or just the python interpreter
 			# deciding to switch threads.
 			time.sleep( 0.1 )
 			return ( key, 1 )
-			
+
 		c = IECore.LRUCache( getter, 100000 )
-		
+
 		def f() :
-		
+
 			c.get( 0 )
-		
+
 		t1 = threading.Thread( target=f )
 		t2 = threading.Thread( target=f )
-		
+
 		t1.start()
 		t2.start()
 		t1.join()
 		t2.join()
-		
+
 	def testRemovalCallback( self ) :
-	
+
 		def getter( key ) :
-		
+
 			return ( key * 2, 1 )
-		
+
 		removed = []
 		def removalCallback( key, value ) :
-		
+
 			removed.append( ( key, value ) )
-		
+
 		c = IECore.LRUCache( getter, removalCallback, 5 )
-		
+
 		self.assertEqual( c.get( 1 ), 2 )
 		self.assertEqual( removed, [] )
-		
+
 		self.assertEqual( c.get( 2 ), 4 )
 		self.assertEqual( removed, [] )
-		
+
 		self.assertEqual( c.get( 3 ), 6 )
 		self.assertEqual( removed, [] )
-		
+
 		self.assertEqual( c.get( 4 ), 8 )
 		self.assertEqual( removed, [] )
-		
+
 		self.assertEqual( c.get( 5 ), 10 )
 		self.assertEqual( removed, [] )
-		
+
 		self.assertEqual( c.get( 6 ), 12 )
 		self.assertEqual( removed, [ ( 1, 2 ) ] )
-		
+
 		self.assertEqual( c.get( 7 ), 14 )
 		self.assertEqual( removed, [ ( 1, 2 ), ( 2, 4 ) ] )
 
 		c.clear()
-		
+
 		self.assertEqual( len( removed ), 7 )
-		
+
 		keys = [ x[0] for x in removed ]
 		for i in range( 1, 8 ) :
 			self.failUnless( i in keys )
-	
+
 	def testSet( self ) :
-	
+
 		def getter( key ) :
 			return ( None, 1 )
-			
+
 		c = IECore.LRUCache( getter, 1000 )
-		
+
 		c.set( 5, 10, 1 )
 		self.assertEqual( c.currentCost(), 1 )
 		self.assertEqual( c.get( 5 ), 10 )
 		self.assertEqual( c.currentCost(), 1 )
-		
+
 		c.set( 5, 20, 100000 )
 		self.assertEqual( c.currentCost(), 0 )
 		self.assertEqual( c.get( 5 ), None )
 		self.assertEqual( c.currentCost(), 1 )
-	
+
 	def testCPPThreading( self ) :
-		
+
 		# arguments are :
 		# iterations, number of unique values, maximum cost, clear frequency
-		
+
 		# cache exactly the right size
 		IECore.testLRUCacheThreading( 100000, 100, 100 )
-		
+
 		# cache not quite big enough
 		IECore.testLRUCacheThreading( 100000, 100, 90 )
-		
+
 		# cache thrashing like crazy
 		IECore.testLRUCacheThreading( 100000, 1000, 2 )
-		
+
 		# clearing all the time while doing concurrent lookups
 		IECore.testLRUCacheThreading( 100000, 1000, 90, 20 )
-		
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECore/ObjectPoolTest.py
+++ b/test/IECore/ObjectPoolTest.py
@@ -104,12 +104,13 @@ class ObjectPoolTest( unittest.TestCase ) :
 		self.assertEqual( p.memoryUsage(), a.memoryUsage() )
 		b = p.store( StringData("abc"), ObjectPool.StoreReference )
 		self.assertEqual( p.memoryUsage(), a.memoryUsage()+b.memoryUsage() )
-		
-		p.setMaxMemoryUsage( b.memoryUsage() )
-		self.assertEqual( p.getMaxMemoryUsage(), b.memoryUsage() )
-		self.assertEqual( p.memoryUsage(), b.memoryUsage() )
-		self.assertFalse( p.contains(a.hash()) )
-		self.assertTrue( p.contains(b.hash()) )
-		
+
+		p.setMaxMemoryUsage( p.memoryUsage() - 1 )
+		self.assertLess( p.getMaxMemoryUsage(), a.memoryUsage() + b.memoryUsage() )
+		self.assertFalse(
+			p.contains( a.hash() ) and
+			p.contains( b.hash() )
+		)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This rewrites the LRUCache to provide :

- Improved performance
- Separate policies optimised for single threaded and multithreaded use cases
- Improved error handing - no more "previous attempt to get item failed"
- Optional GetterKey template argument for passing auxiliary information to the getter function
- Support for recursive calls back into `cache.get()` from the getter function itself

The performance of the previous cache was poor enough that Gaffer has been using a [modified version](https://github.com/GafferHQ/gaffer/blob/master/include/Gaffer/Private/IECorePreview/LRUCache.h) for a long time now, with the intention of moving it into Cortex. This PR is _not_ that same version though - it lacked everything here except the improved performance, and crucially lacked the support for recursive calls, which are essential for future work we want to do in Gaffer.

I've been testing this by timing `IECore.testLRUCacheThreading` in four distinct usage patterns :

- Contended on 1 : All threads hammering a single item in the cache. This is a bit of a worst case scenario for managing the locking efficiently.
- Working set 100 : A working set of 100 items, with all threads continuously requesting random items. This provides opportunities for reducing contention between threads.
- No duplicates : Pulling 10000000 unique items out of the cache, with no item requested twice. The cache is big enough to store everything without evictions, but we gain no benefit from the caching at all.
- Thrashing : Pulling random items out of a set of 1000 out of a cache with a size limit of 2.

This gives the following timings (best of 3 runs in each case, smaller numbers better) :

| | Master | This PR |  Gaffer |
| --- | --- | --- | --- |
|Contended on 1| 7.40 | 1.28 | 1.04 |
|Working set 100| 4.36 | 0.53 | 0.30 |
|No duplicates| 11.7 | 8.8 | 7.2| 
|Thrashing| 0.11 | 0.34 | 0.23 |

So for the scenarios in which we have sufficient cache hits (the first two), the new version gives us a 5-8x speedup over the original. The Gaffer version is even better (7-14x), but lacks the recursive property that we need for the future, which rules it out. Both newer versions suffer for the thrashing case, but I think it's more important that they perform well for hits.

The Serial policy provides improved performance for when the cache will be used from a single thread so no locking is required - somewhere between 2-4x the speed of the Parallel policy :

| | Parallel | Serial |
|---|---|---|
|Contended on 1|  0.87 | 0.39  |
|Working set 100| 0.87 | 0.38 |
|No duplicates| 8.76 | 2.27 | 
|Thrashing| 0.05 | 0.015 |

I've no doubt this isn't the last word in caching, but it does represent a big improvement over the status quo. I was really hoping to get back to the same performance as the Gaffer version, but despite banging my head against it for a long time I've failed. If anyone with a fresh set of eyes and some bright ideas wants to take a stab at further improvements still, that would be brilliant...
