### PR TITLE
When a render (from gaffer) is paused and restarted, we get a new asr…

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -275,8 +275,9 @@ class DisplayTileCallback : public ProgressTileCallback
 
 		void release() override
 		{
-			// We don't need to do anything here.
-			// The tile callback factory deletes this instance.
+			// We need to reset m_displays_initialized because we'll
+			// get a new asr::Frame if/when rendering restarts
+			m_displays_initialized = false;
 		}
 
 		void on_tile_begin(const asr::Frame *frame, const size_t tileX, const size_t tileY) override


### PR DESCRIPTION
When camera parameters are updated in Gaffer, we get a new asr::Frame/asf::Image, but don't currently recognise it. This change should resolve #730 