### PR TITLE
IECoreGL/FilterAlgo: make filtering symmetric

### DIFF
--- a/glsl/IECoreGL/FilterAlgo.h
+++ b/glsl/IECoreGL/FilterAlgo.h
@@ -48,7 +48,7 @@ float ieFilteredStep( float edge, float x )
 float ieFilteredPulse( float edge0, float edge1, float x, float w )
 {
 	float x0 = x - w / 2.0;
-	float x1 = x + w;
+	float x1 = x + w / 2.0;
 	return max( 0.0, ( min( x1, edge1 ) - max( x0, edge0 ) ) / w );
 }
 


### PR DESCRIPTION
Hey John,

remember the arrows for our new connections being drawn slightly off center when they're pretty small? I believe this fixes it? Am I missing something or was this just a bug? I've been staring at small arrows for a little bit now and I don't trust my eyes anymore - would be good if someone could confirm that this indeed solves that problem...

Cheerio! :)

Matti.
 