### PR TITLE
ExceptionAlgo

### DIFF
--- a/include/IECorePython/ExceptionAlgo.h
+++ b/include/IECorePython/ExceptionAlgo.h
@@ -1,0 +1,62 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2012, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_EXCEPTIONALGO_H
+#define IECOREPYTHON_EXCEPTIONALGO_H
+
+#include "IECorePython/Export.h"
+
+namespace IECorePython
+{
+
+namespace ExceptionAlgo
+{
+
+/// Formats the current python exception using the traceback module,
+/// and returns it in the form of a string. If lineNumber is provided, it
+/// will be filled with the number of the line where the error occurred.
+IECOREPYTHON_API std::string formatPythonException( bool withStacktrace = true, int *lineNumber = nullptr );
+
+/// Can be called to translate the current python exception into
+/// an IECore::Exception. Typically this would be called after catching
+/// boost::python::error_already_set.
+IECOREPYTHON_API [[noreturn]] void translatePythonException( bool withStacktrace = true );
+
+} // namespace ExceptionAlgo
+
+} // namespace IECorePython
+
+#endif // IECOREPYTHON_EXCEPTIONALGO_H

--- a/src/IECorePython/ExceptionAlgo.cpp
+++ b/src/IECorePython/ExceptionAlgo.cpp
@@ -1,0 +1,115 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2012, John Haddon. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECore/Exception.h"
+
+#include "IECorePython/ExceptionAlgo.h"
+
+using namespace boost::python;
+
+namespace IECorePython
+{
+
+namespace ExceptionAlgo
+{
+
+std::string formatPythonException( bool withStacktrace, int *lineNumber )
+{
+	PyObject *exceptionPyObject, *valuePyObject, *tracebackPyObject;
+	PyErr_Fetch( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
+
+	if( !exceptionPyObject )
+	{
+		throw IECore::Exception( "No Python exception set" );
+	}
+
+	PyErr_NormalizeException( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
+
+	object exception( ( handle<>( exceptionPyObject ) ) );
+
+	// valuePyObject and tracebackPyObject may be null.
+	object value;
+	if( valuePyObject )
+	{
+		value = object( handle<>( valuePyObject ) );
+	}
+
+	object traceback;
+	if( tracebackPyObject )
+	{
+		traceback = object( handle<>( tracebackPyObject ) );
+	}
+
+	if( lineNumber )
+	{
+		if( PyErr_GivenExceptionMatches( value.ptr(), PyExc_SyntaxError ) )
+		{
+			*lineNumber = extract<int>( value.attr( "lineno" ) );
+		}
+		else if( traceback )
+		{
+			*lineNumber = extract<int>( traceback.attr( "tb_lineno" ) );
+		}
+	}
+
+	object tracebackModule( import( "traceback" ) );
+
+	object formattedList;
+	if( withStacktrace )
+	{
+		formattedList = tracebackModule.attr( "format_exception" )( exception, value, traceback );
+	}
+	else
+	{
+		formattedList = tracebackModule.attr( "format_exception_only" )( exception, value );
+	}
+
+	object formatted = str( "" ).join( formattedList );
+	std::string s = extract<std::string>( formatted );
+
+	return s;
+}
+
+void translatePythonException( bool withStacktrace )
+{
+	throw IECore::Exception( formatPythonException( withStacktrace ) );
+}
+
+} // namespace ExceptionAlgo
+
+} // namespace IECorePython

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -44,6 +44,7 @@
 
 #include "IECorePython/ScopedGILRelease.h"
 #include "IECorePython/LRUCacheBinding.h"
+#include "IECorePython/ExceptionAlgo.h"
 
 using namespace boost::python;
 using namespace IECore;
@@ -82,27 +83,7 @@ struct LRUCacheGetter
 		}
 		catch( const boost::python::error_already_set &e )
 		{
-			/// \todo Bring GafferBindings::ExceptionAlgo over into
-			/// Cortex and use translatePythonException().
-			PyObject *exceptionPyObject, *valuePyObject, *tracebackPyObject;
-			PyErr_Fetch( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
-			PyErr_NormalizeException( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
-
-			object exception( ( handle<>( exceptionPyObject ) ) );
-
-			object value;
-			if( valuePyObject )
-			{
-				value = object( handle<>( valuePyObject ) );
-			}
-
-			object tracebackModule( import( "traceback" ) );
-			object formattedList = tracebackModule.attr( "format_exception_only" )( exception, value );
-
-			object formatted = str( "" ).join( formattedList );
-			std::string s = extract<std::string>( formatted );
-
-			throw IECore::Exception( s );
+			IECorePython::ExceptionAlgo::translatePythonException();
 		}
 	}
 

--- a/src/IECorePython/MessageHandlerBinding.cpp
+++ b/src/IECorePython/MessageHandlerBinding.cpp
@@ -43,6 +43,7 @@
 #include "IECorePython/MessageHandlerBinding.h"
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/ScopedGILLock.h"
+#include "IECorePython/ExceptionAlgo.h"
 
 using namespace boost::python;
 using namespace IECore;
@@ -68,8 +69,7 @@ class MessageHandlerWrapper : public RefCountedWrapper<MessageHandler>
 			}
 			catch( const error_already_set &e )
 			{
-				/// \todo Move GafferBindings::ExceptionAlgo to Cortex and use it here?
-				PyErr_Print();
+				IECorePython::ExceptionAlgo::translatePythonException();
 			}
 		}
 


### PR DESCRIPTION
As discussed on the recent LRUCache PR, this brings Gaffer's ExceptionAlgo functions over into Cortex. There are a bunch more places where we could potentially be using `translatePythonException()` instead of emitting messages, but for now I've taken a fairly conservative approach, and used it only where we had a specific todo comment.