### PR TITLE
Fix IECoreMaya ParameterisedHolder

### DIFF
--- a/src/IECoreMaya/DrawableHolder.cpp
+++ b/src/IECoreMaya/DrawableHolder.cpp
@@ -48,6 +48,7 @@
 #include "IECoreMaya/MayaTypeIds.h"
 #include "IECoreMaya/Convert.h"
 
+#include "maya/MGlobal.h"
 #include "maya/MFnNumericAttribute.h"
 #include "maya/MFnNumericData.h"
 
@@ -75,7 +76,10 @@ void *DrawableHolder::creator()
 MStatus DrawableHolder::initialize()
 {
 	MStatus s = inheritAttributesFrom( ParameterisedHolderSurfaceShape::typeName );
-	assert( s );
+	if( !s )
+	{
+		MGlobal::displayError( "DrawableHolder::initialize(): " + s.errorString() );
+	}
 
 	MFnNumericAttribute nAttr;
 

--- a/src/IECoreMaya/IECoreMaya.cpp
+++ b/src/IECoreMaya/IECoreMaya.cpp
@@ -43,6 +43,7 @@
 #include "maya/MPxObjectSet.h"
 #include "maya/MPxFieldNode.h"
 #include "maya/MPxImagePlane.h"
+#include "maya/MPxSurfaceShapeUI.h"
 #include "maya/MGlobal.h"
 #undef None // must come after certain Maya includes which include X11/X.h
 
@@ -126,6 +127,14 @@ MStatus initialize(MFnPlugin &plugin)
 			ParameterisedHolderSet::creator, ParameterisedHolderSet::initialize, MPxNode::kObjectSet );
 		assert( s );
 
+		s = plugin.registerShape( ParameterisedHolderSurfaceShape::typeName, ParameterisedHolderSurfaceShape::id,
+			ParameterisedHolderSurfaceShape::creator, ParameterisedHolderSurfaceShape::initialize, []() -> void* { return new MPxSurfaceShapeUI; } );
+		assert( s );
+		
+		s = plugin.registerShape( ParameterisedHolderComponentShape::typeName, ParameterisedHolderComponentShape::id,
+			ParameterisedHolderComponentShape::creator, ParameterisedHolderComponentShape::initialize, []() -> void* { return new MPxSurfaceShapeUI; } );
+		assert( s );
+ 
 		s = plugin.registerShape( DrawableHolder::typeName, DrawableHolder::id,
 			DrawableHolder::creator, DrawableHolder::initialize, DrawableHolderUI::creator );
 		assert( s );

--- a/test/IECoreMaya/ParameterisedHolder.py
+++ b/test/IECoreMaya/ParameterisedHolder.py
@@ -38,9 +38,10 @@ import os.path
 
 import maya.cmds as cmds
 import maya.OpenMaya as OpenMaya
-import imath
 
 import IECore
+import imath
+
 import IECoreScene
 import IECoreMaya
 
@@ -152,7 +153,7 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		h = IECoreMaya.FnParameterisedHolder( str(n) )
 		self.assert_( h )
 
-		p = makeOp( imath.Color3f( 0, 0, 0 ) )
+		p = makeOp( IECore.Color3fData( imath.Color3f( 0, 0, 0 ) ) )
 		h.setParameterised( p )
 		dv = cmds.attributeQuery ( "parm_c", node = n, listDefault = True )
 		self.assertEqual( dv, [ 0, 0, 0 ] )

--- a/test/IECoreMaya/ParameterisedHolder.py
+++ b/test/IECoreMaya/ParameterisedHolder.py
@@ -1878,6 +1878,19 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		fnOH = IECoreMaya.FnOpHolder( opNode )
 		self.assertRaises( RuntimeError, IECore.curry( fnOH.setOp, "fake", -1 ) )
 
+	def testDrawableHolderCanHoldParameterised( self ) :
+		
+		n = cmds.createNode( "ieDrawable" )
+		h = IECoreMaya.FnParameterisedHolder( str(n) )
+		self.assert_( h )
+
+		h.setParameterised( "floatParameter", 1, "IECORE_OP_PATHS" )
+		self.assertEqual( h.getParameterised()[1:], ( "floatParameter", 1, "IECORE_OP_PATHS" ) )
+		
+		cmds.setAttr( n + ".parm_f", 1.5 )
+		h.setParameterisedValues()
+		self.assertEqual( h.getParameterised()[0]["f"].getNumericValue(), 1.5 )
+	
 	def tearDown( self ) :
 
 		for f in [


### PR DESCRIPTION
`DrawableHolders` were broken, as were all derived classes of `ParameterisedHolderSurfaceShape` and `ParameterisedHolderComponentShape`.