### PR TITLE
SConstruct : Fix IECoreUSD configuration bug

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2584,7 +2584,7 @@ if doConfigure :
 # Build, install and test the IECoreUSD library and bindings
 ###########################################################################################
 
-usdEnv = corePythonEnv.Clone( IECORE_NAME = "IECoreUSD" )
+usdEnv = pythonEnv.Clone( IECORE_NAME = "IECoreUSD" )
 usdEnvAppends = {
 	"CXXFLAGS" : [
 		"-isystem", "$USD_INCLUDE_PATH",


### PR DESCRIPTION
The `corePythonEnv` includes libIECore in its LIBS variable. This means that the configuration check for the USD library used an environment which linked to IECore. This in turn meant that SCons was building the entirety of IECore _during the configure phase_. The `pythonEnv` doesn't include IECore in LIBS, so is safe to use, and we were already manually adding libIECore after the configuration check had completed anyway.