### PR TITLE
IECoreImage : Forward compatibility module for cortex 10

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -538,6 +538,13 @@ o.Add(
 	"/usr/local/appleseed/lib",
 )
 
+# compatibility options
+
+o.Add(
+	BoolVariable( "WITH_CORTEX10_COMPAT", "Set this to include cortex 10 compatibility modules.", False ),
+)
+
+
 # Build options
 
 o.Add(
@@ -3420,6 +3427,21 @@ if doConfigure :
 		appleseedTestEnv.Depends( appleseedTest, [ appleseedPythonModule + appleseedDriverForTest ] )
 		appleseedTestEnv.Depends( appleseedTest, glob.glob( "contrib/IECoreAppleseed/test/IECoreAppleseed/*.py" ) )
 		appleseedTestEnv.Alias( "testAppleseed", appleseedTest )
+
+###########################################################################################
+# Install Cortex 10 forward-compatibility for IECoreImage
+###########################################################################################
+
+if env["WITH_CORTEX10_COMPAT"] :
+
+	coreImagePythonModuleEnv = pythonModuleEnv.Clone( IECORE_NAME = "IECoreImage" )
+
+	# python module
+	coreImagePythonScripts = glob.glob( "contrib/IECoreImage/python/IECoreImage/*.py" )
+	coreImagePythonModuleInstall = coreImagePythonModuleEnv.Install( "$INSTALL_PYTHON_DIR/IECoreImage", coreImagePythonScripts )
+	coreImagePythonModuleEnv.AddPostAction( "$INSTALL_PYTHON_DIR/IECoreImage", lambda target, source, env : makeSymLinks( coreImagePythonModuleEnv, coreImagePythonModuleEnv["INSTALL_PYTHON_DIR"] ) )
+	coreImagePythonModuleEnv.Alias( "install", coreImagePythonModuleInstall )
+	coreImagePythonModuleEnv.Alias( "installCoreImage", coreImagePythonModuleInstall )
 
 ###########################################################################################
 # Documentation

--- a/config/ie/options
+++ b/config/ie/options
@@ -384,6 +384,9 @@ ALEMBIC_LIB_SUFFIX = "-" + alembicVersion
 HDF5_INCLUDE_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "include" )
 HDF5_LIB_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "lib" )
 
+# enable cortex10 compatibility
+WITH_CORTEX10_COMPAT = 1
+
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )
 

--- a/contrib/IECoreImage/python/IECoreImage/__init__.py
+++ b/contrib/IECoreImage/python/IECoreImage/__init__.py
@@ -1,0 +1,63 @@
+##########################################################################
+#
+#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+"""
+Forward compatibility with Cortex 10 for IECoreImage
+"""
+import IECore
+
+ChannelOp = IECore.ChannelOp
+ClampOp = IECore.ClampOp
+ClientDisplayDriver = IECore.ClientDisplayDriver
+CurveTracer = IECore.CurveTracer
+DisplayDriver = IECore.DisplayDriver
+DisplayDriverServer = IECore.DisplayDriverServer
+EnvMapSampler = IECore.EnvMapSampler
+Font = IECore.Font
+HdrMergeOp = IECore.HdrMergeOp
+ImageCropOp = IECore.ImageCropOp
+ImageDiffOp = IECore.ImageDiffOp
+ImageDisplayDriver = IECore.ImageDisplayDriver
+ImagePrimitive = IECore.ImagePrimitive
+ImagePrimitiveParameter = IECore.ImagePrimitiveParameter
+ImageReader = IECore.ImageReader
+ImageThinner = IECore.ImageThinner
+ImageWriter = IECore.ImageWriter
+LensDistortOp = IECore.LensDistortOp
+LuminanceOp = IECore.LuminanceOp
+MPlayDisplayDriver = IECore.MPlayDisplayDriver
+MedianCutSampler = IECore.MedianCutSampler
+SplineToImage = IECore.SplineToImage
+SummedAreaOp = IECore.SummedAreaOp
+WarpOp = IECore.WarpOp


### PR DESCRIPTION
This should allow us to use `IECoreImage` in cortex 9, so it's already compatible with cortex 10.

It's not supposed to be a full forward-compatibility, but should be enough for most python projects at IE.
