### PR TITLE
Add h16.5 cortex9

### DIFF
--- a/include/IECoreHoudini/CoreHoudiniVersion.h
+++ b/include/IECoreHoudini/CoreHoudiniVersion.h
@@ -1,0 +1,42 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2010-2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREHOUDINI_COREHOUDINIVERSION_H
+#define IECOREHOUDINI_COREHOUDINIVERSION_H
+
+#include "UT/UT_Version.h"
+
+#define MIN_HOU_VERSION(MAJOR, MINOR, PATCH) ( UT_VERSION_INT >= ( ( MAJOR << 24 ) | ( MINOR << 16 ) | PATCH << 0 ) )
+
+#endif //IECOREHOUDINI_COREHOUDINIVERSION_H

--- a/include/IECoreHoudini/GEO_CortexPrimitive.h
+++ b/include/IECoreHoudini/GEO_CortexPrimitive.h
@@ -36,6 +36,7 @@
 #define IECOREHOUDINI_GEOCORTEXPRIMITIVE_H
 
 #include "GA/GA_Defines.h"
+#include "GA/GA_LoadMap.h"
 #include "GEO/GEO_Primitive.h"
 #include "GU/GU_Detail.h"
 #include "GEO/GEO_Point.h"
@@ -112,10 +113,10 @@ class GEO_CortexPrimitive : public GEO_Primitive
 
 		static const char *typeName;
 
-#if UT_MAJOR_VERSION_INT >=16
-
-		static void create(GA_Primitive **new_prims, GA_Size nprimitives, GA_Detail &detail, GA_Offset start_offset, const GA_PrimitiveDefinition &def);
-
+#if UT_MAJOR_VERSION_INT >=16 && UT_MINOR_VERSION_INT >=5
+		static void create(GA_Primitive **new_prims, GA_Size nprimitives, GA_Detail &detail, GA_Offset start_offset, const GA_PrimitiveDefinition &def, bool allowed_to_parallelize);
+#elif UT_MAJOR_VERSION_INT >=16
+        static void create(GA_Primitive **new_prims, GA_Size nprimitives, GA_Detail &detail, GA_Offset start_offset, const GA_PrimitiveDefinition &def);
 #elif UT_MAJOR_VERSION_INT >= 14
 		
 		static GA_Primitive *create( GA_Detail &detail, GA_Offset offset, const GA_PrimitiveDefinition &definition );		

--- a/include/IECoreHoudini/GEO_CortexPrimitive.h
+++ b/include/IECoreHoudini/GEO_CortexPrimitive.h
@@ -58,6 +58,7 @@ typedef GU_ConvertParms ConvertParms;
 
 #endif
 
+#include "IECoreHoudini/CoreHoudiniVersion.h"
 #include "IECore/Object.h"
 
 namespace IECoreHoudini
@@ -113,7 +114,7 @@ class GEO_CortexPrimitive : public GEO_Primitive
 
 		static const char *typeName;
 
-#if UT_MAJOR_VERSION_INT >=16 && UT_MINOR_VERSION_INT >=5
+#if MIN_HOU_VERSION(16, 5, 0)
 		static void create(GA_Primitive **new_prims, GA_Size nprimitives, GA_Detail &detail, GA_Offset start_offset, const GA_PrimitiveDefinition &def, bool allowed_to_parallelize);
 #elif UT_MAJOR_VERSION_INT >=16
         static void create(GA_Primitive **new_prims, GA_Size nprimitives, GA_Detail &detail, GA_Offset start_offset, const GA_PrimitiveDefinition &def);

--- a/include/IECoreHoudini/GEO_CortexPrimitive.h
+++ b/include/IECoreHoudini/GEO_CortexPrimitive.h
@@ -133,9 +133,7 @@ class GEO_CortexPrimitive : public GEO_Primitive
 		virtual void copyPrimitive( const GEO_Primitive *src );
 		
 		virtual const GA_PrimitiveDefinition &getTypeDef() const;
-		/// \todo: setTypeDef is called once by the plugin. Seems quite silly to expose.
-		/// Maybe we should just give up registration in the plugin and do it all here.
-		static void setTypeDef( GA_PrimitiveDefinition *def );
+		static void registerDefinition(GA_PrimitiveFactory *factory);
 		static GA_PrimitiveTypeId typeId();
 		
 		virtual GEO_Primitive *convert( ConvertParms &parms, GA_PointGroup *usedpts = 0 );

--- a/include/IECoreHoudini/LiveScene.h
+++ b/include/IECoreHoudini/LiveScene.h
@@ -35,7 +35,10 @@
 #ifndef IECOREHOUDINI_LIVESCENE_H
 #define IECOREHOUDINI_LIVESCENE_H
 
-#include "OP/OP_Node.h" 
+#include "boost/shared_ptr.hpp"
+#include "boost/function.hpp"
+
+#include "OP/OP_Node.h"
 #include "UT/UT_String.h"
 
 #include "IECore/SceneInterface.h"

--- a/include/IECoreHoudini/NodeHandle.h
+++ b/include/IECoreHoudini/NodeHandle.h
@@ -35,6 +35,8 @@
 #ifndef IE_COREHOUDINI_NODEHANDLE_H
 #define IE_COREHOUDINI_NODEHANDLE_H
 
+#include "boost/shared_ptr.hpp"
+
 #include "OP/OP_Node.h"
 #include "HOM/HOM_Node.h"
 

--- a/python/IECoreHoudini/FnParameterisedHolder.py
+++ b/python/IECoreHoudini/FnParameterisedHolder.py
@@ -88,7 +88,10 @@ class FnParameterisedHolder():
 		if contextArgs.get( "shiftclick", False ) :
 			converter = holder.parent().createNode( "ieCortexConverter", node_name = holder.name()+"Converter" )
 			outputNode = hou.node( contextArgs.get( "outputnodename", "" ) )
-			toolutils.connectInputsAndOutputs( converter, False, holder, outputNode, 0, 0 )
+			if hou.applicationVersion()[0] >= 16 and hou.applicationVersion()[1] >= 5:
+				toolutils.connectMultiInputsAndOutputs( converter, False, [( holder, 0, 0 )] if holder else None, [( outputNode, 0, 0 )] if outputNode else None )
+			else:
+				toolutils.connectInputsAndOutputs( converter, False, holder, outputNode, 0, 0 )
 			x, y = holder.position()
 			converter.setPosition( [x,y-1] )
 		

--- a/python/IECoreHoudini/FnParameterisedHolder.py
+++ b/python/IECoreHoudini/FnParameterisedHolder.py
@@ -88,9 +88,9 @@ class FnParameterisedHolder():
 		if contextArgs.get( "shiftclick", False ) :
 			converter = holder.parent().createNode( "ieCortexConverter", node_name = holder.name()+"Converter" )
 			outputNode = hou.node( contextArgs.get( "outputnodename", "" ) )
-			if hou.applicationVersion()[0] >= 16 and hou.applicationVersion()[1] >= 5:
+			try:
 				toolutils.connectMultiInputsAndOutputs( converter, False, [( holder, 0, 0 )] if holder else None, [( outputNode, 0, 0 )] if outputNode else None )
-			else:
+			except AttributeError:
 				toolutils.connectInputsAndOutputs( converter, False, holder, outputNode, 0, 0 )
 			x, y = holder.position()
 			converter.setPosition( [x,y-1] )

--- a/src/IECoreHoudini/GEO_CortexPrimitive.cpp
+++ b/src/IECoreHoudini/GEO_CortexPrimitive.cpp
@@ -445,13 +445,20 @@ void GEO_CortexPrimitive::create(
 	    GA_Size numPrimitives,
 	    GA_Detail &detail,
 	    GA_Offset startOffset,
-	    const GA_PrimitiveDefinition &def )
+		const GA_PrimitiveDefinition &def
+#if UT_MINOR_VERSION_INT >=5
+	    , bool allowed_to_parallelize
+#endif
+		)
 {
 
 	// allocate all the points and vertices at the same time
 	GA_Offset pointBlock = detail.appendPointBlock( numPrimitives );
-
-	if ( numPrimitives >= 4*GA_PAGE_SIZE )
+#if UT_MINOR_VERSION_INT >=5
+	if ( allowed_to_parallelize && numPrimitives >= 4*GA_PAGE_SIZE )
+#else
+    if ( numPrimitives >= 4*GA_PAGE_SIZE )
+#endif
 	{
 		// Allocate them in parallel if we're allocating many.
 		// This is using the C++11 lambda syntax to make a functor.

--- a/src/IECoreHoudini/GEO_CortexPrimitive.cpp
+++ b/src/IECoreHoudini/GEO_CortexPrimitive.cpp
@@ -58,6 +58,7 @@
 #include "IECore/TransformOp.h"
 #include "IECore/VisibleRenderable.h"
 
+#include "IECoreHoudini/CoreHoudiniVersion.h"
 #include "IECoreHoudini/Convert.h"
 #include "IECoreHoudini/GEO_CortexPrimitive.h"
 #include "IECoreHoudini/SOP_OpHolder.h"
@@ -442,7 +443,7 @@ void GEO_CortexPrimitive::create(
 	    GA_Detail &detail,
 	    GA_Offset startOffset,
 		const GA_PrimitiveDefinition &def
-#if UT_MINOR_VERSION_INT >=5
+#if MIN_HOU_VERSION(16, 5, 0)
 	    , bool allowed_to_parallelize
 #endif
 		)
@@ -450,7 +451,7 @@ void GEO_CortexPrimitive::create(
 
 	// allocate all the points and vertices at the same time
 	GA_Offset pointBlock = detail.appendPointBlock( numPrimitives );
-#if UT_MINOR_VERSION_INT >=5
+#if MIN_HOU_VERSION(16, 5, 0)
 	if ( allowed_to_parallelize && numPrimitives >= 4*GA_PAGE_SIZE )
 #else
     if ( numPrimitives >= 4*GA_PAGE_SIZE )

--- a/src/IECoreHoudini/NodeHandle.cpp
+++ b/src/IECoreHoudini/NodeHandle.cpp
@@ -36,6 +36,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "OP/OP_Director.h"
+#include "boost/shared_ptr.hpp"
 
 #include "IECoreHoudini/NodeHandle.h"
 

--- a/src/IECoreHoudini/ToHoudiniCortexObjectConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniCortexObjectConverter.cpp
@@ -71,8 +71,8 @@ ToHoudiniCortexObjectConverter::~ToHoudiniCortexObjectConverter()
 bool ToHoudiniCortexObjectConverter::doConversion( const Object *object, GU_Detail *geo ) const
 {
 	ConstObjectPtr result = filterAttribs( object );
-	
-	size_t numPrims = geo->getNumPrimitives();
+
+	GA_Size numPrims = geo->getNumPrimitives();
 
 	CortexPrimitive::build( geo, result.get() );
 	
@@ -92,8 +92,8 @@ bool ToHoudiniCortexObjectConverter::doConversion( const Object *object, GU_Deta
 			ToHoudiniStringVectorAttribConverter::convertString( "name", nameData->readable(), geo, newPrims );
 		}
 	}
-	
-	return ( (size_t)geo->getNumPrimitives() > numPrims );
+
+	return ( (GA_Size)geo->getNumPrimitives() > numPrims );
 }
 
 void ToHoudiniCortexObjectConverter::transferAttribs( GU_Detail *geo, const GA_Range &points, const GA_Range &prims ) const

--- a/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
+++ b/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
@@ -63,6 +63,7 @@
 #include "IECore/Parameterised.h"
 #include "IECorePython/PointerFromSWIG.h"
 
+#include "IECoreHoudini/CoreHoudiniVersion.h"
 #include "IECoreHoudini/CoreHoudini.h"
 #include "IECoreHoudini/bindings/TypeIdBinding.h"
 #include "IECoreHoudini/bindings/FnParameterisedHolderBinding.h"
@@ -109,7 +110,7 @@ static void *extractNodeFromHOM( PyObject *o )
 	
 	return OPgetDirector()->findNode( homNode->path().c_str() );
 }
-#if UT_MAJOR_VERSION_INT >= 16 && UT_MINOR_VERSION_INT >= 5
+#if MIN_HOU_VERSION(16, 5, 0)
 
 #elif UT_MAJOR_VERSION_INT >= 16
 // This little function returns the address of Houdini's shared QGLWidget
@@ -198,7 +199,8 @@ BOOST_PYTHON_MODULE(_IECoreHoudini)
 	
 	IECorePython::PointerFromSWIG<HOM_Geometry>();
 
-#if UT_MAJOR_VERSION_INT >= 16 && UT_MINOR_VERSION_INT >= 5
+// in QT5, it's not possible to share the GL context in the same way.
+#if MIN_HOU_VERSION(16, 5, 0)
 
 #elif UT_MAJOR_VERSION_INT >= 14
 

--- a/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
+++ b/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
@@ -109,8 +109,9 @@ static void *extractNodeFromHOM( PyObject *o )
 	
 	return OPgetDirector()->findNode( homNode->path().c_str() );
 }
+#if UT_MAJOR_VERSION_INT >= 16 && UT_MINOR_VERSION_INT >= 5
 
-#if UT_MAJOR_VERSION_INT >= 16
+#elif UT_MAJOR_VERSION_INT >= 16
 // This little function returns the address of Houdini's shared QGLWidget
 // This can be necessary when wanting to create your own OpenGL context
 // which shares resources (textures, vertex buffers etc) with Houdini's contexts.
@@ -197,7 +198,9 @@ BOOST_PYTHON_MODULE(_IECoreHoudini)
 	
 	IECorePython::PointerFromSWIG<HOM_Geometry>();
 
-#if UT_MAJOR_VERSION_INT >= 14
+#if UT_MAJOR_VERSION_INT >= 16 && UT_MINOR_VERSION_INT >= 5
+
+#elif UT_MAJOR_VERSION_INT >= 14
 
 	def( "sharedGLWidget", &sharedGLWidget );
 

--- a/src/IECoreHoudini/plugin/Plugin.cpp
+++ b/src/IECoreHoudini/plugin/Plugin.cpp
@@ -205,40 +205,13 @@ void newRenderHook( GR_RenderTable *table )
 	table->addHook( hook, GR_RENDER_HOOK_VERSION );
 }
 #endif
-
-void newGeometryPrim( GA_PrimitiveFactory *factory )
-{
-
-	GA_PrimitiveDefinition *primDef = factory->registerDefinition(
-		CortexPrimitive::typeName, CortexPrimitive::create,
-		GA_FAMILY_NONE, ( std::string( CortexPrimitive::typeName ) + "s" ).c_str()
-	);
-	
-	if ( !primDef )
+extern "C"{
+	void newGeometryPrim( GA_PrimitiveFactory *factory )
 	{
-		std::cerr << "Warning: Duplicate definition for CortexPrimitive. Make sure only 1 version of the ieCoreHoudini plugin is on your path." << std::endl;
-		return;
+
+		CortexPrimitive::registerDefinition(factory);
+
 	}
-
-// merge constructors removed in H16
-#if UT_MAJOR_VERSION_INT < 16
-	primDef->setMergeConstructor( CortexPrimitive::create );
-#endif
-	primDef->setHasLocalTransform( true );
-	
-	/// \todo: This method is silly. Should we just give up and do the whole registration in CortexPrimitive?
-	CortexPrimitive::setTypeDef( primDef );
-
-	/// Create the default ObjectPool cache
-	UT_ObjectPoolCache::defaultObjectPoolCache();
-
-/// Declare our new Render Hook for Houdini 12.5 and later
-#if UT_MAJOR_VERSION_INT > 12 || UT_MINOR_VERSION_INT >= 5
-
-	DM_RenderTable::getTable()->registerGEOHook( new GUI_CortexPrimitiveHook, primDef->getId(), 0 );
-
-#endif
-
 }
 
 /// Declare our new IO Translators


### PR DESCRIPTION
Improvements
---
- IECoreHoudini: add Houdini16.5 support (#659)

This is the same as this pull request but for cortex 9.
https://github.com/ImageEngine/cortex/pull/656
Tested with Houdini 16.5.268 and Houdini 16.0.557
```

======================================================================
FAIL: testBasicRemapping (AttributeRemap.TestAttributeRemap)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/disk1/carmenp/dev/cortex/test/IECoreHoudini/AttributeRemap.py", line 112, in testBasicRemapping
    self.assertEqual( object['s'].interpolation, IECore.PrimitiveVariable.Interpolation.Vertex )
AssertionError: IECore._IECore.Interpolation.FaceVarying != IECore._IECore.Interpolation.Vertex

======================================================================
FAIL: testReadWritePTC (CobIOTranslator.TestCobIOTranslator)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/disk1/carmenp/dev/cortex/test/IECoreHoudini/CobIOTranslator.py", line 233, in testReadWritePTC
    self.assertRaises( hou.OperationFailed, writer.cook )
AssertionError: OperationFailed not raised

======================================================================
FAIL: testRenderRmanInject (CortexRmanInject.TestCortexRmanInject)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/disk1/carmenp/dev/cortex/test/IECoreHoudini/CortexRmanInject.py", line 97, in testRenderRmanInject
    self.failUnless( "['-radius', '1', '-theta', '360']" in procs[0] )
AssertionError: False is not true

----------------------------------------------------------------------
Ran 361 tests in 26.068s

FAILED (failures=3)

```

