### PR TITLE
IECorePython::ExceptionAlgo : Handle traceback failure

### DIFF
--- a/src/IECorePython/ExceptionAlgo.cpp
+++ b/src/IECorePython/ExceptionAlgo.cpp
@@ -58,51 +58,67 @@ std::string formatPythonException( bool withStacktrace, int *lineNumber )
 		throw IECore::Exception( "No Python exception set" );
 	}
 
-	PyErr_NormalizeException( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
-
-	object exception( ( handle<>( exceptionPyObject ) ) );
-
-	// valuePyObject and tracebackPyObject may be null.
-	object value;
+	std::string simpleFormat = "Could not get exception text\n";
 	if( valuePyObject )
 	{
-		value = object( handle<>( valuePyObject ) );
+		simpleFormat = PyString_AsString(valuePyObject) + std::string( "\n" );
 	}
 
-	object traceback;
-	if( tracebackPyObject )
-	{
-		traceback = object( handle<>( tracebackPyObject ) );
-	}
+	PyErr_NormalizeException( &exceptionPyObject, &valuePyObject, &tracebackPyObject );
 
-	if( lineNumber )
+
+	try
 	{
-		if( PyErr_GivenExceptionMatches( value.ptr(), PyExc_SyntaxError ) )
+		object exception( ( handle<>( exceptionPyObject ) ) );
+
+		// valuePyObject and tracebackPyObject may be null.
+		object value;
+		if( valuePyObject )
 		{
-			*lineNumber = extract<int>( value.attr( "lineno" ) );
+			value = object( handle<>( valuePyObject ) );
 		}
-		else if( traceback )
+
+		object traceback;
+		if( tracebackPyObject )
 		{
-			*lineNumber = extract<int>( traceback.attr( "tb_lineno" ) );
+			traceback = object( handle<>( tracebackPyObject ) );
 		}
+
+		if( lineNumber )
+		{
+			if( PyErr_GivenExceptionMatches( value.ptr(), PyExc_SyntaxError ) )
+			{
+				*lineNumber = extract<int>( value.attr( "lineno" ) );
+			}
+			else if( traceback )
+			{
+				*lineNumber = extract<int>( traceback.attr( "tb_lineno" ) );
+			}
+		}
+
+		object tracebackModule( import( "traceback" ) );
+
+		object formattedList;
+		if( withStacktrace )
+		{
+			formattedList = tracebackModule.attr( "format_exception" )( exception, value, traceback );
+		}
+		else
+		{
+			formattedList = tracebackModule.attr( "format_exception_only" )( exception, value );
+		}
+
+		object formatted = str( "" ).join( formattedList );
+		std::string s = extract<std::string>( formatted );
+
+		return s;
 	}
-
-	object tracebackModule( import( "traceback" ) );
-
-	object formattedList;
-	if( withStacktrace )
+	catch( boost::python::error_already_set &e )
 	{
-		formattedList = tracebackModule.attr( "format_exception" )( exception, value, traceback );
+		PyObject *ptype, *pvalue, *ptraceback;
+		PyErr_Fetch(&ptype, &pvalue, &ptraceback);
+		return std::string( "Python exception can't be formatted nicely due to Python failure: " ) + PyString_AsString( pvalue ) + "\nOriginal exception is: " + simpleFormat;
 	}
-	else
-	{
-		formattedList = tracebackModule.attr( "format_exception_only" )( exception, value );
-	}
-
-	object formatted = str( "" ).join( formattedList );
-	std::string s = extract<std::string>( formatted );
-
-	return s;
 }
 
 void translatePythonException( bool withStacktrace )

--- a/src/IECorePython/ExceptionAlgo.cpp
+++ b/src/IECorePython/ExceptionAlgo.cpp
@@ -82,6 +82,16 @@ std::string formatPythonException( bool withStacktrace, int *lineNumber )
 		if( tracebackPyObject )
 		{
 			traceback = object( handle<>( tracebackPyObject ) );
+
+			simpleFormat += "Simple Traceback:\n";
+			object curTraceback = traceback;
+			while( curTraceback )
+			{
+				std::string filename = extract<std::string>( curTraceback.attr( "tb_frame" ).attr( "f_code" ).attr( "co_filename" ) );
+				int lineNo = extract<int>( curTraceback.attr( "tb_frame" ).attr("f_lineno") );
+				simpleFormat += filename + " : Line " + std::to_string( lineNo ) +  "\n";
+				curTraceback = curTraceback.attr( "tb_next" );
+			}
 		}
 
 		if( lineNumber )


### PR DESCRIPTION
This is pretty weird, and I'm not sure if it's actually worth merging, but I need to reference it from an email I'm writing John about a weird Gafffer issue, so it's probably easiest to put it up as a PR.

In certain weird corner cases during shutdown, I am somehow able to produce a situation where importing the "traceback" module fails, which would previously cause a crash.  With this PR, we just produce quick partial traceback instead of the properly formatted one, which is enough to help track down the issue.

The second commit is maybe too weird, but it would be nice if we could at least merge the first commit, which makes this scenario a lot clearer.  Or maybe once we figure out this weird issue, we will never again encounter a scenario where traceback fails to load, and we can forget about this.