### PR TITLE
Better debugging support

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -355,7 +355,29 @@ DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"],
 os.environ["OCIO"] = "/software/config/openColorIO/nuke-default/config.ocio"
 
 # import vars we need to get our doxygen and python wrappers working
-ENV_VARS_TO_IMPORT="PATH COMPILER COMPILER_VERSION PYTHONPATH IEENV_ROOT IEENV_WORKING_PATH IEENV_LIBRARY_PREFIX_PATH DOXYGEN_VERSION IEENV_DEBUG IEENV_DEBUG_PYTHON IEENV_DEBUGGER IEENV_DEBUGGER_ARGS DELIGHT_CONF SCONS_VERSION DL_VERSION DL_SHADERS_PATH DL_DISPLAYS_PATH solidangle_LICENSE CORTEX_POINTDISTRIBUTION_TILESET OCIO"
+envVarsToImport = ["PATH",
+					"COMPILER",
+					"COMPILER_VERSION",
+					"PYTHONPATH",
+					"IEENV_ROOT",
+					"IEENV_WORKING_PATH",
+					"IEENV_LIBRARY_PREFIX_PATH",
+					"DOXYGEN_VERSION",
+					"IEENV_DEBUG",
+					"IEENV_DEBUG_PYTHON",
+					"IEENV_DEBUGGER",
+					"IEENV_DEBUGGER_ARGS",
+					"DELIGHT_CONF",
+					"SCONS_VERSION",
+					"DL_VERSION",
+					"DL_SHADERS_PATH",
+					"DL_DISPLAYS_PATH",
+					"solidangle_LICENSE",
+					"CORTEX_POINTDISTRIBUTION_TILESET",
+					"OCIO",
+					"IECORE_DEBUG_WAIT"]
+
+ENV_VARS_TO_IMPORT= " ".join(envVarsToImport)
 
 # make sure the tests can run
 testLibs = [ pythonReg["location"] + "/" + compiler + "/" + compilerVersion + "/lib", compilerReg["location"] + "/lib" ]
@@ -416,3 +438,9 @@ INSTALL_PKG_CONFIG_FILE = "0"
 
 # speed up the build a bit hopefully.
 BUILD_CACHEDIR = os.environ["IEBUILD_CACHEDIR"]
+
+# build build will embed full paths to source code paths in the dwarf information
+# Disabling the build cache to ensure our debug builds are correct rather than fast.
+
+if getOption( "DEBUG", False):
+	BUILD_CACHEDIR = ''

--- a/src/IECore/Debug.cpp
+++ b/src/IECore/Debug.cpp
@@ -54,15 +54,17 @@ void waitForDebugger()
 		return;
 	}
 
+	static bool gDebuggerLock = true;
+
 	// Not using IECore::Msg as we might get here before it's globals have been initialised.
 	// It's probably related to the static initialisation order fiasco.
-	std::cerr << ( boost::format( "Attach debugger here and set gDebuggerLock variable to false. pid: %i" ) % getpid() ).str() << std::endl;
-
-	static bool gDebuggerLock = true;
+	std::cerr << ( boost::format( "Attach debugger here and set gDebuggerLock (%p) variable to false. pid: %i" ) % &gDebuggerLock % getpid() ).str() << std::endl;
 	while( gDebuggerLock )
 	{
 		std::this_thread::sleep_for( std::chrono::milliseconds( 100 ) );
 	}
+
+	std::cerr << "unlocked running .. " << std::endl;
 }
 
 struct DebuggerCheckOnInit


### PR DESCRIPTION
I know not many people use an IDE based debugger but I hope these minor changes make it a little easier.

- added *DEBUG_START* option to SConstruct to specify if we should wait for a debugger to attach. 
- Display address of lock boolean & notify user the lock has been released
- Disable build cache for debug as we could have installed our source from different locations and sharing builds requires us to have code on a network share visible to all potential debuggers.

Note my long term goal is to replicate the windows [JIT debugging](https://msdn.microsoft.com/en-us/library/5hs4b7a6.aspx) functionality in windows.


