### PR TITLE
ParameterisedHolderUI : Remove unused variable.

### DIFF
--- a/mel/IECoreMaya/ieParameterisedHolderUI.mel
+++ b/mel/IECoreMaya/ieParameterisedHolderUI.mel
@@ -243,7 +243,6 @@ global proc ieParameterisedHolderUIExtraAttributesNewAndReplace( string $attrNam
 	tokenize( $attrName, ".", $buf);
 	
 	string $nodeName = $buf[0];
-	string $attrName = $buf[1];
 
 	if (`control -exists ieParameterisedAEExtraAttributes`)
 		deleteUI ieParameterisedAEExtraAttributes;

--- a/test/IECoreMaya/ToMayaCameraConverterTest.py
+++ b/test/IECoreMaya/ToMayaCameraConverterTest.py
@@ -59,7 +59,7 @@ class ToMayaCameraConverterTest( IECoreMaya.TestCase ) :
 		matA = maya.cmds.getAttr( camA+".worldMatrix[0]" )
 		matB = maya.cmds.getAttr( camB+".worldMatrix[0]" )
 		for i in range( 0, 16 ) :
-			self.assertAlmostEqual( matA[i], matB[i], 5 )
+			self.assertAlmostEqual( matA[i], matB[i], 4 )
 
 	def assertMayaCamsNotEqual( self, camA, camB ) :
 


### PR DESCRIPTION
It was masking the argument to the method, which was reported in the Maya ScriptEditor.