### PR TITLE
ImageReader: Added support to check completeness of deep image.

### DIFF
--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -46,6 +46,7 @@
 
 #include "OpenImageIO/imagecache.h"
 #include "OpenImageIO/imageio.h"
+#include "OpenImageIO/deepdata.h"
 
 #include "boost/tokenizer.hpp"
 
@@ -99,10 +100,24 @@ class ImageReader::Implementation
 
 			try
 			{
+
 				const ImageSpec *spec = m_cache->imagespec( m_inputFileName );
 
-				std::vector<float> data( spec->nchannels );
+				if( isDeep() )
+				{
+					DeepData deepData;
+					ImageInput *input = ImageInput::open( m_inputFileName.c_str() );
+					return input->read_native_deep_scanlines(
+						spec->height + spec->y - 1,
+						spec->height + spec->y,
+						0, // first deep sample
+						0, // first channel
+						spec->nchannels, // last channel
+						deepData
+					);
+				}
 
+				std::vector<float> data( spec->nchannels );
 				// if the last pixel is there, its complete
 				return m_cache->get_pixels(
 					m_inputFileName,

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -107,6 +107,8 @@ class ImageReader::Implementation
 				{
 					DeepData deepData;
 					ImageInput *input = ImageInput::open( m_inputFileName.c_str() );
+					// this will return false for deep tile image, we should probably find a way to
+					// support verifying integrity for deep tile image as well.
 					return input->read_native_deep_scanlines(
 						spec->height + spec->y - 1,
 						spec->height + spec->y,


### PR DESCRIPTION
Improvements
--

- IECoreImage::ImageReader (#717):
  - Similar to how we verify the integrity of flat image, we read the last
scanline of deep image in order to verify we can correctly read the data.