### PR TITLE
MeshPrimitiveEvaluator : Handle indexed primvars.

### DIFF
--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -156,6 +156,12 @@ T MeshPrimitiveEvaluator::Result::getPrimVar( const PrimitiveVariable &pv ) cons
 		throw InvalidArgumentException( "Could not retrieve primvar data for MeshPrimitiveEvaluator" );
 	}
 
+	// lambda to look up the actual 'real' data location in a primvar
+	const std::vector<int> *primvarIndices = pv.indices ? &pv.indices->readable() : nullptr;
+	auto getRealIndex = [primvarIndices](int index) -> int {
+		return primvarIndices ? (*primvarIndices)[index] : index;
+	};
+
 	switch ( pv.interpolation )
 	{
 		case PrimitiveVariable::Constant :
@@ -164,30 +170,37 @@ T MeshPrimitiveEvaluator::Result::getPrimVar( const PrimitiveVariable &pv ) cons
 			return data->readable()[0];
 
 		case PrimitiveVariable::Uniform :
-			assert( m_triangleIdx < data->readable().size() );
+		{
+			int realIndex = getRealIndex( m_triangleIdx );
 
-			return data->readable()[ m_triangleIdx ];
+			assert( realIndex < data->readable().size() );
 
+			return data->readable()[realIndex];
+		}
 		case PrimitiveVariable::Vertex :
 		case PrimitiveVariable::Varying:
-			assert( m_vertexIds[0] < (int)data->readable().size() );
-			assert( m_vertexIds[1] < (int)data->readable().size() );
-			assert( m_vertexIds[2] < (int)data->readable().size() );
+		{
+			int realIndex[3] = { getRealIndex( m_vertexIds[0] ), getRealIndex( m_vertexIds[1] ), getRealIndex( m_vertexIds[2] ) };
 
-			return static_cast<T>( data->readable()[ m_vertexIds[0] ] * m_bary[0] + data->readable()[ m_vertexIds[1] ] * m_bary[1] + data->readable()[ m_vertexIds[2] ] * m_bary[2] );
+			assert( realIndex[0] < (int) data->readable().size() );
+			assert( realIndex[1] < (int) data->readable().size() );
+			assert( realIndex[2] < (int) data->readable().size() );
+
+			return static_cast<T>( data->readable()[realIndex[0]] * m_bary[0] + data->readable()[realIndex[1]] * m_bary[1] + data->readable()[realIndex[2]] * m_bary[2] );
+		}
 
 		case PrimitiveVariable::FaceVarying:
+		{
+			int realIndex[3] = { getRealIndex( ( m_triangleIdx * 3 ) + 0 ), getRealIndex( ( m_triangleIdx * 3 ) + 1 ), getRealIndex( ( m_triangleIdx * 3 ) + 2) };
 
-			assert( (m_triangleIdx * 3) + 0 < data->readable().size() );
-			assert( (m_triangleIdx * 3) + 1 < data->readable().size() );
-			assert( (m_triangleIdx * 3) + 2 < data->readable().size() );
+			assert( realIndex[0] < (int) data->readable().size() );
+			assert( realIndex[1] < (int) data->readable().size() );
+			assert( realIndex[2] < (int) data->readable().size() );
 
 			return static_cast<T>(
-				  data->readable()[ (m_triangleIdx * 3) + 0 ] * m_bary[0]
-				+ data->readable()[ (m_triangleIdx * 3) + 1 ] * m_bary[1]
-				+ data->readable()[ (m_triangleIdx * 3) + 2 ] * m_bary[2]
+				data->readable()[realIndex[0]] * m_bary[0] + data->readable()[realIndex[1]] * m_bary[1] + data->readable()[realIndex[2]] * m_bary[2]
 			);
-
+		}
 		default :
 			/// Unimplemented primvar interpolation
 			assert( false );
@@ -1304,9 +1317,16 @@ const MeshPrimitiveEvaluator::UVBoundTree *MeshPrimitiveEvaluator::uvBoundTree()
 void MeshPrimitiveEvaluator::triangleUVs( size_t triangleIndex, const Imath::V3i &vertexIds, Imath::V2f uv[3] ) const
 {
 	const std::vector<Imath::V2f> &uvs = ((V2fVectorData *)(m_uv.data.get()))->readable();
-	if( m_uv.interpolation==PrimitiveVariable::FaceVarying )
+	ConstIntVectorDataPtr indexData = m_uv.indices;
+
+	if( m_uv.interpolation == PrimitiveVariable::FaceVarying )
 	{
 		size_t index = triangleIndex * 3;
+		if ( indexData )
+		{
+			index = indexData->readable()[index];
+		}
+
 		uv[0] = uvs[index++];
 		uv[1] = uvs[index++];
 		uv[2] = uvs[index];

--- a/test/IECoreScene/MeshPrimitiveEvaluator.py
+++ b/test/IECoreScene/MeshPrimitiveEvaluator.py
@@ -369,6 +369,64 @@ class TestMeshPrimitiveEvaluator( unittest.TestCase ) :
 					hits = mpe.intersectionPoints( origin, direction )
 					self.failIf( hits )
 
+	def testEvaluatesIndexedPrimitiveVariables( self ) :
+
+		verticesPerFace = IECore.IntVectorData( [3, 3] )
+		vertexIndices = IECore.IntVectorData( [0, 1, 2, 0, 2, 3] )
+		positions = IECore.V3fVectorData( [
+			IECore.V3f( 0, 0, 0 ),
+			IECore.V3f( 1, 0, 0 ),
+			IECore.V3f( 1, 1, 0 ),
+			IECore.V3f( 0, 1, 0 )
+		] )
+
+		uvs = IECore.V2fVectorData( [
+			IECore.V2f( 0, 0 ),
+			IECore.V2f( 1, 0 ),
+			IECore.V2f( 1, 1 )
+		] )
+
+		uvIndices = IECore.IntVectorData( [
+			0, 1, 2,
+			0, 1, 2
+		] )
+
+
+		uniformData = IECore.IntVectorData( [ 123, 321 ])
+		uniformIndices = IECore.IntVectorData( [ 1, 0 ])
+
+		vertexVaryingData = IECore.FloatVectorData( [ 314, 271])
+		vertexVaryingIndices = IECore.IntVectorData( [ 0, 1, 1, 0])
+
+		m = IECoreScene.MeshPrimitive( verticesPerFace, vertexIndices )
+
+		m["P"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, positions )
+		m["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, uvs, uvIndices )
+		m["id"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, uniformData, uniformIndices )
+		m["s"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, vertexVaryingData, vertexVaryingIndices )
+		evaluator = IECoreScene.PrimitiveEvaluator.create( m )
+
+		result = evaluator.createResult()
+
+		# For each point verify that the closest point to it is itself
+		foundClosest = evaluator.closestPoint( IECore.V3f( 0, 0, 0 ), result )
+		self.assertEqual( result.vec2PrimVar( m["uv"] ), IECore.V2f( 0, 0 ) )
+		self.assertEqual( result.floatPrimVar( m["s"] ), 314 )
+
+		foundClosest = evaluator.closestPoint( IECore.V3f( 1, 0, 0 ), result )
+		self.assertEqual( result.vec2PrimVar( m["uv"] ), IECore.V2f( 1, 0 ) )
+		self.assertEqual( result.floatPrimVar( m["s"] ), 271 )
+		self.assertEqual( result.intPrimVar( m["id"] ), 321)
+
+		foundClosest = evaluator.closestPoint( IECore.V3f( 1, 1, 0 ), result )
+		self.assertEqual( result.floatPrimVar( m["s"] ), 271 )
+		self.assertEqual( result.vec2PrimVar( m["uv"] ), IECore.V2f( 1, 1 ) )
+
+		foundClosest = evaluator.closestPoint( IECore.V3f( 0, 1, 0 ), result )
+		self.assertEqual( result.vec2PrimVar( m["uv"] ), IECore.V2f( 1, 1 ) )
+		self.assertEqual( result.floatPrimVar( m["s"] ), 314 )
+		self.assertEqual( result.intPrimVar( m["id"] ), 123)
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
Noticed failures in the grizzly unit tests which depend on on the MeshPrimitiveEvaluator. 
