### PR TITLE
MeshAlgo : resample primvar unitialised memory fix

### DIFF
--- a/src/IECore/MeshAlgo.cpp
+++ b/src/IECore/MeshAlgo.cpp
@@ -312,7 +312,7 @@ struct MeshUniformToVertex
 
 		size_t numVerts = m_mesh->variableSize( PrimitiveVariable::Vertex );
 		std::vector<int> count( numVerts, 0 );
-		trg.resize( numVerts );
+		trg.resize( numVerts, typename From::ValueType::value_type( 0.0f ) );
 
 		typename From::ValueType::const_iterator srcIt = src.begin();
 		std::vector<int>::const_iterator vId = m_mesh->vertexIds()->readable().begin();
@@ -355,7 +355,7 @@ struct MeshFaceVaryingToVertex
 
 		size_t numVerts = m_mesh->variableSize( PrimitiveVariable::Vertex );
 		std::vector<int> count( numVerts, 0 );
-		trg.resize( numVerts );
+		trg.resize( numVerts, typename From::ValueType::value_type( 0.0f ) );
 
 		const std::vector<int>& vertexIds = m_mesh->vertexIds()->readable();
 		std::vector<int>::const_iterator vertexIdIt = vertexIds.begin();

--- a/test/IECore/MeshAlgoTest.py
+++ b/test/IECore/MeshAlgoTest.py
@@ -321,6 +321,20 @@ class MeshAlgoPrimitiveVariableTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, FloatVectorData( [ 0, 2.5, 5, 5.5, 7.5, 9.5, 11, 12.5, 14 ] ) )
 
+	def testInitialisationOfVectorData( self ) :
+		# This exercises a bug whereby the resampling methods that use averaging
+		# were not initialising the results to zero before accumulating.
+		m = MeshPrimitive.createPlane( Box2f( V2f( -1 ), V2f( 1 ) ), V2i( 100 ) )
+		for i in range( 0, 10 ) :
+			for interpolation in ( PrimitiveVariable.Interpolation.Uniform, PrimitiveVariable.Interpolation.FaceVarying ) :
+				pv = PrimitiveVariable(
+					interpolation,
+					V2fVectorData( [ V2f( 0 ) ] * m.variableSize( interpolation ) )
+				)
+				MeshAlgo.resamplePrimitiveVariable( m, pv, PrimitiveVariable.Interpolation.Vertex )
+				self.assertEqual( len( pv.data ), m.variableSize( PrimitiveVariable.Interpolation.Vertex ) )
+				for v in pv.data :
+					self.assertEqual( v, V2f( 0 ) )
 
 class MeshAlgoDeleteFacesTest( unittest.TestCase ) :
 


### PR DESCRIPTION
Fixes
-------

- undefined results in OSLObject & Resample primitive variables.