### PR TITLE
LRUCache : Don't bother calling limitCost if the maxCost is increased

### DIFF
--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -622,8 +622,16 @@ void LRUCache<Key, Value, Policy, GetterKey>::clear()
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>
 void LRUCache<Key, Value, Policy, GetterKey>::setMaxCost( Cost maxCost )
 {
-	m_maxCost = maxCost;
-	limitCost( maxCost );
+	if( maxCost >= m_maxCost )
+	{
+		m_maxCost = maxCost;
+	}
+	else
+	{
+		m_maxCost = maxCost;
+		limitCost( maxCost );
+	}
+
 }
 
 template<typename Key, typename Value, template <typename> class Policy, typename GetterKey>


### PR DESCRIPTION
Matching the change in: https://github.com/GafferHQ/gaffer/pull/2262