### PR TITLE
Houdini test utils

### DIFF
--- a/python/IECoreHoudini/TestCase.py
+++ b/python/IECoreHoudini/TestCase.py
@@ -42,5 +42,18 @@ class TestCase( unittest.TestCase ) :
 	## Derived classes may override this, but they should call the
 	# base class implementation too.
 	def setUp( self ) :
-
+		self.__fileIndex = 0
 		hou.hipFile.clear( True )
+
+	def checkPointHipFile( self, name = None ) :
+		"""
+		Utility function to dump a .hip file to the temp directory
+		It's useful to call this function during a test after the houdini nodes are setup,
+		you can load the file in houdini to visually see what the test is supposed to be testing.
+		"""
+
+		if not name :
+			name = self.id()
+
+		hou.hipFile.save( "/tmp/{0}.{1}.hip".format( name, self.__fileIndex ) )
+		self.__fileIndex += 1

--- a/src/IECore/Debug.cpp
+++ b/src/IECore/Debug.cpp
@@ -1,0 +1,78 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include <iostream>
+#include <cstdlib>
+#include <thread>
+#include <chrono>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "boost/format.hpp"
+
+
+namespace
+{
+
+void waitForDebugger()
+{
+	char *waitEnvVar = std::getenv( "IECORE_DEBUG_WAIT" );
+	if( !waitEnvVar )
+	{
+		return;
+	}
+
+	// Not using IECore::Msg as we might get here before it's globals have been initialised.
+	// It's probably related to the static initialisation order fiasco.
+	std::cerr << ( boost::format( "Attach debugger here and set gDebuggerLock variable to false. pid: %i" ) % getpid() ).str() << std::endl;
+
+	static bool gDebuggerLock = true;
+	while( gDebuggerLock )
+	{
+		std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
+	}
+}
+
+struct DebuggerCheckOnInit
+{
+	DebuggerCheckOnInit()
+	{
+		waitForDebugger();
+	}
+};
+
+static DebuggerCheckOnInit gDebuggerCheck;
+
+} // namespace
+


### PR DESCRIPTION
A little utilities to help debugging houdini unit tests:

1. function to wait for a debugger to be attached before continuing.
2. save .hip file to /tmp to help with inspecting unit test node graphs
