### PR TITLE
IECoreUSD : USDScene - Throw exception in ctor if USD load fails.

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -1285,6 +1285,12 @@ class USDScene::Reader : public USDScene::IO
 		Reader( const std::string &fileName ) : IO( fileName )
 		{
 			m_usdStage = pxr::UsdStage::Open( fileName );
+
+			if ( !m_usdStage )
+			{
+				throw IECore::Exception( boost::str( boost::format( "USDScene::Reader() Failed to open usd file: '%1%'" ) % fileName ) );
+			}
+
 			m_timeCodesPerSecond = m_usdStage->GetTimeCodesPerSecond();
 			m_rootPrim = m_usdStage->GetPseudoRoot();
 		}

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -51,6 +51,14 @@ class USDSceneTest( unittest.TestCase ) :
 		s = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( s.fileName(), fileName )
 
+	def testMissingFileThrowsException( self ) :
+
+		fileName = os.path.dirname( __file__ ) + "/data/cubeMissing.usda"
+
+		with self.assertRaises(RuntimeError):
+			s = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+
 	def testHierarchy( self ) :
 
 		# root


### PR DESCRIPTION
Fix a terrible crash if we attempt to load a missing or malformed USD file.