### PR TITLE
MatrixMotionTransform : Fix crash in `transform()` method

### DIFF
--- a/src/IECore/MatrixMotionTransform.cpp
+++ b/src/IECore/MatrixMotionTransform.cpp
@@ -100,8 +100,9 @@ Imath::M44f MatrixMotionTransform::transform( float time ) const
 		return m_snapshots.rbegin()->second;
 	}
 	SnapshotMap::const_iterator uIt = m_snapshots.upper_bound( time );
-	SnapshotMap::const_reverse_iterator lIt( uIt );
-	lIt++;
+	SnapshotMap::const_iterator lIt = uIt;
+	lIt--;
+
 	/// \todo We should probably do something to interpolate rotations better.
 	return lerp( lIt->second, uIt->second, lerpfactor( time, lIt->first, uIt->first ) );
 }


### PR DESCRIPTION
It appears I misunderstood how reverse iterators work. When contructing `reverse_iterator( it )`, the reverse iterator does _not_ point to the same value as `it`, but rather to the prior value. Since map iterators are bidirectional we can make things less confusing by simply decrementing a forward iterator instead.