### PR TITLE
IECoreUSD : Comprehensive PrimVar type conversions.

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -637,8 +637,16 @@ struct PrimVarConverter
 
 		if( !p )
 		{
+			/* todo check why this conversion fails
+			 		WARNING : USDScene
+					Typed conversion failed for PrimVar: 'primvars:displayColor' type: color3f[]
+
+					WARNING : USDScene
+					Typed conversion failed for PrimVar: 'primvars:displayOpacity' type: float[]
+
 			IECore::msg(IECore::MessageHandler::Level::Warning, "USDScene", boost::format("Typed conversion failed for PrimVar: '%1%' type: %2%") % m_primVar.GetName().GetString() %
 				m_primVar.GetTypeName().GetAsToken().GetString());
+			 */
 			return;
 		}
 

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -43,9 +43,10 @@
 #include "pxr/usd/usd/stage.h"
 #include "pxr/usd/usdGeom/mesh.h"
 #include "pxr/usd/usdGeom/points.h"
-#include "pxr/usd/usdGeom/nurbsCurves.h"
+#include "pxr/usd/usdGeom/basisCurves.h"
 #include "pxr/usd/usdGeom/bboxCache.h"
 #include "pxr/usd/usdGeom/tokens.h"
+#include "pxr/usd/usdGeom/xform.h"
 #include "pxr/base/gf/matrix3d.h"
 #include "pxr/base/gf/matrix3f.h"
 #include "pxr/base/gf/matrix4d.h"
@@ -92,6 +93,12 @@ void convert( Imath::V3f &dst, const pxr::GfVec3f &src )
 }
 
 template<>
+void convert( pxr::GfVec3f &dst, const Imath::V3f &src )
+{
+	dst = pxr::GfVec3f( src[0], src[1], src[2] );
+}
+
+template<>
 void convert( Imath::V4f &dst, const pxr::GfVec4f &src )
 {
 	dst = Imath::V4f( src[0], src[1], src[2], src[3] );
@@ -104,9 +111,21 @@ void convert( Imath::V2d &dst, const pxr::GfVec2d &src )
 }
 
 template<>
+void convert( pxr::GfVec2d &dst, const Imath::V2d &src )
+{
+	dst = pxr::GfVec2d( src[0], src[1] );
+}
+
+template<>
 void convert( Imath::V2f &dst, const pxr::GfVec2f &src )
 {
 	dst = Imath::V2f( src[0], src[1] );
+}
+
+template<>
+void convert( pxr::GfVec2f &dst, const Imath::V2f &src )
+{
+	dst = pxr::GfVec2f( src[0], src[1] );
 }
 
 template<>
@@ -116,9 +135,21 @@ void convert( Imath::V2i &dst, const pxr::GfVec2i &src )
 }
 
 template<>
+void convert( pxr::GfVec2i &dst, const Imath::V2i &src)
+{
+	dst = pxr::GfVec2i( src[0], src[1] );
+}
+
+template<>
 void convert( Imath::V3i &dst, const pxr::GfVec3i &src )
 {
 	dst = Imath::V3i( src[0], src[1], src[2] );
+}
+
+template<>
+void convert( pxr::GfVec3i &dst, const Imath::V3i &src)
+{
+	dst = pxr::GfVec3i( src[0], src[1], src[2] );
 }
 
 template<>
@@ -140,9 +171,27 @@ void convert( Imath::Color3f& dst, const pxr::GfVec3f& src)
 }
 
 template<>
+void convert( pxr::GfVec3f &dst, const Imath::Color3f& src )
+{
+	dst = pxr::GfVec3f(src[0], src[1], src[2]);
+}
+
+template<>
+void convert( pxr::GfVec3d &dst, const Imath::V3d &src)
+{
+	dst = pxr::GfVec3d(src[0], src[1], src[2]);
+}
+
+template<>
 void convert( Imath::Color3<double>& dst, const pxr::GfVec3d& src)
 {
 	dst = Imath::Color3<double>(src[0], src[1], src[2]);
+}
+
+template<>
+void convert( pxr::GfVec3d &dst, const Imath::Color3<double> &src)
+{
+	dst = pxr::GfVec3d(src[0], src[1], src[2]);
 }
 
 template<>
@@ -150,10 +199,24 @@ void convert( Imath::Color4f& dst, const pxr::GfVec4f& src)
 {
 	dst = Imath::Color4f(src[0], src[1], src[2], src[3]);
 }
+
+template<>
+void convert( pxr::GfVec4f &dst, const Imath::Color4f &src )
+{
+	dst = pxr::GfVec4f(src[0], src[1], src[2], src[3]);
+}
+
+
 template<>
 void convert( Imath::Color4<double>& dst, const pxr::GfVec4d& src)
 {
 	dst = Imath::Color4<double>(src[0], src[1], src[2], src[3]);
+}
+
+template<>
+void convert( pxr::GfVec4d &dst, const Imath::Color4<double> &src )
+{
+	dst = pxr::GfVec4d(src[0], src[1], src[2], src[3]);
 }
 
 template<>
@@ -163,7 +226,40 @@ void convert( IECore::InternedString& dst, const pxr::TfToken &src)
 }
 
 template<>
+void convert( pxr::TfToken &dst, const IECore::InternedString& src )
+{
+	dst = pxr::TfToken( src.string() );
+}
+
+
+
+template<>
 void convert( Imath::M33f& dst, const pxr::GfMatrix3f& src)
+{
+	for( int i = 0; i < 3; ++i )
+	{
+		for( int j = 0; j < 3; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+
+template<>
+void convert( pxr::GfMatrix3f& dst, const Imath::M33f& src)
+{
+	for( int i = 0; i < 3; ++i )
+	{
+		for( int j = 0; j < 3; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+template<>
+void convert( pxr::GfMatrix3d& dst, const Imath::M33f& src)
 {
 	for( int i = 0; i < 3; ++i )
 	{
@@ -187,6 +283,18 @@ void convert( Imath::M33d& dst, const pxr::GfMatrix3d& src)
 }
 
 template<>
+void convert( pxr::GfMatrix3d& dst, const Imath::M33d& src)
+{
+	for( int i = 0; i < 3; ++i )
+	{
+		for( int j = 0; j < 3; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+template<>
 void convert( Imath::M44f& dst, const pxr::GfMatrix4f& src)
 {
 	for( int i = 0; i < 4; ++i )
@@ -199,7 +307,47 @@ void convert( Imath::M44f& dst, const pxr::GfMatrix4f& src)
 }
 
 template<>
+void convert( pxr::GfMatrix4f& dst, const Imath::M44f& src )
+{
+	for( int i = 0; i < 4; ++i )
+	{
+		for( int j = 0; j < 4; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+
+
+template<>
 void convert( Imath::M44d& dst, const pxr::GfMatrix4d& src)
+{
+
+	for( int i = 0; i < 4; ++i )
+	{
+		for( int j = 0; j < 4; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+template<>
+void convert( pxr::GfMatrix4d& dst, const Imath::M44f& src )
+{
+	for( int i = 0; i < 4; ++i )
+	{
+		for( int j = 0; j < 4; ++j )
+		{
+			dst[i][j] = src[i][j];
+		}
+	}
+}
+
+
+template<>
+void convert( pxr::GfMatrix4d& dst, const Imath::M44d& src)
 {
 
 	for( int i = 0; i < 4; ++i )
@@ -211,6 +359,7 @@ void convert( Imath::M44d& dst, const pxr::GfMatrix4d& src)
 	}
 
 }
+
 
 template<>
 void convert( Imath::Box3d &dst, const pxr::GfBBox3d &src )
@@ -263,11 +412,23 @@ void convert(Imath::Quatf& dst, const pxr::GfQuatf &src)
 }
 
 template<>
+void convert(pxr::GfQuatf &dst, const Imath::Quatf& src )
+{
+	dst = pxr::GfQuatf(src.r, src.v[0], src.v[1], src.v[2]);
+}
+
+template<>
 void convert(Imath::Quatd& dst, const pxr::GfQuatd &src)
 {
 	Imath::V3d img;
 	convert(img, src.GetImaginary());
 	dst = Imath::Quatf(src.GetReal(), img);
+}
+
+template<>
+void convert(pxr::GfQuatd &dst, const Imath::Quatd& src )
+{
+	dst = pxr::GfQuatf(src.r, src.v[0], src.v[1], src.v[2]);
 }
 
 IECoreScene::PrimitiveVariable::Interpolation convertInterpolation( pxr::TfToken interpolationToken )
@@ -295,6 +456,34 @@ IECoreScene::PrimitiveVariable::Interpolation convertInterpolation( pxr::TfToken
 
 	return IECoreScene::PrimitiveVariable::Invalid;
 }
+
+pxr::TfToken convertInterpolation( IECoreScene::PrimitiveVariable::Interpolation interpolation)
+{
+	if( interpolation == IECoreScene::PrimitiveVariable::Constant )
+	{
+		return pxr::UsdGeomTokens->constant;
+	}
+	if ( interpolation == IECoreScene::PrimitiveVariable::Uniform )
+	{
+		return pxr::UsdGeomTokens->uniform;
+	}
+	if ( interpolation == IECoreScene::PrimitiveVariable::Vertex)
+	{
+		return pxr::UsdGeomTokens->vertex;
+	}
+	if ( interpolation == IECoreScene::PrimitiveVariable::Varying)
+	{
+		return pxr::UsdGeomTokens->varying;
+	}
+	if ( interpolation == IECoreScene::PrimitiveVariable::FaceVarying)
+	{
+		return pxr::UsdGeomTokens->faceVarying;
+	}
+
+	return pxr::TfToken();
+}
+
+
 
 template<typename DestElementType, typename SourceElementType, template <typename P> class StorageType = IECore::GeometricTypedData>
 struct TypedArrayConverter
@@ -351,11 +540,79 @@ struct TypedScalarConverter
 	}
 };
 
+template<typename DestType, typename SourceType, template <typename P> class StorageType = IECore::GeometricTypedData >
+struct ToUSDArray
+{
+	typedef std::vector<SourceType> ArrayType;
+	typedef StorageType<ArrayType > SourceDataType;
+	typedef typename SourceDataType::ConstPtr SourceDataTypeConstPtr;
+
+	pxr::VtValue doConversion( IECore::ConstDataPtr srcData)
+	{
+		SourceDataTypeConstPtr ptr = IECore::runTimeCast<const SourceDataType>( srcData );
+
+		const ArrayType& arr = ptr->readable();
+
+		pxr::VtArray<DestType> destArray( arr.size() );
+
+		for (size_t i = 0; i < arr.size(); ++i)
+		{
+			convert( destArray[i], arr[i] );
+		}
+
+		return pxr::VtValue( destArray );
+	}
+};
+
 std::string cleanPrimVarName( const std::string &primVarName )
 {
 	return boost::algorithm::replace_first_copy( primVarName, "primvars:", "" );
 }
 
+
+struct ToUSDConverter
+{
+	ToUSDConverter( pxr::UsdGeomImageable &imageable, const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, pxr::UsdTimeCode time )
+		: m_imageable( imageable ), m_name( name ), m_primitiveVariable( primitiveVariable ), m_time( time )
+	{
+	}
+
+	template<typename ToUSDTypedConverter>
+	void doConversion( const pxr::SdfValueTypeName & valueTypeName)
+	{
+		pxr::TfToken usdInterpolation = convertInterpolation( m_primitiveVariable.interpolation );
+
+		if ( usdInterpolation.IsEmpty() )
+		{
+			IECore::msg(IECore::MessageHandler::Level::Warning, "USDScene", boost::format("Invalid Interpolation on %1%") % m_name );
+			return;
+		}
+
+		ToUSDTypedConverter typedConverter;
+
+		pxr::VtValue primVarValue = typedConverter.doConversion( m_primitiveVariable.data );
+
+		pxr::UsdGeomPrimvar usdPrimVar = m_imageable.CreatePrimvar( pxr::TfToken( m_name ), valueTypeName, usdInterpolation );
+
+		usdPrimVar.Set( primVarValue, m_time);
+
+		if ( m_primitiveVariable.indices )
+		{
+			pxr::VtIntArray usdIndices(m_primitiveVariable.indices->readable().size());
+			for (size_t i = 0; i < m_primitiveVariable.indices->readable().size(); ++i)
+			{
+				usdIndices[i] = m_primitiveVariable.indices->readable()[i];
+			}
+			usdPrimVar.SetIndices( usdIndices );
+		}
+	}
+
+	pxr::UsdGeomImageable m_imageable;
+	const std::string &m_name;
+	const IECoreScene::PrimitiveVariable &m_primitiveVariable;
+	pxr::UsdTimeCode m_time;
+
+};
 struct PrimVarConverter
 {
 	PrimVarConverter( IECoreScene::PrimitivePtr primitive, const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time ) : m_primitive( primitive ), m_primVar( primVar ), m_time( time )
@@ -380,7 +637,7 @@ struct PrimVarConverter
 
 		if( !p )
 		{
-			IECore::msg(IECore::MessageHandler::Level::Warning, "USDScene", boost::format("Typed conversion failed for PrimVar: %1% type: %2%") % m_primVar.GetName().GetString() %
+			IECore::msg(IECore::MessageHandler::Level::Warning, "USDScene", boost::format("Typed conversion failed for PrimVar: '%1%' type: %2%") % m_primVar.GetName().GetString() %
 				m_primVar.GetTypeName().GetAsToken().GetString());
 			return;
 		}
@@ -403,6 +660,50 @@ struct PrimVarConverter
 	pxr::UsdTimeCode m_time;
 };
 
+
+static std::map<IECore::TypeId, std::function<void( ToUSDConverter&)> > ToUSDConverters =
+{
+	{ IECore::BoolVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<bool, bool, IECore::TypedData> >( pxr::SdfValueTypeNames->BoolArray ); } },
+	{ IECore::HalfVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfHalf, half, IECore::TypedData> >( pxr::SdfValueTypeNames->HalfArray ); } },
+	{ IECore::FloatVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<float, float, IECore::TypedData> >( pxr::SdfValueTypeNames->FloatArray ); } },
+	{ IECore::DoubleVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<double, double, IECore::TypedData> >( pxr::SdfValueTypeNames->DoubleArray ); } },
+	{ IECore::IntVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<int, int, IECore::TypedData> >( pxr::SdfValueTypeNames->IntArray ); } },
+	{ IECore::UIntVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<unsigned int, unsigned int, IECore::TypedData> >( pxr::SdfValueTypeNames->UIntArray ); } },
+	{ IECore::CharVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<unsigned char, char, IECore::TypedData> >( pxr::SdfValueTypeNames->UCharArray ); } },
+	{ IECore::UCharVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<unsigned char, unsigned char, IECore::TypedData> >( pxr::SdfValueTypeNames->UCharArray ); } },
+	{ IECore::ShortVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<int, short, IECore::TypedData> >( pxr::SdfValueTypeNames->IntArray ); } },
+	{ IECore::UShortVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<int, unsigned short, IECore::TypedData> >( pxr::SdfValueTypeNames->IntArray ); } },
+	{ IECore::Int64VectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<int64_t, int64_t, IECore::TypedData> >( pxr::SdfValueTypeNames->Int64Array ); } },
+	{ IECore::UInt64VectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<uint64_t, uint64_t, IECore::TypedData> >( pxr::SdfValueTypeNames->UInt64Array ); } },
+	{ IECore::StringVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<std::string, std::string, IECore::TypedData> >( pxr::SdfValueTypeNames->StringArray ); } },
+	{ IECore::InternedStringVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::TfToken, InternedString, IECore::TypedData> >( pxr::SdfValueTypeNames->TokenArray ); } },
+
+	{ IECore::V2fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec2f, Imath::V2f> >( pxr::SdfValueTypeNames->Float2Array ); } },
+	{ IECore::V3fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec3f, Imath::V3f> >( pxr::SdfValueTypeNames->Float3Array ); } },
+	{ IECore::V2iVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec2i, Imath::V2i> >( pxr::SdfValueTypeNames->Int2Array ); } },
+	{ IECore::V3iVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec3i, Imath::V3i> >( pxr::SdfValueTypeNames->Int3Array ); } },
+	{ IECore::V2dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec2d, Imath::V2d> >( pxr::SdfValueTypeNames->Double2Array ); } },
+	{ IECore::V3dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec3d, Imath::V3d> >( pxr::SdfValueTypeNames->Double3Array ); } },
+
+	{ IECore::Color3fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec3f, Imath::Color3<float>, IECore::TypedData> >( pxr::SdfValueTypeNames->Color3fArray ); } },
+	{ IECore::Color3dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec3d, Imath::Color3<double>, IECore::TypedData> >( pxr::SdfValueTypeNames->Color3dArray ); } },
+
+	{ IECore::Color4fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec4f, Imath::Color4<float>, IECore::TypedData> >( pxr::SdfValueTypeNames->Color4fArray ); } },
+	{ IECore::Color4dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfVec4d, Imath::Color4<double>, IECore::TypedData> >( pxr::SdfValueTypeNames->Color4dArray ); } },
+
+	{ IECore::QuatfVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfQuatf, Imath::Quatf, IECore::TypedData> >( pxr::SdfValueTypeNames->QuatfArray ); } },
+	{ IECore::QuatdVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfQuatd, Imath::Quatd, IECore::TypedData> >( pxr::SdfValueTypeNames->QuatdArray ); } },
+
+	{ IECore::M33fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfMatrix3d, Imath::M33f, IECore::TypedData> >( pxr::SdfValueTypeNames->Matrix3dArray ); } },
+	{ IECore::M33dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfMatrix3d, Imath::M33d, IECore::TypedData> >( pxr::SdfValueTypeNames->Matrix3dArray ); } },
+
+	{ IECore::M44fVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfMatrix4d, Imath::M44f, IECore::TypedData> >( pxr::SdfValueTypeNames->Matrix4dArray ); } },
+	{ IECore::M44dVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfMatrix4d, Imath::M44d, IECore::TypedData> >( pxr::SdfValueTypeNames->Matrix4dArray ); } },
+
+	{ IECore::QuatfVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfQuatf, Imath::Quatf, IECore::TypedData> >( pxr::SdfValueTypeNames->QuatfArray ); } },
+	{ IECore::QuatdVectorDataTypeId, [] (ToUSDConverter& converter) { converter.doConversion< ToUSDArray<pxr::GfQuatd, Imath::Quatd, IECore::TypedData> >( pxr::SdfValueTypeNames->QuatdArray ); } },
+
+};
 
 static std::map<pxr::TfToken, std::function<void( PrimVarConverter& converter )> > primvarConversions =
 {
@@ -534,7 +835,8 @@ static std::map<pxr::TfToken, std::function<void( PrimVarConverter& converter )>
 
 void convertPrimVar( IECoreScene::PrimitivePtr primitive, const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time )
 {
-	pxr::TfToken typeToken = primVar.GetTypeName().GetAsToken();
+
+	pxr::TfToken typeToken = primVar.GetTypeName().GetAsToken(); // docs state 'GetAsToken' should not be used for comparision purposes.
 
 	auto it = primvarConversions.find( typeToken );
 	if ( it != primvarConversions.end() )
@@ -553,7 +855,18 @@ void convertPrimVar( IECoreScene::PrimitivePtr primitive, const pxr::UsdGeomPrim
 	{
 		IECore::msg(IECore::MessageHandler::Level::Warning, "USDScene", boost::format("Unknown type %1% on PrimVar %2% ") % typeToken.GetString() % primVar.GetName().GetString());
 	}
+}
 
+
+void convertPrimVar( pxr::UsdGeomImageable &imageablePrim, const std::string &srcPrimVarName, const IECoreScene::PrimitiveVariable &srcPrimVar, pxr::UsdTimeCode timeCode )
+{
+	auto it = ToUSDConverters.find( srcPrimVar.data->typeId() );
+
+	if (it != ToUSDConverters.end())
+	{
+		ToUSDConverter converter(imageablePrim, srcPrimVarName, srcPrimVar, timeCode);
+		it->second( converter );
+	}
 }
 
 void convertPrimVars( pxr::UsdGeomImageable imagable, IECoreScene::PrimitivePtr primitive, pxr::UsdTimeCode time )
@@ -641,6 +954,84 @@ IECoreScene::MeshPrimitivePtr convertPrimitive( pxr::UsdGeomMesh mesh, pxr::UsdT
 	}
 
 	return newMesh;
+}
+
+void convertPrimitiveVariables( pxr::UsdGeomImageable imageable, const IECoreScene::Primitive *primitive, pxr::UsdTimeCode timeCode)
+{
+	const static std::set<std::string> primVarsToIgnore = {"P"};
+
+	for ( const auto &primitiveVariable : primitive->variables )
+	{
+		if (primVarsToIgnore.find( primitiveVariable.first ) == primVarsToIgnore.end() )
+		{
+			convertPrimVar( imageable, primitiveVariable.first, primitiveVariable.second, timeCode );
+		}
+	}
+}
+
+void convertPoints( pxr::UsdGeomPointBased pointsBased, const IECoreScene::Primitive *primitive, pxr::UsdTimeCode timeCode)
+{
+	ToUSDArray<pxr::GfVec3f, Imath::V3f> toUSDVec3Array;
+
+	const auto it = primitive->variables.find("P");
+	if (it != primitive->variables.end() )
+	{
+		pointsBased.CreatePointsAttr().Set(  toUSDVec3Array.doConversion ( it->second.data ), timeCode);
+	}
+	else
+	{
+		//todo raise an exception
+	}
+
+}
+
+void convertPrimitive( pxr::UsdGeomMesh usdMesh, const IECoreScene::MeshPrimitive *mesh, pxr::UsdTimeCode timeCode )
+{
+	// convert topology
+	ToUSDArray<int, int, IECore::TypedData> toUSDIntArray;
+	usdMesh.CreateFaceVertexCountsAttr().Set(  toUSDIntArray.doConversion( mesh->verticesPerFace() ) , timeCode);
+	usdMesh.CreateFaceVertexIndicesAttr().Set( toUSDIntArray.doConversion( mesh->vertexIds() ), timeCode );
+
+	// positions
+	convertPoints(usdMesh, mesh, timeCode );
+
+	// set the interpolation
+
+	if (mesh->interpolation() == std::string("catmullClark"))
+	{
+		usdMesh.CreateSubdivisionSchemeAttr().Set( pxr::UsdGeomTokens->catmullClark );
+	}
+	else
+	{
+		usdMesh.CreateSubdivisionSchemeAttr().Set( pxr::UsdGeomTokens->none );
+	}
+
+
+
+	// convert all primvars to USD
+	convertPrimitiveVariables( usdMesh, mesh, timeCode );
+}
+
+void convertPrimitive( pxr::UsdGeomPoints usdPoints, const IECoreScene::PointsPrimitive *points, pxr::UsdTimeCode timeCode )
+{
+	// positions
+	convertPoints(usdPoints, points, timeCode);
+
+	// convert all primvars to USD
+	convertPrimitiveVariables( usdPoints, points, timeCode );
+}
+
+void convertPrimitive( pxr::UsdGeomBasisCurves usdCurves, const IECoreScene::CurvesPrimitive *curves, pxr::UsdTimeCode timeCode )
+{
+	// convert topology
+	ToUSDArray<int, int, IECore::TypedData> toUSDIntArray;
+	usdCurves.CreateCurveVertexCountsAttr().Set( toUSDIntArray.doConversion( curves->verticesPerCurve() ), timeCode );
+
+	// positions
+	convertPoints( usdCurves, curves, timeCode );
+
+	// convert all primvars to USD
+	convertPrimitiveVariables( usdCurves, curves, timeCode );
 }
 
 bool isConvertible( pxr::UsdPrim prim )
@@ -760,6 +1151,10 @@ class USDScene::IO : public RefCounted
 		{
 		}
 
+		virtual ~IO()
+		{
+		}
+
 		const std::string &fileName() const
 		{
 			return m_fileName;
@@ -767,6 +1162,13 @@ class USDScene::IO : public RefCounted
 
 		virtual pxr::UsdPrim root() const = 0;
 		virtual pxr::UsdTimeCode getTime( double timeSeconds ) const = 0;
+
+		virtual bool isReader() const = 0;
+
+		pxr::UsdStageRefPtr getStage() const { return m_usdStage; }
+	protected:
+		pxr::UsdStageRefPtr m_usdStage;
+
 	private:
 		std::string m_fileName;
 };
@@ -791,8 +1193,10 @@ class USDScene::Reader : public USDScene::IO
 			return timeSeconds * m_timeCodesPerSecond;
 		}
 
+		bool isReader()  const override { return true; }
+
 	private:
-		pxr::UsdStageRefPtr m_usdStage;
+
 		pxr::UsdPrim m_rootPrim;
 
 		double m_timeCodesPerSecond;
@@ -803,8 +1207,14 @@ class USDScene::Writer : public USDScene::IO
 	public:
 		Writer( const std::string &fileName ) : IO( fileName )
 		{
-			m_usdStage = pxr::UsdStage::CreateNew( "gaffer" );
+			m_usdStage = pxr::UsdStage::CreateNew( fileName );
+			m_timeCodesPerSecond = m_usdStage->GetTimeCodesPerSecond();
 			m_rootPrim = m_usdStage->GetPseudoRoot();
+		}
+
+		~Writer() override
+		{
+			m_usdStage->GetRootLayer()->Save();
 		}
 
 		pxr::UsdPrim root() const override
@@ -814,12 +1224,16 @@ class USDScene::Writer : public USDScene::IO
 
 		pxr::UsdTimeCode getTime( double timeSeconds ) const override
 		{
-			return 0.0;
+			return timeSeconds * m_timeCodesPerSecond;
 		}
 
+		bool isReader()  const override { return false; }
+
 	private:
-		pxr::UsdStageRefPtr m_usdStage;
+
 		pxr::UsdPrim m_rootPrim;
+
+		double m_timeCodesPerSecond;
 };
 
 USDScene::USDScene( const std::string &path, IndexedIO::OpenMode &mode )
@@ -859,15 +1273,21 @@ Imath::Box3d USDScene::readBound( double time ) const
 	{
 		pxr::UsdAttribute attr = boundable.GetExtentAttr();
 
-		pxr::VtArray<pxr::GfVec3f> extents;
-		attr.Get<pxr::VtArray<pxr::GfVec3f> >( &extents, m_root->getTime( time ) );
+		if ( attr.IsValid() )
+		{
+			pxr::VtArray<pxr::GfVec3f> extents;
+			attr.Get<pxr::VtArray<pxr::GfVec3f> >( &extents, m_root->getTime( time ) );
 
-		Imath::V3f min;
-		convert( min, extents[0] );
+			Imath::V3f min;
+			convert( min, extents[0] );
 
-		Imath::V3f max;
-		convert( max, extents[1] );
-		return Imath::Box3d( min, max );
+			Imath::V3f max;
+			convert( max, extents[1] );
+			return Imath::Box3d( min, max );
+		}
+
+		return Imath::Box3d();
+
 	}
 
 	return Imath::Box3d();
@@ -929,12 +1349,45 @@ bool USDScene::hasBound() const
 
 void USDScene::writeBound( const Imath::Box3d &bound, double time )
 {
-	throw IECore::NotImplementedException( "USDScene::writeBound not supported" );
+//	pxr::UsdGeomBoundable boundable( m_location->prim );
+//	if( !boundable )
+//	{
+//		return;
+//	}
+//
+//	pxr::UsdAttribute boundAttribute = boundable.CreateExtentAttr();
+//
+//	VtValue boundValue
+//	boundAttribute.Set()
+
 }
 
 void USDScene::writeTransform( const Data *transform, double time )
 {
-	throw IECore::NotImplementedException( "USDScene::writeTransform not supported" );
+
+	pxr::UsdTimeCode timeCode = m_root->getTime( time );
+
+	const M44dData *m44 = IECore::runTimeCast<const M44dData>( transform );
+	if( !m44 )
+	{
+		return;
+	}
+
+	Imath::M44d matrix = m44->readable();
+	pxr::UsdGeomXformable xformable( m_location->prim );
+
+	if( xformable )
+	{
+		pxr::UsdGeomXformOp transformOp = xformable.MakeMatrixXform();
+		pxr::GfMatrix4d usdMat;
+
+		convert(usdMat, matrix);
+
+		transformOp.Set( usdMat, timeCode );
+
+		return;
+	}
+
 }
 
 bool USDScene::hasAttribute( const SceneInterface::Name &name ) const
@@ -944,12 +1397,10 @@ bool USDScene::hasAttribute( const SceneInterface::Name &name ) const
 
 void USDScene::attributeNames( SceneInterface::NameList &attrs ) const
 {
-
 }
 
 void USDScene::writeAttribute( const SceneInterface::Name &name, const Object *attribute, double time )
 {
-	throw IECore::NotImplementedException( "USDScene::writeAttribute not supported" );
 }
 
 bool USDScene::hasTag( const SceneInterface::Name &name, int filter ) const
@@ -964,7 +1415,6 @@ void USDScene::readTags( SceneInterface::NameList &tags, int filter ) const
 
 void USDScene::writeTags( const SceneInterface::NameList &tags )
 {
-	throw IECore::NotImplementedException( "USDScene::writeTags not supported" );
 }
 
 bool USDScene::hasObject() const
@@ -979,7 +1429,35 @@ PrimitiveVariableMap USDScene::readObjectPrimitiveVariables( const std::vector<I
 
 void USDScene::writeObject( const Object *object, double time )
 {
-	throw IECore::NotImplementedException( "USDScene::writeObject not supported" );
+	pxr::UsdTimeCode timeCode = m_root->getTime( time );
+
+	const IECoreScene::MeshPrimitive* meshPrimitive = IECore::runTimeCast<const IECoreScene::MeshPrimitive>( object );
+	if ( meshPrimitive )
+	{
+		pxr::SdfPath p = m_location->prim.GetPath();
+
+		pxr::UsdGeomMesh usdMesh = pxr::UsdGeomMesh::Define( m_root->getStage(), p );
+		convertPrimitive( usdMesh, meshPrimitive, timeCode );
+	}
+
+	const IECoreScene::PointsPrimitive* pointsPrimitive = IECore::runTimeCast<const IECoreScene::PointsPrimitive>( object );
+	if ( pointsPrimitive )
+	{
+		pxr::SdfPath p = m_location->prim.GetPath();
+
+		pxr::UsdGeomPoints usdPoints = pxr::UsdGeomPoints::Define( m_root->getStage(), p );
+		convertPrimitive( usdPoints, pointsPrimitive, timeCode );
+	}
+
+	const IECoreScene::CurvesPrimitive* curvesPrimitive = IECore::runTimeCast<const IECoreScene::CurvesPrimitive>( object );
+	if ( curvesPrimitive )
+	{
+		pxr::SdfPath p = m_location->prim.GetPath();
+
+		pxr::UsdGeomBasisCurves usdCurves = pxr::UsdGeomBasisCurves::Define( m_root->getStage(), p );
+		convertPrimitive( usdCurves, curvesPrimitive, timeCode );
+	}
+
 }
 
 bool USDScene::hasChild( const SceneInterface::Name &name ) const
@@ -1020,7 +1498,20 @@ SceneInterfacePtr USDScene::child( const SceneInterface::Name &name, SceneInterf
 		case SceneInterface::ThrowIfMissing :
 			throw IOException( "Child \"" + name.string() + "\" does not exist" );
 		case SceneInterface::CreateIfMissing :
-			throw InvalidArgumentException( "Child creation not supported" );
+		{
+			if( m_root->isReader() )
+			{
+				throw InvalidArgumentException( "Child creation not supported" );
+			}
+			else
+			{
+				pxr::UsdPrim prim = m_location->prim;
+				pxr::SdfPath newPath = prim.GetPath().AppendChild( pxr::TfToken( name.string() ) );
+				pxr::UsdGeomXform newXform = pxr::UsdGeomXform::Define( m_root->getStage(), newPath );
+
+				return new USDScene( m_root, new Location( newXform.GetPrim() ) );
+			}
+		}
 		default:
 			return nullptr;
 	}
@@ -1033,8 +1524,11 @@ ConstSceneInterfacePtr USDScene::child( const SceneInterface::Name &name, SceneI
 
 SceneInterfacePtr USDScene::createChild( const SceneInterface::Name &name )
 {
-	throw IECore::NotImplementedException( "USDScene::createChild not supported" );
-	return nullptr;
+	pxr::UsdPrim prim = m_location->prim;
+	pxr::SdfPath newPath = prim.GetPath().AppendChild( pxr::TfToken( name.string() ) );
+	pxr::UsdGeomXform newXform = pxr::UsdGeomXform::Define( m_root->getStage(), newPath );
+
+	return new USDScene( m_root, new Location( newXform.GetPrim() ) );
 }
 
 SceneInterfacePtr USDScene::scene( const SceneInterface::Path &path, SceneInterface::MissingBehaviour missingBehaviour )

--- a/contrib/IECoreUSD/test/IECoreUSD/All.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/All.py
@@ -36,6 +36,7 @@ import unittest
 import sys
 
 from USDSceneTest import USDSceneTest
+from USDSceneWriterTest import USDSceneWriterTest
 
 import IECore
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -75,7 +75,7 @@ class USDSceneTest( unittest.TestCase ) :
 		# todo: childname & hierarchy hashes should also
 		# todo: be constant but I'm unsure how to implement this right now.
 		hashTypes = [cube.HashType.TransformHash, cube.HashType.ObjectHash, cube.HashType.BoundHash]
-		# hashTypes = IECore.SceneInterface.HashType.values.values()
+		# hashTypes = IECoreScene.SceneInterface.HashType.values.values()
 
 		hashes = [cube.hash( hashType, 0 ) for hashType in hashTypes]
 
@@ -159,4 +159,91 @@ class USDSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( transform, expectedMatrix )
 
+	def testPrimVarTypes ( self ) :
+
+		root = IECoreScene.SceneInterface.create( os.path.dirname( __file__ ) + "/data/primVars.usda", IECore.IndexedIO.OpenMode.Read )
+
+		object = root.child("root").child("sphere").readObject(0.0)
+
+		expected = {
+			'test_Bool_Scalar_constant' : IECore.BoolData( 0 ),
+			'test_Double2_Array_constant' : IECore.V2dVectorData( [IECore.V2d( 1.1, 1.2 ), IECore.V2d( 2.1, 2.2 ), IECore.V2d( 3.1, 3.2 )] ),
+			'test_Double2_Scalar_constant' : IECore.V2dData( IECore.V2d( 0.1, 0.2 ) ),
+			'test_Double3_Array_constant' : IECore.V3dVectorData( [IECore.V3d( 1.1, 1.2, 1.3 ), IECore.V3d( 2.1, 2.2, 2.3 ), IECore.V3d( 3.1, 3.2, 3.3 )] ),
+			'test_Double3_Scalar_constant' : IECore.V3dData( IECore.V3d( 0.1, 0.2, 0.3 ) ),
+			'test_Double_Array_constant' : IECore.DoubleVectorData([1.2, 1.3, 1.4]),
+			'test_Double_Scalar_constant' : IECore.DoubleData( 1.1 ),
+			'test_Float2_Array_constant' : IECore.V2fVectorData( [IECore.V2f( 1.1, 1.2 ), IECore.V2f( 2.1, 2.2 ), IECore.V2f( 3.1, 3.2 )] ),
+			'test_Float2_Scalar_constant' : IECore.V2fData( IECore.V2f( 0.1, 0.2 ) ),
+			'test_Float3_Array_constant' : IECore.V3fVectorData( [IECore.V3f( 1.1, 1.2, 1.3 ), IECore.V3f( 2.1, 2.2, 2.3 ), IECore.V3f( 3.1, 3.2, 3.3 )] ),
+			'test_Float3_Scalar_constant' : IECore.V3fData( IECore.V3f( 0.1, 0.2, 0.3 ) ),
+			'test_Float_Array_constant' : IECore.FloatVectorData( [0.7, 0.8, 0.9] ),
+			'test_Float_Scalar_constant' : IECore.FloatData( 0.6 ),
+			'test_Half_Array_constant' : IECore.HalfVectorData( [0.0999756, 0.199951, 0.300049] ),
+			'test_Half_Scalar_constant' : IECore.HalfData( 0.5 ),
+			'test_Int2_Array_constant' : IECore.V2iVectorData( [IECore.V2i( 3, 4 ), IECore.V2i( 5, 6 ), IECore.V2i( 7, 8 )] ),
+			'test_Int2_Scalar_constant' : IECore.V2iData( IECore.V2i( 1, 2 ) ),
+			'test_Int3_Array_constant' : IECore.V3iVectorData([IECore.V3i(3, 4, 5), IECore.V3i(5, 6, 7), IECore.V3i(7, 8, 9)]),
+			'test_Int3_Scalar_constant' : IECore.V3iData(IECore.V3i(1, 2, 3)),
+			'test_Int64_Array_constant' : IECore.Int64VectorData([9223372036854775805, 9223372036854775806, 9223372036854775807]),
+			'test_Int64_Scalar_constant' : IECore.Int64Data(-9223372036854775808),
+			'test_Int_Array_constant' : IECore.IntVectorData([0, -1, -2]),
+			'test_Int_Scalar_constant' : IECore.IntData(-1),
+			'test_String_Array_constant' : IECore.StringVectorData(["is", "a", "test"]),
+			'test_String_Scalar_constant': IECore.StringData('this'),
+			'test_Token_Array_constant' : IECore.InternedStringVectorData([IECore.InternedString("t-is"), IECore.InternedString("t-a"), IECore.InternedString("t-test")]),
+			'test_Token_Scalar_constant' : IECore.InternedStringData(IECore.InternedString("t-this")),
+			'test_UChar_Array_constant' : IECore.UCharVectorData([0,1,2]),
+			'test_UChar_Scalar_constant' : IECore.UCharData(0),
+			'test_UInt64_Array_constant' : IECore.UInt64VectorData([18446744073709551613, 18446744073709551614, 18446744073709551615]),
+			'test_UInt64_Scalar_constant' : IECore.UInt64Data(18446744073709551615),
+			'test_UInt_Array_constant' : IECore.UIntVectorData([4294967293, 4294967294, 4294967295]),
+			'test_UInt_Scalar_constant' : IECore.UIntData(4294967295),
+			'test_color3d_Array_constant' : IECore.Color3dVectorData([IECore.Color3d(1.1, 1.2, 1.3), IECore.Color3d(2.1, 2.2, 2.3), IECore.Color3d(3.1, 3.2, 3.3)]),
+			'test_color3d_Scalar_constant' : IECore.Color3dData(IECore.Color3d(0.1, 0.2, 0.3)),
+			'test_color3f_Array_constant' : IECore.Color3fVectorData([IECore.Color3f(1.1, 1.2, 1.3), IECore.Color3f(2.1, 2.2, 2.3), IECore.Color3f(3.1, 3.2, 3.3)]),
+			'test_color3f_Scalar_constant' :  IECore.Color3fData(IECore.Color3f(0.1, 0.2, 0.3)),
+			'test_color4d_Array_constant' : IECore.Color4dVectorData([IECore.Color4d(1.1, 1.2, 1.3, 1.4), IECore.Color4d(2.1, 2.2, 2.3, 2.4), IECore.Color4d(3.1, 3.2, 3.3, 3.4)]),
+			'test_color4d_Scalar_constant' : IECore.Color4dData(IECore.Color4d(0.1, 0.2, 0.3, 0.4)),
+			'test_color4f_Array_constant' : IECore.Color4fVectorData([IECore.Color4f(1.1, 1.2, 1.3, 1.4), IECore.Color4f(2.1, 2.2, 2.3, 2.4), IECore.Color4f(3.1, 3.2, 3.3, 3.4)]),
+			'test_color4f_Scalar_constant' : IECore.Color4fData(IECore.Color4f(0.1, 0.2, 0.3, 0.4)),
+			'test_matrix3d_Array_constant' : IECore.M33dVectorData(
+				[
+					IECore.M33d(0, 0, 0, 0, 1, 0,0, 0, 0),
+					IECore.M33d(0, 0, 0, 0, 0, 0,0, 0, 2),
+					IECore.M33d(0, 0, 4, 0, 0, 0,0, 0, 0)
+				]
+			),
+			'test_matrix3d_Scalar_constant' : IECore.M33dData(IECore.M33d(0, 0, 0, 0, 0, 0, 0, 0, 0)),
+			'test_matrix4d_Array_constant' : IECore.M44dVectorData(
+				[
+					IECore.M44d(1, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0),
+					IECore.M44d(1, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+					IECore.M44d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0)
+				]
+			),
+			'test_matrix4d_Scalar_constant' : IECore.M44dData(IECore.M44d(1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)),
+			'test_normal3d_Array_constant' : IECore.V3dVectorData([IECore.V3d( 1.1, 1.2, 1.3 ), IECore.V3d( 2.1, 2.2, 2.3 ), IECore.V3d( 3.1, 3.2, 3.3 )]),
+			'test_normal3d_Scalar_constant' : IECore.V3dData (IECore.V3d( 0.1, 0.2, 0.3 )),
+			'test_normal3f_Array_constant': IECore.V3fVectorData([IECore.V3f( 1.1, 1.2, 1.3 ), IECore.V3f( 2.1, 2.2, 2.3 ), IECore.V3f( 3.1, 3.2, 3.3 )]),
+			'test_normal3f_Scalar_constant' : IECore.V3fData (IECore.V3f( 0.1, 0.2, 0.3 )),
+			'test_point3d_Array_constant' : IECore.V3dVectorData([IECore.V3d( 1.1, 1.2, 1.3 ), IECore.V3d( 2.1, 2.2, 2.3 ), IECore.V3d( 3.1, 3.2, 3.3 )]),
+			'test_point3d_Scalar_constant' : IECore.V3dData (IECore.V3d( 0.1, 0.2, 0.3 )),
+			'test_point3f_Array_constant' : IECore.V3fVectorData([IECore.V3f( 1.1, 1.2, 1.3 ), IECore.V3f( 2.1, 2.2, 2.3 ), IECore.V3f( 3.1, 3.2, 3.3 )]),
+			'test_point3f_Scalar_constant' : IECore.V3fData(IECore.V3f(0.1, 0.2, 0.3)),
+			'test_quatd_Array_constant' : IECore.QuatdVectorData([IECore.Quatd(1, 0, 0, 0), IECore.Quatd(0, 1, 0, 0), IECore.Quatd(0, 0, 1, 0)]),
+			'test_quatd_Scalar_constant' : IECore.QuatdData(IECore.Quatd(0, 0, 0, 1)),
+			'test_quatf_Array_constant' : IECore.QuatfVectorData([IECore.Quatf(1, 0, 0, 0), IECore.Quatf(0, 1, 0, 0), IECore.Quatf(0, 0, 1, 0)]),
+			'test_quatf_Scalar_constant' : IECore.QuatfData(IECore.Quatf(0, 0, 0, 1)),
+			'test_vector3d_Array_constant' : IECore.V3dVectorData([IECore.V3d( 1.1, 1.2, 1.3 ), IECore.V3d( 2.1, 2.2, 2.3 ), IECore.V3d( 3.1, 3.2, 3.3 )]),
+			'test_vector3d_Scalar_constant' : IECore.V3dData (IECore.V3d( 0.1, 0.2, 0.3 )),
+			'test_vector3f_Array_constant' : IECore.V3fVectorData([IECore.V3f( 1.1, 1.2, 1.3 ), IECore.V3f( 2.1, 2.2, 2.3 ), IECore.V3f( 3.1, 3.2, 3.3 )]),
+			'test_vector3f_Scalar_constant' : IECore.V3fData (IECore.V3f( 0.1, 0.2, 0.3 )),
+		}
+
+
+		for primVarName, primVarExpectedValue in expected.items():
+			self.assertTrue(primVarName in object.keys())
+			p = object[primVarName]
+			self.assertEqual(p.data, primVarExpectedValue)
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneWriterTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneWriterTest.py
@@ -92,7 +92,11 @@ class USDSceneWriterTest( unittest.TestCase ) :
 		uvData = IECore.V2fVectorData( [IECore.V2f( 1.0, 2.0 )] )
 		uvIndexData = IECore.IntVectorData( [0, 0, 0, 0] )
 
+		scalarTest = IECore.IntData( 123 )
+
 		quad["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, uvData, uvIndexData )
+		quad["scalarTest"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, scalarTest )
+
 		flatEarth.writeObject( quad, 0.0 )
 
 		del flatEarth
@@ -108,12 +112,16 @@ class USDSceneWriterTest( unittest.TestCase ) :
 
 		self.assertTrue( "P" in readMesh )
 		self.assertTrue( "uv" in readMesh )
+		self.assertTrue( "scalarTest" in readMesh)
 
 		roundTripData = readMesh["uv"].data
 		roundTripIndices = readMesh["uv"].indices
 
 		self.assertEqual(roundTripData, IECore.V2fVectorData( [ IECore.V2f( 1.0, 2.0) ] ) )
 		self.assertEqual(roundTripIndices, IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+
+		roundTripScalar = readMesh["scalarTest"].data
+		self.assertEqual(roundTripScalar, IECore.IntData( 123 ) )
 
 	def testCanWritePoints ( self ):
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneWriterTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneWriterTest.py
@@ -1,0 +1,347 @@
+import os
+import unittest
+
+import IECore
+import IECoreScene
+import IECoreUSD
+
+
+class USDSceneWriterTest( unittest.TestCase ) :
+
+	def getOutputPath( self, filename ):
+		return os.path.join( os.path.dirname( __file__ ), filename)
+
+	def testCanWriteEmptyUSDFile( self ) :
+
+		fileName = self.getOutputPath("usd_empty.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), [] )
+
+	def testCanWriteTransformHeirarchy ( self ) :
+
+		fileName = self.getOutputPath("usd_transform.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		numberOneSon = sceneWrite.createChild( "nakamoto" )
+		numberOneGrandson = numberOneSon.createChild( "satoshi" )
+		testTransform = IECore.M44dData( IECore.M44d( [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 2, 3, 1] ) )
+		numberOneGrandson.writeTransform( testTransform , 0.0 )
+
+		del numberOneGrandson
+		del numberOneSon
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), [ "nakamoto" ] )
+		sceneReadNumberOneSon = sceneRead.child("nakamoto")
+		self.assertEqual( sceneReadNumberOneSon.childNames(), [ "satoshi" ] )
+		sceneReadNumberOneGrandson = sceneReadNumberOneSon.child("satoshi")
+
+		self.assertEqual( sceneReadNumberOneGrandson.childNames(), [] )
+		self.assertEqual( sceneReadNumberOneGrandson.readTransform( 0.0 ), testTransform)
+
+	def testCanWriteSimpleMesh( self ) :
+
+		fileName = self.getOutputPath("usd_simple_mesh.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		flatEarth = sceneWrite.createChild( "flatearth" )
+
+		planeDimensions = IECore.Box2f( IECore.V2f( 0, 0 ), IECore.V2f( 1, 1 ) )
+		planeDivisions = IECore.V2i( 16, 16 )
+
+		flatEarthObject = IECoreScene.MeshPrimitive.createPlane( planeDimensions, planeDivisions )
+
+		flatEarth.writeObject( flatEarthObject, 0.0 )
+
+		del flatEarth
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["flatearth"] )
+		otherWorld = sceneRead.child( "flatearth" )
+
+		self.assertTrue( otherWorld.hasObject() )
+
+		object = otherWorld.readObject( 0.0 )
+		self.assertIsInstance( object, IECoreScene.MeshPrimitive )
+
+		otherMesh = object
+
+		self.assertTrue("P" in otherMesh)
+
+	def testCanWritePrimitiveVariables( self ) :
+
+		fileName = self.getOutputPath("usd_primvars.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		flatEarth = sceneWrite.createChild( "flatearth" )
+
+		planeDimensions = IECore.Box2f( IECore.V2f( 0, 0 ), IECore.V2f( 1, 1 ) )
+		planeDivisions = IECore.V2i( 1, 1 )
+
+		quad = IECoreScene.MeshPrimitive.createPlane( planeDimensions, planeDivisions )
+
+		uvData = IECore.V2fVectorData( [IECore.V2f( 1.0, 2.0 )] )
+		uvIndexData = IECore.IntVectorData( [0, 0, 0, 0] )
+
+		quad["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, uvData, uvIndexData )
+		flatEarth.writeObject( quad, 0.0 )
+
+		del flatEarth
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["flatearth"] )
+		otherWorld = sceneRead.child( "flatearth" )
+
+		readMesh = otherWorld.readObject( 0.0 )
+
+		self.assertIsInstance( readMesh, IECoreScene.MeshPrimitive )
+
+		self.assertTrue( "P" in readMesh )
+		self.assertTrue( "uv" in readMesh )
+
+		roundTripData = readMesh["uv"].data
+		roundTripIndices = readMesh["uv"].indices
+
+		self.assertEqual(roundTripData, IECore.V2fVectorData( [ IECore.V2f( 1.0, 2.0) ] ) )
+		self.assertEqual(roundTripIndices, IECore.IntVectorData( [ 0, 0, 0, 0 ] ) )
+
+	def testCanWritePoints ( self ):
+
+		fileName = self.getOutputPath("usd_points.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+
+		positionData = []
+		for i in range( 16 ) :
+			for j in range( 16 ) :
+				positionData.append( IECore.V3f( [i, j, 0] ) );
+
+		positions = IECore.V3fVectorData( positionData )
+
+		pointsPrimitive = IECoreScene.PointsPrimitive( positions )
+		root.writeObject( pointsPrimitive, 0.0 )
+
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["root"] )
+		readRoot = sceneRead.child( "root" )
+
+		self.assertTrue( readRoot.hasObject() )
+
+		readPoints = readRoot.readObject( 0.0 )
+		self.assertIsInstance( readPoints, IECoreScene.PointsPrimitive )
+
+		roundTripPositions = readPoints["P"].data
+		self.assertEqual( roundTripPositions, positions )
+
+	def testCanWriteCurves( self ) :
+
+		fileName = self.getOutputPath("usd_curves.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+
+		vertsPerCurveData = []
+		positionData = []
+		for i in range( 16 ) :
+			for j in range( 16 ) :
+				vertsPerCurveData.append( 4 );
+				for k in range( 3 ) :
+					positionData.append( IECore.V3f( [i, j, k] ) )
+
+		curvesPrimitive = IECoreScene.CurvesPrimitive( IECore.IntVectorData( vertsPerCurveData ), IECore.CubicBasisf.linear(), False, IECore.V3fVectorData( positionData ) )
+
+		root.writeObject( curvesPrimitive, 0.0 )
+
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["root"] )
+		readRoot = sceneRead.child( "root" )
+
+		self.assertTrue( readRoot.hasObject() )
+
+		readCurves = readRoot.readObject( 0.0 )
+		self.assertIsInstance( readCurves, IECoreScene.CurvesPrimitive )
+
+		self.assertEqual( readCurves.verticesPerCurve(), IECore.IntVectorData( vertsPerCurveData ) )
+		roundTripPositions = readCurves["P"].data
+		for a, b in zip(roundTripPositions, IECore.V3fVectorData( positionData )):
+			self.assertEqual( a, b )
+
+	def testCanWriteAnimatedTransforms( self ):
+
+		fileName = self.getOutputPath("usd_animated_transforms.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+		child = root.createChild( "child" )
+
+		box = IECoreScene.MeshPrimitive.createBox( IECore.Box3f ( IECore.V3f(0,0,0), IECore.V3f(1,1,1)))
+
+		child.writeObject( box, 0)
+
+		for t in range( 64 ):
+
+			translation = IECore.M44dData( IECore.M44d( [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, t, 0, 0, 1] ) )
+			root.writeTransform( translation , t )
+
+		del box
+		del child
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		readRoot = sceneRead.createChild( "root" )
+
+		for t in range(64):
+			self.assertEqual( readRoot.readTransform( t ), IECore.M44dData( IECore.M44d( [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, t, 0, 0, 1] ) ) )
+
+	def testCanWriteAnimatedPositions( self ):
+
+		fileName = self.getOutputPath("usd_animated_positions.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+		child = root.createChild( "child" )
+
+		for t in range( 64 ):
+
+			planeDimensions = IECore.Box2f( IECore.V2f( 0, 0 ), IECore.V2f( 1 + t, 1 ) )
+			planeDivisions = IECore.V2i( 1, 1 )
+
+			plane = IECoreScene.MeshPrimitive.createPlane( planeDimensions, planeDivisions )
+			child.writeObject( plane, t )
+
+		del child
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+		root = sceneRead.child( "root" )
+		child = root.child( "child" )
+
+		for t in range( 64 ):
+			readObject = child.readObject ( t )
+
+			self.assertEqual(readObject["P"].data[1][0], 1 + t)
+
+
+	def testCanWriteSubD( self ):
+
+		fileName = self.getOutputPath("usd_subd.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+		child = root.createChild( "child" )
+
+		box = IECoreScene.MeshPrimitive.createBox( IECore.Box3f( IECore.V3f( 0, 0, 0 ), IECore.V3f( 1, 1, 1 ) ) )
+		box.interpolation = "catmullClark"
+
+		child.writeObject ( box, 0.0 )
+
+		del child
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		readRoot = sceneRead.child( "root" )
+		readChild = readRoot.child( "child" )
+
+		self.assertEqual(readChild.readObject( 0.0 ).interpolation, "catmullClark")
+
+	def testCanWriteAnimatedPrimitiveVariable ( self ):
+
+		fileName = self.getOutputPath("usd_animated_primvar.usda")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+
+		for t in range(32):
+			positionData = []
+			primvarData = []
+			for i in range( 16 ) :
+				for j in range( 16 ) :
+					positionData.append( IECore.V3f( [i, j, 0] ) )
+					primvarData.append ( i * 16 + j + t )
+
+			positions = IECore.V3fVectorData( positionData )
+			primvar = IECore.IntVectorData( primvarData)
+
+			pointsPrimitive = IECoreScene.PointsPrimitive( positions )
+			pointsPrimitive["index"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, primvar )
+			root.writeObject( pointsPrimitive, t )
+
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["root"] )
+		readRoot = sceneRead.child( "root" )
+
+		self.assertTrue( readRoot.hasObject() )
+
+		readPoints = readRoot.readObject( 0.0 )
+		self.assertIsInstance( readPoints, IECoreScene.PointsPrimitive )
+
+		roundTripPositions = readPoints["P"].data
+		self.assertEqual( roundTripPositions, positions )
+
+	def testCanWriteVariousPrimVarTypes ( self ):
+
+		fileName = self.getOutputPath("usd_various_primvars.usdc")
+
+		sceneWrite = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root = sceneWrite.createChild( "root" )
+		child = root.createChild( "child" )
+
+		positions = IECore.V3fVectorData( [ IECore.V3f(0, 0, 0 ) ] )
+		c3f = IECore.Color3fVectorData( [ IECore.Color3f( 0, 0, 0 ) ] )
+		intStr = IECore.InternedStringVectorData ( [ IECore.InternedString("a")] )
+		quat = IECore.QuatfVectorData( [ IECore.Quatf(0,1,2,3)] )
+
+		pointsPrimitive = IECoreScene.PointsPrimitive( positions )
+		pointsPrimitive["c3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, c3f)
+		pointsPrimitive["token"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, intStr)
+		pointsPrimitive["quat"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, quat)
+
+		child.writeObject( pointsPrimitive, 0.0 )
+
+		del root
+		del sceneWrite
+
+		sceneRead = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( sceneRead.childNames(), ["root"] )
+		readRoot = sceneRead.child( "root" )
+		readChild = readRoot.child( "child" )
+
+		readObject = readChild.readObject( 0.0 )
+
+		self.assertTrue("c3f" in readObject)
+		self.assertIsInstance( readObject["c3f"].data, IECore.Color3fVectorData )
+
+		self.assertTrue("token" in readObject)
+		self.assertIsInstance( readObject["token"].data, IECore.InternedStringVectorData )
+
+		self.assertTrue("quat" in readObject)
+		self.assertIsInstance( readObject["quat"].data, IECore.QuatfVectorData )
+
+
+
+
+

--- a/contrib/IECoreUSD/test/IECoreUSD/data/primVars.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/primVars.usda
@@ -1,0 +1,273 @@
+#usda 1.0
+
+def Xform "root"
+{
+    def Points "sphere"
+    {
+        bool[] primvars:test_Bool_Array_constant = [0, 1] (
+            interpolation = "constant"
+        )
+        bool primvars:test_Bool_Scalar_constant = 0 (
+            interpolation = "constant"
+        )
+        color3d[] primvars:test_color3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        color3d primvars:test_color3d_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        color3f[] primvars:test_color3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        color3f primvars:test_color3f_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        color3h[] primvars:test_color3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
+            interpolation = "constant"
+        )
+        color3h primvars:test_color3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+            interpolation = "constant"
+        )
+        color4d[] primvars:test_color4d_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
+            interpolation = "constant"
+        )
+        color4d primvars:test_color4d_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
+            interpolation = "constant"
+        )
+        color4f[] primvars:test_color4f_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
+            interpolation = "constant"
+        )
+        color4f primvars:test_color4f_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
+            interpolation = "constant"
+        )
+        color4h[] primvars:test_color4h_Array_constant = [(1.09961, 1.2002, 1.2998, 1.40039), (2.09961, 2.19922, 2.30078, 2.40039), (3.09961, 3.19922, 3.30078, 3.40039)] (
+            interpolation = "constant"
+        )
+        color4h primvars:test_color4h_Scalar_constant = (0.0999756, 0.199951, 0.300049, 0.399902) (
+            interpolation = "constant"
+        )
+        double2[] primvars:test_Double2_Array_constant = [(1.1, 1.2), (2.1, 2.2), (3.1, 3.2)] (
+            interpolation = "constant"
+        )
+        double2 primvars:test_Double2_Scalar_constant = (0.1, 0.2) (
+            interpolation = "constant"
+        )
+        double3[] primvars:test_Double3_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        double3 primvars:test_Double3_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        double4[] primvars:test_Double4_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
+            interpolation = "constant"
+        )
+        double4 primvars:test_Double4_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
+            interpolation = "constant"
+        )
+        double[] primvars:test_Double_Array_constant = [1.2, 1.3, 1.4] (
+            interpolation = "constant"
+        )
+        double primvars:test_Double_Scalar_constant = 1.1 (
+            interpolation = "constant"
+        )
+        float2[] primvars:test_Float2_Array_constant = [(1.1, 1.2), (2.1, 2.2), (3.1, 3.2)] (
+            interpolation = "constant"
+        )
+        float2 primvars:test_Float2_Scalar_constant = (0.1, 0.2) (
+            interpolation = "constant"
+        )
+        float3[] primvars:test_Float3_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        float3 primvars:test_Float3_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        float4[] primvars:test_Float4_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
+            interpolation = "constant"
+        )
+        float4 primvars:test_Float4_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
+            interpolation = "constant"
+        )
+        float[] primvars:test_Float_Array_constant = [0.7, 0.8, 0.9] (
+            interpolation = "constant"
+        )
+        float primvars:test_Float_Scalar_constant = 0.6 (
+            interpolation = "constant"
+        )
+        half2[] primvars:test_Half2_Array_constant = [(1.09961, 1.2002), (2.09961, 2.19922), (3.09961, 3.19922)] (
+            interpolation = "constant"
+        )
+        half2 primvars:test_Half2_Scalar_constant = (0.0999756, 0.199951) (
+            interpolation = "constant"
+        )
+        half3[] primvars:test_Half3_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
+            interpolation = "constant"
+        )
+        half3 primvars:test_Half3_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+            interpolation = "constant"
+        )
+        half4[] primvars:test_Half4_Array_constant = [(1.09961, 1.2002, 1.2998, 1.40039), (2.09961, 2.19922, 2.30078, 2.40039), (3.09961, 3.19922, 3.30078, 3.40039)] (
+            interpolation = "constant"
+        )
+        half4 primvars:test_Half4_Scalar_constant = (0.0999756, 0.199951, 0.300049, 0.399902) (
+            interpolation = "constant"
+        )
+        half[] primvars:test_Half_Array_constant = [0.0999756, 0.199951, 0.300049] (
+            interpolation = "constant"
+        )
+        half primvars:test_Half_Scalar_constant = 0.5 (
+            interpolation = "constant"
+        )
+        int2[] primvars:test_Int2_Array_constant = [(3, 4), (5, 6), (7, 8)] (
+            interpolation = "constant"
+        )
+        int2 primvars:test_Int2_Scalar_constant = (1, 2) (
+            interpolation = "constant"
+        )
+        int3[] primvars:test_Int3_Array_constant = [(3, 4, 5), (5, 6, 7), (7, 8, 9)] (
+            interpolation = "constant"
+        )
+        int3 primvars:test_Int3_Scalar_constant = (1, 2, 3) (
+            interpolation = "constant"
+        )
+        int4[] primvars:test_Int4_Array_constant = [(3, 4, 5, 6), (5, 6, 7, 8), (7, 8, 9, 10)] (
+            interpolation = "constant"
+        )
+        int4 primvars:test_Int4_Scalar_constant = (1, 2, 3, 4) (
+            interpolation = "constant"
+        )
+        int64[] primvars:test_Int64_Array_constant = [9223372036854775805, 9223372036854775806, 9223372036854775807] (
+            interpolation = "constant"
+        )
+        int64 primvars:test_Int64_Scalar_constant = -9223372036854775808 (
+            interpolation = "constant"
+        )
+        int[] primvars:test_Int_Array_constant = [0, -1, -2] (
+            interpolation = "constant"
+        )
+        int primvars:test_Int_Scalar_constant = -1 (
+            interpolation = "constant"
+        )
+        matrix2d[] primvars:test_matrix2d_Array_constant = [( (0, 1), (0, 0) ), ( (0, 0), (2, 0) ), ( (0, 0), (3, 0) )] (
+            interpolation = "constant"
+        )
+        matrix2d primvars:test_matrix2d_Scalar_constant = ( (1, 0), (0, 0) ) (
+            interpolation = "constant"
+        )
+        matrix3d[] primvars:test_matrix3d_Array_constant = [( (0, 0, 0), (0, 1, 0), (0, 0, 0) ), ( (0, 0, 0), (0, 0, 0), (0, 0, 2) ), ( (0, 0, 4), (0, 0, 0), (0, 0, 0) )] (
+            interpolation = "constant"
+        )
+        matrix3d primvars:test_matrix3d_Scalar_constant = ( (0, 0, 0), (0, 0, 0), (0, 0, 0) ) (
+            interpolation = "constant"
+        )
+        matrix4d[] primvars:test_matrix4d_Array_constant = [( (1, 0, 0, 0), (0, 0, 0, 0), (9, 0, 0, 0), (0, 0, 0, 0) ), ( (1, 0, 0, 0), (0, 3, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0) ), ( (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 2, 0) )] (
+            interpolation = "constant"
+        )
+        matrix4d primvars:test_matrix4d_Scalar_constant = ( (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0) ) (
+            interpolation = "constant"
+        )
+        normal3d[] primvars:test_normal3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        normal3d primvars:test_normal3d_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        normal3f[] primvars:test_normal3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        normal3f primvars:test_normal3f_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        normal3h[] primvars:test_normal3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
+            interpolation = "constant"
+        )
+        normal3h primvars:test_normal3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+            interpolation = "constant"
+        )
+        point3d[] primvars:test_point3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        point3d primvars:test_point3d_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        point3f[] primvars:test_point3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        point3f primvars:test_point3f_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        point3h[] primvars:test_point3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
+            interpolation = "constant"
+        )
+        point3h primvars:test_point3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+            interpolation = "constant"
+        )
+        quatd[] primvars:test_quatd_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
+            interpolation = "constant"
+        )
+        quatd primvars:test_quatd_Scalar_constant = (0, 0, 0, 1) (
+            interpolation = "constant"
+        )
+        quatf[] primvars:test_quatf_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
+            interpolation = "constant"
+        )
+        quatf primvars:test_quatf_Scalar_constant = (0, 0, 0, 1) (
+            interpolation = "constant"
+        )
+        quath[] primvars:test_quath_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
+            interpolation = "constant"
+        )
+        quath primvars:test_quath_Scalar_constant = (0, 0, 0, 1) (
+            interpolation = "constant"
+        )
+        string[] primvars:test_String_Array_constant = ["is", "a", "test"] (
+            interpolation = "constant"
+        )
+        string primvars:test_String_Scalar_constant = "this" (
+            interpolation = "constant"
+        )
+        token[] primvars:test_Token_Array_constant = ["t-is", "t-a", "t-test"] (
+            interpolation = "constant"
+        )
+        token primvars:test_Token_Scalar_constant = "t-this" (
+            interpolation = "constant"
+        )
+        uchar[] primvars:test_UChar_Array_constant = [0, 1, 2] (
+            interpolation = "constant"
+        )
+        uchar primvars:test_UChar_Scalar_constant = 0 (
+            interpolation = "constant"
+        )
+        uint64[] primvars:test_UInt64_Array_constant = [18446744073709551613, 18446744073709551614, 18446744073709551615] (
+            interpolation = "constant"
+        )
+        uint64 primvars:test_UInt64_Scalar_constant = 18446744073709551615 (
+            interpolation = "constant"
+        )
+        uint[] primvars:test_UInt_Array_constant = [4294967293, 4294967294, 4294967295] (
+            interpolation = "constant"
+        )
+        uint primvars:test_UInt_Scalar_constant = 4294967295 (
+            interpolation = "constant"
+        )
+        vector3d[] primvars:test_vector3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        vector3d primvars:test_vector3d_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        vector3f[] primvars:test_vector3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
+            interpolation = "constant"
+        )
+        vector3f primvars:test_vector3f_Scalar_constant = (0.1, 0.2, 0.3) (
+            interpolation = "constant"
+        )
+        vector3h[] primvars:test_vector3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
+            interpolation = "constant"
+        )
+        vector3h primvars:test_vector3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+            interpolation = "constant"
+        )
+    }
+}
+

--- a/contrib/IECoreUSD/test/IECoreUSD/makePrimvarData.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/makePrimvarData.py
@@ -1,0 +1,84 @@
+import os
+from pxr import Usd, UsdGeom, Tf, Sdf, Vt, Gf
+
+# Helper script to generate a USD file with a single sphere primitive with all the primvar types on it
+# both array and scalar
+# just for reference in case we need to generate ./data/primVars.usda again
+
+usdTypes = {
+	"Bool" : [Vt.Bool( False ), Vt.BoolArray( [False, True] )],
+	"UChar" : [Vt.UChar( 0 ), Vt.UCharArray( [0, 1, 2] )],
+	"Int" : [Vt.Int( -1 ), Vt.IntArray( [0, -1, -2] )],
+	"UInt" : [Vt.UInt( 4294967295 ), Vt.UIntArray( [4294967293, 4294967294, 4294967295] )],
+	"UInt64" : [Vt.UInt64( 18446744073709551615 ), Vt.UInt64Array( [18446744073709551613, 18446744073709551614, 18446744073709551615] )],
+	"Int64" : [Vt.Int64( -9223372036854775808 ), Vt.Int64Array( [9223372036854775805, 9223372036854775806, 9223372036854775807] )],
+	"Half" : [Vt.Half( 0.5 ), Vt.HalfArray( [0.1, 0.2, 0.3] )],
+	"Float" : [Vt.Float( 0.6 ), Vt.FloatArray( [0.7, 0.8, 0.9] )],
+	"Double" : [Vt.Double( 1.1 ), Vt.DoubleArray( [1.2, 1.3, 1.4] )],
+	"String" : ["this", ["is", "a", "test"]],
+	"Token" : ["t-this", ["t-is", "t-a", "t-test"]],
+	"Int2" : [Gf.Vec2i( 1, 2 ), [Gf.Vec2i( 3, 4 ), Gf.Vec2i( 5, 6 ), Gf.Vec2i( 7, 8 )]],
+	"Int3" : [Gf.Vec3i( 1, 2, 3 ), [Gf.Vec3i( 3, 4, 5 ), Gf.Vec3i( 5, 6, 7 ), Gf.Vec3i( 7, 8, 9 )]],
+	"Int4" : [Gf.Vec4i( 1, 2, 3, 4 ), [Gf.Vec4i( 3, 4, 5, 6 ), Gf.Vec4i( 5, 6, 7, 8 ), Gf.Vec4i( 7, 8, 9, 10 )]],
+	"Half2" : [Gf.Vec2h( 0.1, 0.2 ), [Gf.Vec2h( 1.1, 1.2 ), Gf.Vec2h( 2.1, 2.2 ), Gf.Vec2h( 3.1, 3.2 )]],
+	"Half3" : [Gf.Vec3h( 0.1, 0.2, 0.3 ), [Gf.Vec3h( 1.1, 1.2, 1.3 ), Gf.Vec3h( 2.1, 2.2, 2.3 ), Gf.Vec3h( 3.1, 3.2, 3.3 )]],
+	"Half4" : [Gf.Vec4h( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4h( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4h( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4h( 3.1, 3.2, 3.3, 3.4 )]],
+	"Float2" : [Gf.Vec2f( 0.1, 0.2 ), [Gf.Vec2f( 1.1, 1.2 ), Gf.Vec2f( 2.1, 2.2 ), Gf.Vec2f( 3.1, 3.2 )]],
+	"Float3" : [Gf.Vec3f( 0.1, 0.2, 0.3 ), [Gf.Vec3f( 1.1, 1.2, 1.3 ), Gf.Vec3f( 2.1, 2.2, 2.3 ), Gf.Vec3f( 3.1, 3.2, 3.3 )]],
+	"Float4" : [Gf.Vec4f( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4f( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4f( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4f( 3.1, 3.2, 3.3, 3.4 )]],
+	"Double2" : [Gf.Vec2d( 0.1, 0.2 ), [Gf.Vec2d( 1.1, 1.2 ), Gf.Vec2d( 2.1, 2.2 ), Gf.Vec2d( 3.1, 3.2 )]],
+	"Double3" : [Gf.Vec3d( 0.1, 0.2, 0.3 ), [Gf.Vec3d( 1.1, 1.2, 1.3 ), Gf.Vec3d( 2.1, 2.2, 2.3 ), Gf.Vec3d( 3.1, 3.2, 3.3 )]],
+	"Double4" : [Gf.Vec4d( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4d( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4d( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4d( 3.1, 3.2, 3.3, 3.4 )]],
+	"point3h" : [Gf.Vec3h( 0.1, 0.2, 0.3 ), [Gf.Vec3h( 1.1, 1.2, 1.3 ), Gf.Vec3h( 2.1, 2.2, 2.3 ), Gf.Vec3h( 3.1, 3.2, 3.3 )]],
+	"point3f" : [Gf.Vec3f( 0.1, 0.2, 0.3 ), [Gf.Vec3f( 1.1, 1.2, 1.3 ), Gf.Vec3f( 2.1, 2.2, 2.3 ), Gf.Vec3f( 3.1, 3.2, 3.3 )]],
+	"point3d" : [Gf.Vec3d( 0.1, 0.2, 0.3 ), [Gf.Vec3d( 1.1, 1.2, 1.3 ), Gf.Vec3d( 2.1, 2.2, 2.3 ), Gf.Vec3d( 3.1, 3.2, 3.3 )]],
+	"vector3h" : [Gf.Vec3h( 0.1, 0.2, 0.3 ), [Gf.Vec3h( 1.1, 1.2, 1.3 ), Gf.Vec3h( 2.1, 2.2, 2.3 ), Gf.Vec3h( 3.1, 3.2, 3.3 )]],
+	"vector3f" : [Gf.Vec3f( 0.1, 0.2, 0.3 ), [Gf.Vec3f( 1.1, 1.2, 1.3 ), Gf.Vec3f( 2.1, 2.2, 2.3 ), Gf.Vec3f( 3.1, 3.2, 3.3 )]],
+	"vector3d" : [Gf.Vec3d( 0.1, 0.2, 0.3 ), [Gf.Vec3d( 1.1, 1.2, 1.3 ), Gf.Vec3d( 2.1, 2.2, 2.3 ), Gf.Vec3d( 3.1, 3.2, 3.3 )]],
+	"normal3h" : [Gf.Vec3h( 0.1, 0.2, 0.3 ), [Gf.Vec3h( 1.1, 1.2, 1.3 ), Gf.Vec3h( 2.1, 2.2, 2.3 ), Gf.Vec3h( 3.1, 3.2, 3.3 )]],
+	"normal3f" : [Gf.Vec3f( 0.1, 0.2, 0.3 ), [Gf.Vec3f( 1.1, 1.2, 1.3 ), Gf.Vec3f( 2.1, 2.2, 2.3 ), Gf.Vec3f( 3.1, 3.2, 3.3 )]],
+	"normal3d" : [Gf.Vec3d( 0.1, 0.2, 0.3 ), [Gf.Vec3d( 1.1, 1.2, 1.3 ), Gf.Vec3d( 2.1, 2.2, 2.3 ), Gf.Vec3d( 3.1, 3.2, 3.3 )]],
+	"color3h" : [Gf.Vec3h( 0.1, 0.2, 0.3 ), [Gf.Vec3h( 1.1, 1.2, 1.3 ), Gf.Vec3h( 2.1, 2.2, 2.3 ), Gf.Vec3h( 3.1, 3.2, 3.3 )]],
+	"color3f" : [Gf.Vec3f( 0.1, 0.2, 0.3 ), [Gf.Vec3f( 1.1, 1.2, 1.3 ), Gf.Vec3f( 2.1, 2.2, 2.3 ), Gf.Vec3f( 3.1, 3.2, 3.3 )]],
+	"color3d" : [Gf.Vec3d( 0.1, 0.2, 0.3 ), [Gf.Vec3d( 1.1, 1.2, 1.3 ), Gf.Vec3d( 2.1, 2.2, 2.3 ), Gf.Vec3d( 3.1, 3.2, 3.3 )]],
+	"color4h" : [Gf.Vec4h( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4h( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4h( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4h( 3.1, 3.2, 3.3, 3.4 )]],
+	"color4f" : [Gf.Vec4f( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4f( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4f( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4f( 3.1, 3.2, 3.3, 3.4 )]],
+	"color4d" : [Gf.Vec4d( 0.1, 0.2, 0.3, 0.4 ), [Gf.Vec4d( 1.1, 1.2, 1.3, 1.4 ), Gf.Vec4d( 2.1, 2.2, 2.3, 2.4 ), Gf.Vec4d( 3.1, 3.2, 3.3, 3.4 )]],
+	"quath" : [Gf.Quath( 0, 0, 0, 1 ), [Gf.Quath( 1, 0, 0, 0 ), Gf.Quath( 0, 1, 0, 0 ), Gf.Quath( 0, 0, 1, 0 )]],
+	"quatf" : [Gf.Quatf( 0, 0, 0, 1 ), [Gf.Quatf( 1, 0, 0, 0 ), Gf.Quatf( 0, 1, 0, 0 ), Gf.Quatf( 0, 0, 1, 0 )]],
+	"quatd" : [Gf.Quatd( 0, 0, 0, 1 ), [Gf.Quatd( 1, 0, 0, 0 ), Gf.Quatd( 0, 1, 0, 0 ), Gf.Quatd( 0, 0, 1, 0 )]],
+	"matrix2d" : [Gf.Matrix2d( 1, 0, 0, 0 ), [Gf.Matrix2d( 0, 1, 0, 0 ), Gf.Matrix2d( 0, 0, 2, 0 ), Gf.Matrix2d( 0, 0, 3, 0 )]],
+	"matrix3d" : [Gf.Matrix3d( 0, 0, 0, 0, 0, 0, 0, 0, 0 ), [Gf.Matrix3d( 0, 0, 0, 0, 1, 0, 0, 0, 0 ), Gf.Matrix3d( 0, 0, 0, 0, 0, 0, 0, 0, 2 ), Gf.Matrix3d( 0, 0, 4, 0, 0, 0, 0, 0, 0 )]],
+	"matrix4d" : [Gf.Matrix4d( 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ),
+		[Gf.Matrix4d( 1, 0, 0, 0, 0, 0, 0, 0, 9, 0, 0, 0, 0, 0, 0, 0 ), Gf.Matrix4d( 1, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ), Gf.Matrix4d( 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0 )]],
+}
+
+interpolations = ['constant']
+arrayVariations = [False, True]
+
+
+fileName = os.path.join( os.path.dirname( __file__ ), "data/primVars.usda")
+
+stage = Usd.Stage.CreateNew( fileName )
+
+xformPrim = UsdGeom.Xform.Define( stage, '/root' )
+spherePrim = UsdGeom.Points.Define( stage, '/root/sphere' )
+
+for usdType, testData in usdTypes.items() :
+	scalarTestData, arrayTestData = testData
+	for isArray in arrayVariations :
+		for interpolation in interpolations :
+
+			fullType = usdType
+			if isArray :
+				fullType += "[]"
+
+			fullType = fullType.lower()
+
+			primVar = spherePrim.CreatePrimvar( attrName = "test_{0}_{1}_{2}".format( usdType, "Array" if isArray else "Scalar", interpolation ), typeName = Sdf.ValueTypeNames.Find( fullType ),
+				interpolation = interpolation )
+			attr = primVar.GetAttr()
+			data = arrayTestData if isArray else scalarTestData
+			attr.Set( data )
+
+stage.GetRootLayer().Save()


### PR DESCRIPTION
Mainly it's half & 4 element vectors we don't support. Any objection if I add these types into SimpleTypedData & VectorTypedData?

Currently unsupported primvar types:
`color3h[]
color3h
color4h[]
color4h
double4[]
double4
float4[]
float4
half2[]
half2
half3[]
half3
half4[]
half4
int4[]
int4
matrix2d[]
matrix2d
normal3h[]
normal3h
point3h[]
point3h
quath[]
quath
vector3h[]
vector3h
`


