### PR TITLE
Object improvements

### DIFF
--- a/include/IECore/Data.h
+++ b/include/IECore/Data.h
@@ -47,7 +47,7 @@ class IECORE_API Data : public Object
 {
 	public :
 
-		IE_CORE_DECLAREABSTRACTOBJECT( Data, Object );
+		IE_CORE_DECLAREOBJECT( Data, Object );
 
 	protected :
 

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -56,11 +56,6 @@ class MurmurHash;
 		static const IECore::Object::TypeDescription<TYPENAME> m_typeDescription;										\
 	public :																											\
 
-#define IE_CORE_DECLAREABSTRACTOBJECTTYPEDESCRIPTION( TYPENAME )														\
-	private :																											\
-		static const IECore::Object::AbstractTypeDescription<TYPENAME> m_typeDescription;								\
-	public :																											\
-
 #define IE_CORE_DECLAREOBJECTMEMBERFNS( TYPENAME )																		\
 	public :																											\
 		TYPENAME::Ptr copy() const { return boost::static_pointer_cast<TYPENAME>( IECore::Object::copy() ); }			\
@@ -77,26 +72,13 @@ class MurmurHash;
 	IE_CORE_DECLAREOBJECTMEMBERFNS( TYPE );																				\
 	IE_CORE_DECLAREOBJECTTYPEDESCRIPTION( TYPE );																		\
 
-#define IE_CORE_DECLAREABSTRACTOBJECT( TYPE, BASETYPE ) 																\
-	IE_CORE_DECLARERUNTIMETYPED( TYPE, BASETYPE ); 																		\
-	IE_CORE_DECLAREOBJECTMEMBERFNS( TYPE ); 																			\
-	IE_CORE_DECLAREABSTRACTOBJECTTYPEDESCRIPTION( TYPE );																\
-
 #define IE_CORE_DECLAREEXTENSIONOBJECT( TYPE, TYPEID, BASETYPE ) 														\
 	IE_CORE_DECLARERUNTIMETYPEDEXTENSION( TYPE, TYPEID, BASETYPE ); 													\
 	IE_CORE_DECLAREOBJECTMEMBERFNS( TYPE );																				\
 	IE_CORE_DECLAREOBJECTTYPEDESCRIPTION( TYPE );																		\
 
-#define IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( TYPE, TYPEID, BASETYPE )												\
-	IE_CORE_DECLARERUNTIMETYPEDEXTENSION( TYPE, TYPEID, BASETYPE );														\
-	IE_CORE_DECLAREOBJECTMEMBERFNS( TYPE );																				\
-	IE_CORE_DECLAREABSTRACTOBJECTTYPEDESCRIPTION( TYPE );																\
-
 #define IE_CORE_DEFINEOBJECTTYPEDESCRIPTION( TYPENAME )																	\
 	const IECore::Object::TypeDescription<TYPENAME> TYPENAME::m_typeDescription											\
-
-#define IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION( TYPENAME )															\
-	const IECore::Object::AbstractTypeDescription<TYPENAME> TYPENAME::m_typeDescription									\
 
 /// A base class defining copying and streaming.
 /// \ingroup coreGroup
@@ -204,21 +186,8 @@ class IECORE_API Object : public RunTimeTyped
 			public :
 				/// Registers the object using its static typeId and static typename
 				TypeDescription();
-
 				/// Registers the object using a specified typeId and typename
 				TypeDescription( TypeId alternateTypeId, const std::string &alternateTypeName );
-			private :
-				static ObjectPtr creator();
-		};
-		/// As for TypeDescription, but for registering abstract classes.
-		/// \todo Hopefully find a way of not needing a separate
-		/// class for this, but use a specialisation of TypeDescription
-		/// or summink.
-		template<class T>
-		class AbstractTypeDescription : protected RunTimeTyped::TypeDescription<T>
-		{
-			public :
-				AbstractTypeDescription();
 		};
 
 		/// A simple class used in the copyFrom() method to provide
@@ -360,7 +329,7 @@ class IECORE_API Object : public RunTimeTyped
 		struct TypeInformation;
 		static TypeInformation *typeInformation();
 
-		static const AbstractTypeDescription<Object> m_typeDescription;
+		static const TypeDescription<Object> m_typeDescription;
 
 		static const unsigned int m_ioVersion;
 

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -39,7 +39,6 @@
 #include <map>
 #include <string>
 
-#include "boost/shared_ptr.hpp"
 #include "IECore/Export.h"
 #include "IECore/RunTimeTyped.h"
 #include "IECore/IndexedIO.h"
@@ -245,10 +244,10 @@ class IECORE_API Object : public RunTimeTyped
 
 				typedef std::map<const Object *, IndexedIO::EntryIDList > SavedObjectMap;
 
-				SaveContext( IndexedIOPtr ioInterface, boost::shared_ptr<SavedObjectMap> savedObjects );
+				SaveContext( IndexedIOPtr ioInterface, std::shared_ptr<SavedObjectMap> savedObjects );
 
 				IndexedIOPtr m_ioInterface;
-				boost::shared_ptr<SavedObjectMap> m_savedObjects;
+				std::shared_ptr<SavedObjectMap> m_savedObjects;
 
 		};
 
@@ -275,13 +274,13 @@ class IECORE_API Object : public RunTimeTyped
 			private :
 				typedef std::map< IndexedIO::EntryIDList, ObjectPtr> LoadedObjectMap;
 
-				LoadContext( ConstIndexedIOPtr ioInterface, boost::shared_ptr<LoadedObjectMap> loadedObjects );
+				LoadContext( ConstIndexedIOPtr ioInterface, std::shared_ptr<LoadedObjectMap> loadedObjects );
 
 				ObjectPtr loadObjectOrReference( const IndexedIO *container, const IndexedIO::EntryID &name );
 				ObjectPtr loadObject( const IndexedIO *container );
 
 				ConstIndexedIOPtr m_ioInterface;
-				boost::shared_ptr<LoadedObjectMap> m_loadedObjects;
+				std::shared_ptr<LoadedObjectMap> m_loadedObjects;
 		};
 		IE_CORE_DECLAREPTR( LoadContext );
 

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -326,11 +326,7 @@ class IECORE_API Object : public RunTimeTyped
 
 	private :
 
-		struct TypeInformation;
-		static TypeInformation *typeInformation();
-
 		static const TypeDescription<Object> m_typeDescription;
-
 		static const unsigned int m_ioVersion;
 
 };

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -186,11 +186,10 @@ class IECORE_API Object : public RunTimeTyped
 		static ObjectPtr load( ConstIndexedIOPtr ioInterface, const IndexedIO::EntryID &name );
 		//@}
 
-		typedef ObjectPtr (*CreatorFn)( void *data );
+		typedef std::function<ObjectPtr ()> CreatorFn;
 
-		/// Register a new Object-derived type with the system. The specified void* data is passed into the creator function
-		static void registerType( TypeId typeId, const std::string &typeName, CreatorFn creator, void *data = nullptr );
-
+		/// Register a new Object-derived type with the system.
+		static void registerType( TypeId typeId, const std::string &typeName, CreatorFn creator = CreatorFn() );
 
 	protected :
 
@@ -209,7 +208,7 @@ class IECORE_API Object : public RunTimeTyped
 				/// Registers the object using a specified typeId and typename
 				TypeDescription( TypeId alternateTypeId, const std::string &alternateTypeName );
 			private :
-				static ObjectPtr creator( void *data = nullptr );
+				static ObjectPtr creator();
 		};
 		/// As for TypeDescription, but for registering abstract classes.
 		/// \todo Hopefully find a way of not needing a separate

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -229,10 +229,12 @@ class IECORE_API Object : public RunTimeTyped
 		class IECORE_API CopyContext
 		{
 			public :
+				CopyContext();
 				/// Returns a copy of the specified object.
 				template<class T>
 				typename T::Ptr copy( const T *toCopy );
 			private :
+				ObjectPtr copyInternal( const Object *toCopy );
 				std::map<const Object *, Object *> m_copies;
 		};
 

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -35,8 +35,6 @@
 #ifndef IE_CORE_OBJECT_H
 #define IE_CORE_OBJECT_H
 
-#include <set>
-#include <map>
 #include <string>
 
 #include "IECore/Export.h"
@@ -202,7 +200,8 @@ class IECORE_API Object : public RunTimeTyped
 				typename T::Ptr copy( const T *toCopy );
 			private :
 				ObjectPtr copyInternal( const Object *toCopy );
-				std::map<const Object *, Object *> m_copies;
+				struct CopiedObjects;
+				std::unique_ptr<CopiedObjects> m_copies;
 		};
 
 		/// Must be implemented in all subclasses to make a deep copy of
@@ -241,14 +240,10 @@ class IECORE_API Object : public RunTimeTyped
 				/// using this container, it provides performance benefits only in extreme cases!
 				IndexedIO *rawContainer();
 			private :
-
-				typedef std::map<const Object *, IndexedIO::EntryIDList > SavedObjectMap;
-
-				SaveContext( IndexedIOPtr ioInterface, std::shared_ptr<SavedObjectMap> savedObjects );
-
+				struct SavedObjects;
+				SaveContext( IndexedIOPtr ioInterface, std::shared_ptr<SavedObjects> savedObjects );
 				IndexedIOPtr m_ioInterface;
-				std::shared_ptr<SavedObjectMap> m_savedObjects;
-
+				std::shared_ptr<SavedObjects> m_savedObjects;
 		};
 
 		/// The class provided to the load() method implemented by subclasses.
@@ -272,15 +267,13 @@ class IECORE_API Object : public RunTimeTyped
 				const IndexedIO *rawContainer();
 
 			private :
-				typedef std::map< IndexedIO::EntryIDList, ObjectPtr> LoadedObjectMap;
-
-				LoadContext( ConstIndexedIOPtr ioInterface, std::shared_ptr<LoadedObjectMap> loadedObjects );
-
+				struct LoadedObjects;
+				LoadContext( ConstIndexedIOPtr ioInterface, std::shared_ptr<LoadedObjects> loadedObjects );
 				ObjectPtr loadObjectOrReference( const IndexedIO *container, const IndexedIO::EntryID &name );
 				ObjectPtr loadObject( const IndexedIO *container );
 
 				ConstIndexedIOPtr m_ioInterface;
-				std::shared_ptr<LoadedObjectMap> m_loadedObjects;
+				std::shared_ptr<LoadedObjects> m_loadedObjects;
 		};
 		IE_CORE_DECLAREPTR( LoadContext );
 
@@ -314,8 +307,9 @@ class IECORE_API Object : public RunTimeTyped
 				/// Returns the total accumulated to date.
 				size_t total() const;
 			private :
-				std::set<const void *> m_accumulated;
 				size_t m_total;
+				struct Accumulated;
+				std::unique_ptr<Accumulated> m_accumulated;
 		};
 
 		/// Must be implemented in all derived classes to specify the amount of memory they are

--- a/include/IECore/Object.h
+++ b/include/IECore/Object.h
@@ -193,7 +193,7 @@ class IECORE_API Object : public RunTimeTyped
 		/// a means of copying Object derived member data while
 		/// ensuring the uniqueness of copies of objects in the case
 		/// that an object is referred to more than once.
-		class IECORE_API CopyContext
+		class IECORE_API CopyContext : private boost::noncopyable
 		{
 			public :
 				CopyContext();
@@ -213,7 +213,7 @@ class IECORE_API Object : public RunTimeTyped
 		virtual void copyFrom( const Object *other, CopyContext *context ) = 0;
 
 		/// The class provided to the save() method implemented by subclasses.
-		class IECORE_API SaveContext
+		class IECORE_API SaveContext : private boost::noncopyable
 		{
 			public :
 				SaveContext( IndexedIOPtr ioInterface );
@@ -299,7 +299,7 @@ class IECORE_API Object : public RunTimeTyped
 
 		/// The class provided to the memoryUsage() virtual method implemented
 		/// by subclasses.
-		class IECORE_API MemoryAccumulator
+		class IECORE_API MemoryAccumulator : private boost::noncopyable
 		{
 			public :
 				MemoryAccumulator();

--- a/include/IECore/Object.inl
+++ b/include/IECore/Object.inl
@@ -49,27 +49,25 @@ typename T::Ptr Object::CopyContext::copy( const T *toCopy )
 template<class T>
 Object::TypeDescription<T>::TypeDescription() : RunTimeTyped::TypeDescription<T>()
 {
-	Object::registerType( T::staticTypeId(), T::staticTypeName(), creator, (void*)nullptr );
+	Object::registerType( T::staticTypeId(), T::staticTypeName(), creator );
 }
 
 template<class T>
 Object::TypeDescription<T>::TypeDescription( TypeId alternateTypeId, const std::string &alternateTypeName ) : RunTimeTyped::TypeDescription<T>()
 {
-	Object::registerType( alternateTypeId, alternateTypeName, creator, (void*)nullptr );
+	Object::registerType( alternateTypeId, alternateTypeName, creator );
 }
 
-
 template<class T>
-ObjectPtr Object::TypeDescription<T>::creator( void *data )
+ObjectPtr Object::TypeDescription<T>::creator()
 {
-	assert( !data ); // We don't expect to receive any data here.
 	return new T;
 }
 
 template<class T>
 Object::AbstractTypeDescription<T>::AbstractTypeDescription() : RunTimeTyped::TypeDescription<T>()
 {
-	Object::registerType( T::staticTypeId(), T::staticTypeName(), nullptr, (void*)nullptr );
+	Object::registerType( T::staticTypeId(), T::staticTypeName() );
 }
 
 template<class T>

--- a/include/IECore/Object.inl
+++ b/include/IECore/Object.inl
@@ -43,15 +43,7 @@ namespace IECore
 template<class T>
 typename T::Ptr Object::CopyContext::copy( const T *toCopy )
 {
-	std::map<const Object *, Object *>::const_iterator it = m_copies.find( toCopy );
-	if( it!=m_copies.end() )
-	{
-		return static_cast<T *>( it->second );
-	}
-	ObjectPtr copy = create( toCopy->typeId() );
-	copy->copyFrom( toCopy, this );
-	m_copies.insert( std::pair<const Object *, Object *>( toCopy, copy.get() ) );
-	return boost::static_pointer_cast<T>( copy );
+	return boost::static_pointer_cast<T>( copyInternal( toCopy ) );
 }
 
 template<class T>

--- a/include/IECoreScene/PreWorldRenderable.h
+++ b/include/IECoreScene/PreWorldRenderable.h
@@ -51,7 +51,7 @@ class IECORESCENE_API PreWorldRenderable : public Renderable
 		PreWorldRenderable();
 		~PreWorldRenderable() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( PreWorldRenderable, PreWorldRenderableTypeId, Renderable );
+		IE_CORE_DECLAREEXTENSIONOBJECT( PreWorldRenderable, PreWorldRenderableTypeId, Renderable );
 
 	private:
 

--- a/include/IECoreScene/Primitive.h
+++ b/include/IECoreScene/Primitive.h
@@ -58,7 +58,7 @@ class IECORESCENE_API Primitive : public VisibleRenderable
 		Primitive();
 		~Primitive() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( Primitive, PrimitiveTypeId, VisibleRenderable );
+		IE_CORE_DECLAREEXTENSIONOBJECT( Primitive, PrimitiveTypeId, VisibleRenderable );
 
 		/// Variables a stored as a public map for easy manipulation.
 		PrimitiveVariableMap variables;

--- a/include/IECoreScene/Renderable.h
+++ b/include/IECoreScene/Renderable.h
@@ -54,7 +54,7 @@ class IECORESCENE_API Renderable : public IECore::BlindDataHolder
 		Renderable();
 		~Renderable() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( Renderable, RenderableTypeId, IECore::BlindDataHolder );
+		IE_CORE_DECLAREEXTENSIONOBJECT( Renderable, RenderableTypeId, IECore::BlindDataHolder );
 
 		/// Render the object held by this instance via the given renderer.
 		virtual void render( Renderer *renderer ) const = 0;

--- a/include/IECoreScene/StateRenderable.h
+++ b/include/IECoreScene/StateRenderable.h
@@ -52,7 +52,7 @@ class IECORESCENE_API StateRenderable : public Renderable
 		StateRenderable();
 		~StateRenderable() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( StateRenderable, StateRenderableTypeId, Renderable );
+		IE_CORE_DECLAREEXTENSIONOBJECT( StateRenderable, StateRenderableTypeId, Renderable );
 
 	private:
 

--- a/include/IECoreScene/Transform.h
+++ b/include/IECoreScene/Transform.h
@@ -53,7 +53,7 @@ class IECORESCENE_API Transform : public StateRenderable
 		Transform();
 		~Transform() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( Transform, TransformTypeId, StateRenderable );
+		IE_CORE_DECLAREEXTENSIONOBJECT( Transform, TransformTypeId, StateRenderable );
 
 		/// Returns the transform this object represents,
 		/// evaluated at the requested time.

--- a/include/IECoreScene/VisibleRenderable.h
+++ b/include/IECoreScene/VisibleRenderable.h
@@ -55,7 +55,7 @@ class IECORESCENE_API VisibleRenderable : public Renderable
 		VisibleRenderable();
 		~VisibleRenderable() override;
 
-		IE_CORE_DECLAREABSTRACTEXTENSIONOBJECT( VisibleRenderable, VisibleRenderableTypeId, Renderable );
+		IE_CORE_DECLAREEXTENSIONOBJECT( VisibleRenderable, VisibleRenderableTypeId, Renderable );
 
 		/// Returns the bounding box for the rendered objects.
 		virtual Imath::Box3f bound() const = 0;

--- a/src/IECore/Data.cpp
+++ b/src/IECore/Data.cpp
@@ -36,7 +36,7 @@
 
 using namespace IECore;
 
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION( Data );
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION( Data );
 
 const unsigned int Data::m_ioVersion = 0;
 

--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -136,11 +136,11 @@ ObjectPtr Object::CopyContext::copyInternal( const Object *toCopy )
 //////////////////////////////////////////////////////////////////////////////////////////
 
 Object::SaveContext::SaveContext( IndexedIOPtr ioInterface )
-	:	m_ioInterface( ioInterface ), m_savedObjects( new SavedObjectMap )
+	:	m_ioInterface( ioInterface ), m_savedObjects( make_shared<SavedObjectMap>() )
 {
 }
 
-Object::SaveContext::SaveContext( IndexedIOPtr ioInterface, boost::shared_ptr<SavedObjectMap> savedObjects )
+Object::SaveContext::SaveContext( IndexedIOPtr ioInterface, std::shared_ptr<SavedObjectMap> savedObjects )
 	:	m_ioInterface( ioInterface ), m_savedObjects( savedObjects )
 {
 }
@@ -212,7 +212,7 @@ Object::LoadContext::LoadContext( ConstIndexedIOPtr ioInterface )
 {
 }
 
-Object::LoadContext::LoadContext( ConstIndexedIOPtr ioInterface, boost::shared_ptr<LoadedObjectMap> loadedObjects )
+Object::LoadContext::LoadContext( ConstIndexedIOPtr ioInterface, std::shared_ptr<LoadedObjectMap> loadedObjects )
 	:	m_ioInterface( ioInterface ), m_loadedObjects( loadedObjects )
 {
 }

--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -46,7 +46,7 @@ using namespace std;
 
 IE_CORE_DEFINERUNTIMETYPED( Object );
 
-const Object::AbstractTypeDescription<Object> Object::m_typeDescription;
+const Object::TypeDescription<Object> Object::m_typeDescription;
 
 static IndexedIO::EntryID g_ioVersionEntry("ioVersion");
 static IndexedIO::EntryID g_dataEntry("data");

--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -94,6 +94,40 @@ Object::TypeInformation *Object::typeInformation()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////
+// copy context stuff
+//////////////////////////////////////////////////////////////////////////////////////////
+
+Object::CopyContext::CopyContext()
+{
+}
+
+ObjectPtr Object::CopyContext::copyInternal( const Object *toCopy )
+{
+	if( toCopy->refCount() > 1 )
+	{
+		// object may occur multiple times in the data structure
+		// being copied - ensure we don't copy it twice.
+		std::map<const Object *, Object *>::const_iterator it = m_copies.find( toCopy );
+		if( it!=m_copies.end() )
+		{
+			return it->second;
+		}
+		ObjectPtr copy = create( toCopy->typeId() );
+		copy->copyFrom( toCopy, this );
+		m_copies.insert( std::pair<const Object *, Object *>( toCopy, copy.get() ) );
+		return copy;
+	}
+	else
+	{
+		// object can only occur once in the data structure being
+		// counted - avoid unnecessary bookkeeping overhead.
+		ObjectPtr copy = create( toCopy->typeId() );
+		copy->copyFrom( toCopy, this );
+		return copy;
+	}
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
 // save context stuff
 //////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/IECore/Object.cpp
+++ b/src/IECore/Object.cpp
@@ -71,16 +71,19 @@ Object::~Object()
 // type information structure
 //////////////////////////////////////////////////////////////////////////////////////////
 
-struct Object::TypeInformation
+namespace
 {
-	typedef std::map< TypeId, CreatorFn > TypeIdsToCreatorsMap;
-	typedef std::map< std::string, CreatorFn > TypeNamesToCreatorsMap;
+
+struct TypeInformation
+{
+	typedef std::map< TypeId, Object::CreatorFn > TypeIdsToCreatorsMap;
+	typedef std::map< std::string, Object::CreatorFn > TypeNamesToCreatorsMap;
 
 	TypeIdsToCreatorsMap typeIdsToCreators;
 	TypeNamesToCreatorsMap typeNamesToCreators;
 };
 
-Object::TypeInformation *Object::typeInformation()
+TypeInformation *typeInformation()
 {
 	// we have a function to return the type information rather than
 	// just have it as a static data member as we can't guarantee
@@ -91,6 +94,8 @@ Object::TypeInformation *Object::typeInformation()
 	static TypeInformation *i = new TypeInformation;
 	return i;
 }
+
+} // namespace
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // copy context stuff

--- a/src/IECoreScene/PreWorldRenderable.cpp
+++ b/src/IECoreScene/PreWorldRenderable.cpp
@@ -37,7 +37,7 @@
 using namespace IECore;
 using namespace IECoreScene;
 
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION(PreWorldRenderable);
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(PreWorldRenderable);
 
 const unsigned int PreWorldRenderable::m_ioVersion = 0;
 

--- a/src/IECoreScene/Primitive.cpp
+++ b/src/IECoreScene/Primitive.cpp
@@ -57,7 +57,7 @@ static IndexedIO::EntryID g_interpolationEntry("interpolation");
 static IndexedIO::EntryID g_dataEntry("data");
 static IndexedIO::EntryID g_indicesEntry("indices");
 const unsigned int Primitive::m_ioVersion = 2;
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION( Primitive );
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION( Primitive );
 
 Primitive::Primitive()
 {

--- a/src/IECoreScene/Renderable.cpp
+++ b/src/IECoreScene/Renderable.cpp
@@ -37,7 +37,7 @@
 using namespace IECore;
 using namespace IECoreScene;
 
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION(Renderable);
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(Renderable);
 
 const unsigned int Renderable::m_ioVersion = 1;
 

--- a/src/IECoreScene/StateRenderable.cpp
+++ b/src/IECoreScene/StateRenderable.cpp
@@ -37,7 +37,7 @@
 using namespace IECore;
 using namespace IECoreScene;
 
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION(StateRenderable);
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(StateRenderable);
 
 const unsigned int StateRenderable::m_ioVersion = 0;
 

--- a/src/IECoreScene/Transform.cpp
+++ b/src/IECoreScene/Transform.cpp
@@ -38,7 +38,7 @@ using namespace IECore;
 using namespace IECoreScene;
 
 const unsigned int Transform::m_ioVersion = 0;
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION(Transform);
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(Transform);
 
 Transform::Transform()
 {

--- a/src/IECoreScene/VisibleRenderable.cpp
+++ b/src/IECoreScene/VisibleRenderable.cpp
@@ -37,7 +37,7 @@
 using namespace IECore;
 using namespace IECoreScene;
 
-IE_CORE_DEFINEABSTRACTOBJECTTYPEDESCRIPTION(VisibleRenderable);
+IE_CORE_DEFINEOBJECTTYPEDESCRIPTION(VisibleRenderable);
 
 const unsigned int VisibleRenderable::m_ioVersion = 0;
 


### PR DESCRIPTION
This contains miscellaneous improvements to the core Object type. The optimisation for `Object::copy()` is something I've had knocking around for a long time, waiting for a major version so we can merge it. Then there are a bunch of simplifications and improvements made possible by C++11, and finally I've hidden a lot of the implementation to enable future improvements without affecting compatibility. The final commit is something I need for working around symbol visibility problems on OSX (upcoming PR); hopefully it's justifiable in its own right, but please let me know if it seems odd or contrived.