### PR TITLE
IECoreGL : Expand PrimitiveVariableData when converting to attributes

### DIFF
--- a/src/IECoreGL/MeshPrimitive.cpp
+++ b/src/IECoreGL/MeshPrimitive.cpp
@@ -99,11 +99,11 @@ void MeshPrimitive::addPrimitiveVariable( const std::string &name, const IECore:
 
 	if ( primVar.interpolation==IECore::PrimitiveVariable::FaceVarying )
 	{
-		addVertexAttribute( name, primVar.data );
+		addVertexAttribute( name, primVar.expandedData() );
 	}
 	else if ( primVar.interpolation==IECore::PrimitiveVariable::Constant )
 	{
-		addUniformAttribute( name, primVar.data );
+		addUniformAttribute( name, primVar.expandedData() );
 	}
 	else if ( primVar.interpolation==IECore::PrimitiveVariable::Vertex || primVar.interpolation==IECore::PrimitiveVariable::Varying )
 	{

--- a/src/IECoreGL/Primitive.cpp
+++ b/src/IECoreGL/Primitive.cpp
@@ -172,11 +172,11 @@ void Primitive::addPrimitiveVariable( const std::string &name, const IECore::Pri
 {
 	if ( primVar.interpolation == IECore::PrimitiveVariable::Constant )
 	{
-		addUniformAttribute( name, primVar.data );
+		addUniformAttribute( name, primVar.expandedData() );
 	}
 	else
 	{
-		addVertexAttribute( name, primVar.data );
+		addVertexAttribute( name, primVar.expandedData() );
 	}
 }
 


### PR DESCRIPTION
Otherwise we end up passing arrays that are too short, and get crashes.