### PR TITLE
Enable Travis tests for IECoreImage and IECoreAlembic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,26 @@ script:
     - export LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
     - export LD_LIBRARY_PATH=$DEPENDENCIES/lib
     - scons -j 2
-      testCore testCorePython testScene
+      testCore testCorePython testScene testImage testAlembic
       CXX=$CXX
       CXXSTD=$CXXSTD
+      TBB_INCLUDE_PATH=$DEPENDENCIES/lib
+      TBB_LIB_PATH=$DEPENDENCIES/lib
       BOOST_INCLUDE_PATH=$DEPENDENCIES/include
+      BOOST_LIB_PATH=$DEPENDENCIES/lib
+      BOOST_LIB_SUFFIX=""
+      OPENEXR_INCLUDE_PATH=$DEPENDENCIES/include
+      OPENEXR_LIB_PATH=$DEPENDENCIES/lib
+      ILMBASE_INCLUDE_PATH=$DEPENDENCIES/include
+      ILMBASE_LIB_PATH=$DEPENDENCIES/lib
+      FREETYPE_INCLUDE_PATH=$DEPENDENCIES/include/freetype2
+      FREETYPE_LIB_PATH=$DEPENDENCIES/lib
+      ALEMBIC_INCLUDE_PATH=$DEPENDENCIES/include
+      ALEMBIC_LIB_PATH=$DEPENDENCIES/lib
+      HDF5_INCLUDE_PATH=$DEPENDENCIES/include
+      HDF5_LIB_PATH=$DEPENDENCIES/lib
+      APPLESEED_INCLUDE_PATH=$DEPENDENCIES/appleseed/include
+      APPLESEED_LIB_PATH=$DEPENDENCIES/appleseed/lib
       PYTHON=$DEPENDENCIES/bin/python
       PYTHON_INCLUDE_PATH=$DEPENDENCIES/include/python2.7
       PYTHON_LINK_FLAGS=-lpython2.7
@@ -42,7 +58,6 @@ script:
       DEBUG=$DEBUG
       ENV_VARS_TO_IMPORT="PATH TRAVIS LD_PRELOAD LD_LIBRARY_PATH"
       RMAN_ROOT=$DELIGHT
-      BOOST_LIB_SUFFIX=""
       BUILD_CACHEDIR=sconsCache
     - cat test/IECore/results.txt
 

--- a/SConstruct
+++ b/SConstruct
@@ -2824,8 +2824,6 @@ if doConfigure :
 		alembicTestEnv["ENV"]["PYTHONPATH"] += ":./contrib/IECoreAlembic/python"
 		alembicTest = alembicTestEnv.Command( "contrib/IECoreAlembic/test/IECoreAlembic/results.txt", alembicPythonModule, pythonExecutable + " $TEST_ALEMBIC_SCRIPT" )
 		NoCache( alembicTest )
-		if haveArnold:
-			alembicTestEnv.Depends( arnoldTest, glob.glob( "contrib/IECoreAlembic/test/IECoreAlembic/*.py" ) )
 		alembicTestEnv.Alias( "testAlembic", alembicTest )
 
 ###########################################################################################

--- a/SConstruct
+++ b/SConstruct
@@ -2819,6 +2819,8 @@ if doConfigure :
 
 		# tests
 		alembicTestEnv = testEnv.Clone()
+		alembicTestLibPaths = alembicEnv.subst( ":".join( alembicPythonModuleEnv["LIBPATH"] ) )
+		alembicTestEnv["ENV"][alembicTestEnv["TEST_LIBRARY_PATH_ENV_VAR"]] += ":" + alembicTestLibPaths
 		alembicTestEnv["ENV"]["PYTHONPATH"] += ":./contrib/IECoreAlembic/python"
 		alembicTest = alembicTestEnv.Command( "contrib/IECoreAlembic/test/IECoreAlembic/results.txt", alembicPythonModule, pythonExecutable + " $TEST_ALEMBIC_SCRIPT" )
 		NoCache( alembicTest )

--- a/test/IECoreImage/ImageReaderTest.py
+++ b/test/IECoreImage/ImageReaderTest.py
@@ -63,7 +63,7 @@ class ImageReaderTest( unittest.TestCase ) :
 
 	def testDeep( self ) :
 
-		r = IECore.Reader.create( "test/IECoreRI/data/exr/primitives.exr" )
+		r = IECore.Reader.create( "test/IECoreImage/data/exr/primitives.exr" )
 		self.assertEqual( r.channelNames(), IECore.StringVectorData( [] ) )
 		h = r.readHeader()
 		self.assertEqual( h[ "deep" ], IECore.BoolData( True ) )


### PR DESCRIPTION
I've been fighting with this most of the day, but I'm hopeful that it should now actually be working. After repeated debugging it turned out that the main issue was actually in the linking of Alembic itself, which was fixed by [updating the version in the dependencies package](https://github.com/GafferHQ/dependencies/pull/67). Now, if only someone would do the same for IECoreMaya and IECoreHoudini on the internal CI server :)