### PR TITLE
CurveLookup: fix memory corruption

### DIFF
--- a/include/IECoreNuke/CurveLookup.inl
+++ b/include/IECoreNuke/CurveLookup.inl
@@ -100,8 +100,7 @@ void CurveLookup<T>::knob( DD::Image::Knob_Callback f )
 	{
 		for( unsigned i=0; i<m_namesAndDefaultsStrings->size(); i+=2 )
 		{
-			DD::Image::CurveDescription d;
-			memset( &d, 0, sizeof( d ) );
+			DD::Image::CurveDescription d = DD::Image::CurveDescription();
 			d.name = (*m_namesAndDefaultsStrings)[i].c_str();
 			d.defaultValue = (*m_namesAndDefaultsStrings)[i+1].c_str();
 			d.flags = 0;


### PR DESCRIPTION
Fixes
----

- IECoreNuke::CurveLookup:

  - memset was corrupting the memory once nuke switched from char * to
std::string.
  - correctly initialized memory using NULL instead.