### PR TITLE
IECoreGL::ColorTexture : Fix bug retrieving RGBA images

### DIFF
--- a/src/IECoreGL/ColorTexture.cpp
+++ b/src/IECoreGL/ColorTexture.cpp
@@ -271,7 +271,7 @@ IECoreImage::ImagePrimitivePtr ColorTexture::imagePrimitive() const
 	// there are potentially loads of different internal formats which denote alpha.
 	// these are the only ones encountered so far, but it's not a great way of testing
 	// and i can't find another way of doing it.
-	if( internalFormat==GL_RGBA || internalFormat==GL_RGBA8_EXT || internalFormat==GL_RGBA16 )
+	if( internalFormat==GL_RGBA || internalFormat == GL_RGBA32F || internalFormat==GL_RGBA8_EXT || internalFormat==GL_RGBA16 )
 	{
 		ad = new FloatVectorData();
 		a = &ad->writable(); a->resize( width * height );


### PR DESCRIPTION
This was occurring on MacOS. Really it'd be better to find a way of querying whether a texture has alpha more directly, but in the absence of other ideas I've continued with the lame method that was in use already.