### PR TITLE
IECoreScene : SceneInterface::Path stream insertion << operator

### DIFF
--- a/include/IECoreScene/SceneInterface.h
+++ b/include/IECoreScene/SceneInterface.h
@@ -285,6 +285,8 @@ class IECORESCENE_API SceneInterface : public IECore::RunTimeTyped
 
 };
 
+IECORESCENE_API std::ostream &operator <<( std::ostream &o, const SceneInterface::Path &path );
+
 } // namespace IECoreScene
 
 #include "IECoreScene/SceneInterface.inl"

--- a/src/IECoreScene/SceneInterface.cpp
+++ b/src/IECoreScene/SceneInterface.cpp
@@ -168,4 +168,18 @@ void SceneInterface::stringToPath( const std::string &path, SceneInterface::Path
 	}
 }
 
-
+std::ostream &operator <<( std::ostream &o, const IECoreScene::SceneInterface::Path &path )
+{
+	if( !path.size() )
+	{
+		o << "/";
+	}
+	else
+	{
+		for( const auto &n : path )
+		{
+			o << "/" << n;
+		}
+	}
+	return o;
+}


### PR DESCRIPTION
+ useful for quick printing of paths when debugging.
+ We should remove the Gaffer version of this operator when this is merged.