### PR TITLE
Appleseed DisplayTileCallback : Pass all parameters to `Display::create()`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3281,7 +3281,7 @@ if doConfigure :
 		appleseedDriverEnv.AddPostAction( appleseedDriverInstall, lambda target, source, env : makeLibSymLinks( appleseedDriverEnv, libNameVar="INSTALL_APPLESEEDOUTPUTDRIVER_NAME" ) )
 		appleseedDriverEnv.Alias( "install", appleseedDriverInstall )
 		appleseedDriverEnv.Alias( "installAppleseed", appleseedDriverInstall )
-		appleseedDriverForTest = appleseedDriverEnv.Command( "contrib/IECoreAppleseed/test/IECoreAppleseed/plugins/ieOutputDriver.so", appleseedDriver, Copy( "$TARGET", "$SOURCE" ) )
+		appleseedDriverForTest = appleseedDriverEnv.Install( "contrib/IECoreAppleseed/test/IECoreAppleseed/plugins", appleseedDriver )
 
 		Default( [ appleseedLibrary, appleseedPythonModule, appleseedDriver, appleseedDriverForTest ] )
 
@@ -3290,10 +3290,10 @@ if doConfigure :
 		appleseedTestEnv["ENV"]["PYTHONPATH"] += ":./contrib/IECoreAppleseed/python" + ":" + appleseedEnv.subst( "$APPLESEED_LIB_PATH/python2.7" )
 		appleseedTestEnv["ENV"][testEnv["TEST_LIBRARY_PATH_ENV_VAR"]] += ":" + appleseedEnv.subst( ":".join( appleseedPythonModuleEnv["LIBPATH"] ) )
 		appleseedTestEnv["ENV"]["PATH"] = appleseedEnv.subst( "$APPLESEED_ROOT/bin" ) + ":" + appleseedTestEnv["ENV"]["PATH"]
-		appleseedTestEnv["ENV"]["APPLESEED_PLUGIN_PATH"] = "contrib/IECoreAppleseed/test/IECoreAppleseed/plugins"
+		appleseedTestEnv["ENV"]["APPLESEED_SEARCHPATH"] = os.getcwd() + "/contrib/IECoreAppleseed/test/IECoreAppleseed/plugins"
 		appleseedTest = appleseedTestEnv.Command( "contrib/IECoreAppleseed/test/IECoreAppleseed/results.txt", appleseedPythonModule, pythonExecutable + " $TEST_APPLESEED_SCRIPT" )
 		NoCache( appleseedTest )
-		appleseedTestEnv.Depends( appleseedTest, [ appleseedPythonModule + appleseedDriverForTest ] )
+		appleseedTestEnv.Depends( appleseedTest, [ corePythonModule, appleseedPythonModule, appleseedDriverForTest ] )
 		appleseedTestEnv.Depends( appleseedTest, glob.glob( "contrib/IECoreAppleseed/test/IECoreAppleseed/*.py" ) )
 		appleseedTestEnv.Alias( "testAppleseed", appleseedTest )
 

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -146,14 +146,6 @@ class DisplayTileCallback : public ProgressTileCallback
 
 	private:
 
-		void copy_optional_param( const char *key, CompoundDataMap &dst ) const
-		{
-			if( m_params.strings().exist( key ) )
-			{
-				dst[key] = new StringData( m_params.get( key ) );
-			}
-		}
-
 		void init_display( const asr::Frame *frame )
 		{
 			assert( !m_display_initialized );
@@ -183,13 +175,11 @@ class DisplayTileCallback : public ProgressTileCallback
 
 			CompoundDataPtr parameters = new CompoundData();
 			CompoundDataMap &p = parameters->writable();
-			p["type"] = new StringData( m_params.get( "type" ) );
 
-			copy_optional_param( "displayHost", p );
-			copy_optional_param( "displayPort", p );
-			copy_optional_param( "driverType", p );
-			copy_optional_param( "remoteDisplayType", p );
-			copy_optional_param( "handle", p );
+			for( asf::StringDictionary::const_iterator it = m_params.strings().begin(), eIt = m_params.strings().end(); it != eIt; ++it )
+			{
+				p[it.key()] = new StringData( it.value() );
+			}
 
 			// reserve space for one tile
 			const asf::CanvasProperties &frameProps = frame->image().properties();

--- a/contrib/IECoreAppleseed/test/IECoreAppleseed/AttributeTest.py
+++ b/contrib/IECoreAppleseed/test/IECoreAppleseed/AttributeTest.py
@@ -117,6 +117,15 @@ class AttributeTest( AppleseedTest.TestCase ):
 		image = IECore.ImageDisplayDriver.removeStoredImage( "testHandle" )
 		expectedImage = IECore.EXRImageReader( os.path.dirname( __file__ ) + "/data/referenceImages/expectedAlphaMaps.exr" ).read()
 
+		for channel in ( "R", "G", "B" ) :
+			# Appleseed's default shading appears to have changed since
+			# expectedAlphaMaps.exr was created, so since we're only interested
+			# in the alpha channel, we delete the other channels before comparing
+			# the images.
+			del image[channel]
+			del expectedImage[channel]
+		self.assertIn( "A", image )
+
 		self.failIf( IECore.ImageDiffOp()( imageA=image, imageB=expectedImage, maxError=0.003 ).value )
 
 	def testMediumPriorities( self ) :


### PR DESCRIPTION
This is needed to allow "catalogue:name" and similar parameters to be passed through to the ClientDisplayDriver for use in Gaffer.

@est77, do you see any problems with this?