### PR TITLE
ToGLMeshConverter : Don't flip V coordinate

### DIFF
--- a/src/IECoreGL/ToGLMeshConverter.cpp
+++ b/src/IECoreGL/ToGLMeshConverter.cpp
@@ -65,7 +65,7 @@ ToGLMeshConverter::~ToGLMeshConverter()
 IECore::RunTimeTypedPtr ToGLMeshConverter::doConversion( IECore::ConstObjectPtr src, IECore::ConstCompoundObjectPtr operands ) const
 {
 	IECore::MeshPrimitivePtr mesh = boost::static_pointer_cast<IECore::MeshPrimitive>( src->copy() ); // safe because the parameter validated it for us
-	
+
 	if( !mesh->variableData<IECore::V3fVectorData>( "P", IECore::PrimitiveVariable::Vertex ) )
 	{
 		throw IECore::Exception( "Must specify primitive variable \"P\", of type V3fVectorData and interpolation type Vertex." );
@@ -84,7 +84,7 @@ IECore::RunTimeTypedPtr ToGLMeshConverter::doConversion( IECore::ConstObjectPtr 
 		);
 		normalOp->operate();
 	}
-	
+
 	IECore::TriangulateOpPtr op = new IECore::TriangulateOp();
 	op->inputParameter()->setValue( mesh );
 	op->throwExceptionsParameter()->setTypedValue( false ); // it's better to see something than nothing
@@ -100,27 +100,7 @@ IECore::RunTimeTypedPtr ToGLMeshConverter::doConversion( IECore::ConstObjectPtr 
 
 	for ( IECore::PrimitiveVariableMap::iterator pIt = mesh->variables.begin(); pIt != mesh->variables.end(); ++pIt )
 	{
-		if( pIt->first == "uv" )
-		{
-			if( IECore::V2fVectorDataPtr uvData = mesh->expandedVariableData<IECore::V2fVectorData>( "uv", IECore::PrimitiveVariable::FaceVarying ) )
-			{
-				std::vector<Imath::V2f> &uvs = uvData->writable();
-				for( unsigned i = 0; i < uvs.size(); ++i )
-				{
-					// as of Cortex 10, we take a UDIM centric approach
-					// to UVs, which clashes with OpenGL, so we must flip
-					// the v values during conversion.
-					uvs[i][1] = 1.0 - uvs[i][1];
-				}
-
-				glMesh->addPrimitiveVariable( "uv", IECore::PrimitiveVariable( IECore::PrimitiveVariable::FaceVarying, uvData ) );
-			}
-			else
-			{
-				IECore::msg( IECore::Msg::Warning, "ToGLMeshConverter", "If specified, primitive variable \"uv\" must be of type V2fVectorData." );
-			}
-		}
-		else if( pIt->second.data )
+		if( pIt->second.data )
 		{
 			glMesh->addPrimitiveVariable( pIt->first, pIt->second );
 		}

--- a/test/IECoreGL/MeshPrimitiveTest.py
+++ b/test/IECoreGL/MeshPrimitiveTest.py
@@ -59,8 +59,11 @@ class MeshPrimitiveTest( unittest.TestCase ) :
 		{
 			vec4 pCam = gl_ModelViewMatrix * vec4( vertexP, 1 );
 			gl_Position = gl_ProjectionMatrix * pCam;
-
-			color = vec4(vertexuv.x, vertexuv.y, 0.0, 1.0);
+			// Note that we're only flipping V here because the expected
+			// output image was generated with the wrong texture coordinates.
+			// It is _not_ expected that you would need to modify texture
+			// coordinates in the general case.
+			color = vec4(vertexuv.x, 1.0 - vertexuv.y, 0.0, 1.0);
 		}
 		"""
 


### PR DESCRIPTION
Cortex has the following conventions :

- 0,0 in image pixel space is top left, with increasing Y going down
- 0,0 in UV space is bottom left, with increasing V going up

OpenGL has the following conventions :

- 0,0 in texture pixel space is bottom left, with increasing Y going up
- 0,0 in UV space is bottom left, with increasing V going up

I haven't found chapter and verse for this, but I believe
[this link](https://stackoverflow.com/questions/17430753/what-is-the-orientation-of-opengl-texture-data)
because it matches my own observations.

Since the image/texture orientations differ, we should be flipping images
when uploading them as textures, which we are doing already in the Texture
classes. And since we're doing that, and the UV conventions match, we should
_not_ need to flip the V coordinate.

This fixes texture orientation when previewing textures in Gaffer using
glsl/Texture.frag. As far as I can tell, this has always been broken. Now seems the right time to fix it, since we'll be needing to adjust any shaders to use uv rather than st anyway.