### PR TITLE
Module startup : Load config files from CORTEX_STARTUP_PATHS

### DIFF
--- a/contrib/IECoreAlembic/python/IECoreAlembic/__init__.py
+++ b/contrib/IECoreAlembic/python/IECoreAlembic/__init__.py
@@ -36,3 +36,5 @@
 __import__( "IECoreScene" )
 
 from _IECoreAlembic import *
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreAlembic" )

--- a/contrib/IECoreAppleseed/python/IECoreAppleseed/__init__.py
+++ b/contrib/IECoreAppleseed/python/IECoreAppleseed/__init__.py
@@ -35,3 +35,5 @@
 __import__( "IECoreScene" )
 
 from _IECoreAppleseed import *
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreAppleseed" )

--- a/contrib/IECoreArnold/python/IECoreArnold/__init__.py
+++ b/contrib/IECoreArnold/python/IECoreArnold/__init__.py
@@ -36,3 +36,5 @@ __import__( "IECoreScene" )
 
 from _IECoreArnold import *
 from UniverseBlock import UniverseBlock
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreArnold" )

--- a/contrib/IECoreUSD/python/IECoreUSD/__init__.py
+++ b/contrib/IECoreUSD/python/IECoreUSD/__init__.py
@@ -33,3 +33,5 @@
 ##########################################################################
 
 from _IECoreUSD import *
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreUSD" )

--- a/python/IECore/__init__.py
+++ b/python/IECore/__init__.py
@@ -109,3 +109,4 @@ from Preset import Preset
 from BasicPreset import BasicPreset
 from RelativePreset import RelativePreset
 
+loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECore" )

--- a/python/IECoreGL/__init__.py
+++ b/python/IECoreGL/__init__.py
@@ -37,3 +37,5 @@ __import__( "IECoreScene" )
 from _IECoreGL import *
 
 from State import State
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreGL" )

--- a/python/IECoreHoudini/__init__.py
+++ b/python/IECoreHoudini/__init__.py
@@ -60,3 +60,5 @@ from UpdateMode import UpdateMode
 
 ## \todo: remove this hack if SideFx provides a swig-free method for sending a HOM_Node* to python
 LiveScene.node = lambda x : hou.node( x._getNodePath() )
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreHoudini" )

--- a/python/IECoreImage/__init__.py
+++ b/python/IECoreImage/__init__.py
@@ -35,3 +35,5 @@
 __import__( "IECore" )
 
 from _IECoreImage import *
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreImage" )

--- a/python/IECoreMaya/__init__.py
+++ b/python/IECoreMaya/__init__.py
@@ -99,3 +99,5 @@ import SceneShapeUI
 from FnSceneShape import FnSceneShape
 from RefreshDisabled import RefreshDisabled
 from UndoChunk import UndoChunk
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreMaya" )

--- a/python/IECoreNuke/__init__.py
+++ b/python/IECoreNuke/__init__.py
@@ -45,3 +45,5 @@ from UndoManagers import UndoState, UndoDisabled, UndoEnabled, UndoBlock
 from TestCase import TestCase
 from FnOpHolder import FnOpHolder
 import Menus
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreNuke" )

--- a/python/IECoreScene/__init__.py
+++ b/python/IECoreScene/__init__.py
@@ -45,3 +45,5 @@ from EditBlock import EditBlock
 from MotionBlock import MotionBlock
 from IDXReader import IDXReader
 from SWAReader import SWAReader
+
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreScene" )

--- a/python/IECoreVDB/__init__.py
+++ b/python/IECoreVDB/__init__.py
@@ -45,3 +45,4 @@ with warnings.catch_warnings():
 
 from _IECoreVDB import *
 
+__import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", {}, subdirectory = "IECoreVDB" )


### PR DESCRIPTION
This mirrors the startup sequence for all Gaffer modules, and provides an opportunity to insert compatibility configs, load and register new file formats etc. The main reason I've added it now is to provide an alternative to things like https://github.com/ImageEngine/cortex/pull/715/commits/f7e19444a3fba2bcba2fd06a9d34653958260493.