### PR TITLE
Houdini : Revert GL Context mechanism for Qt5 builds.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2592,6 +2592,12 @@ if doConfigure :
 
 	else :
 
+		# Houdini 16.0 and beyond can optionally ship using Qt5.
+		# Since IECoreHoudini makes some UI related calls, we add
+		# a custom define so we can change the logic as needed.
+		if os.path.exists( os.path.join( houdiniCheckEnv.subst( "$HOUDINI_LIB_PATH" ), "libQt5Core.so" ) ) :
+			houdiniPythonModuleEnv.Append( CXXFLAGS = "-DIECOREHOUDINI_WITH_QT5" )
+
 		c.Finish()
 
 		#=====

--- a/SConstruct
+++ b/SConstruct
@@ -2575,9 +2575,17 @@ mantraWorldEnv =  houdiniEnv.Clone( IECORE_NAME="VRAY_ieWorld" )
 
 if doConfigure :
 
-	c = Configure( houdiniEnv )
+	# Since we only build shared libraries and not exectuables,
+	# we only need to check that shared libs will link correctly.
+	# This approach succeeds because building a shared library
+	# doesn't require resolving the unresolved symbols of the
+	# libraries that it links to.
+	houdiniCheckEnv = houdiniEnv.Clone()
+	houdiniCheckEnv.Append( CXXFLAGS = [ "-fPIC" ] )
+	houdiniCheckEnv.Append( LINKFLAGS = [ "-shared" ] )
+	c = Configure( houdiniCheckEnv )
 
-	if not c.CheckCXXHeader( "SOP/SOP_API.h" ) :
+	if not c.CheckLibWithHeader( "HoudiniGEO", "SOP/SOP_API.h", "CXX" ) :
 
 		sys.stderr.write( "WARNING : no houdini devkit found, not building IECoreHoudini - check HOUDINI_ROOT.\n" )
 		c.Finish()


### PR DESCRIPTION
Houdini 16.0 and 16.5 optionally ship Qt5 builds, in which case they no longer us a QGLWidget internally. We can still make their main GL context current similarly to what we'd been doing before they exposed a shared widget.

I've contacted SideFx to find out if this approach is ok or if they have a better recommendation.