### PR TITLE
Timers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1075,6 +1075,8 @@ if doConfigure :
 			"boost_date_time" + env["BOOST_LIB_SUFFIX"],
 			"boost_thread" + env["BOOST_LIB_SUFFIX"],
 			"boost_wave" + env["BOOST_LIB_SUFFIX"],
+			"boost_timer" + env["BOOST_LIB_SUFFIX"],
+			"boost_chrono" + env["BOOST_LIB_SUFFIX"]
 		]
 	)
 	if int( env["BOOST_MINOR_VERSION"] ) >=35 :

--- a/include/IECore/Timer.h
+++ b/include/IECore/Timer.h
@@ -39,6 +39,8 @@
 
 #include "boost/timer/timer.hpp"
 
+#include <string>
+
 namespace IECore
 {
 
@@ -86,6 +88,17 @@ class IECORE_API Timer
 		double m_accumulated;
 		boost::timer::cpu_timer m_timer;
 		Mode m_mode;
+};
+
+class IECORE_API ScopedTimer
+{
+	public:
+		ScopedTimer( const std::string &name );
+		~ScopedTimer();
+
+	private:
+		IECore::Timer m_timer;
+		std::string m_name;
 };
 
 } // namespace IECore

--- a/include/IECore/Timer.h
+++ b/include/IECore/Timer.h
@@ -37,7 +37,7 @@
 
 #include "IECore/Export.h"
 
-#include "boost/timer.hpp"
+#include "boost/timer/timer.hpp"
 
 namespace IECore
 {
@@ -49,13 +49,19 @@ namespace IECore
 /// \ingroup utilityGroup
 class IECORE_API Timer
 {
-
 	public :
+
+		enum Mode
+		{
+			WallClock,
+			UserCPU,
+			SystemCPU
+		};
 
 		/// Creates a new timer. If startAlready
 		/// is true then calls start(), otherwise
 		/// the timer is created stopped.
-		Timer( bool start = true );
+		Timer( bool start = true, Mode mode = UserCPU  );
 
 		/// Starts the timer. Throws an Exception if
 		/// it's already running.
@@ -78,8 +84,8 @@ class IECORE_API Timer
 
 		bool m_running;
 		double m_accumulated;
-		boost::timer m_timer;
-
+		boost::timer::cpu_timer m_timer;
+		Mode m_mode;
 };
 
 } // namespace IECore

--- a/src/IECore/Timer.cpp
+++ b/src/IECore/Timer.cpp
@@ -35,6 +35,8 @@
 #include "IECore/Timer.h"
 
 #include "IECore/Exception.h"
+#include "IECore/MessageHandler.h"
+
 #include <iostream>
 
 using namespace IECore;
@@ -108,4 +110,17 @@ double Timer::currentElapsed() const
 double Timer::totalElapsed() const
 {
 	return m_accumulated + currentElapsed();
+}
+
+ScopedTimer::ScopedTimer( const std::string &name ) : m_timer( true, IECore::Timer::WallClock ), m_name( name )
+{
+}
+
+ScopedTimer::~ScopedTimer()
+{
+	IECore::msg(
+		IECore::MessageHandler::Debug,
+		"ScopedTimer",
+		boost::str( boost::format( "[timed block] name: '%1%' time: %2% ms" ) % m_name % (m_timer.currentElapsed() * 1000.0) )
+	);
 }

--- a/src/IECorePython/TimerBinding.cpp
+++ b/src/IECorePython/TimerBinding.cpp
@@ -47,7 +47,9 @@ namespace IECorePython
 
 void bindTimer()
 {
-	class_<Timer>( "Timer", init<bool>() )
+
+	scope s = class_<Timer>( "Timer", init<bool>() )
+	    .def( init<bool, Timer::Mode>() )
 		.def( init<>() )
 		.def( "start", &Timer::start )
 		.def( "stop", &Timer::stop )
@@ -55,6 +57,14 @@ void bindTimer()
 		.def( "currentElapsed", &Timer::currentElapsed )
 		.def( "totalElapsed", &Timer::totalElapsed )
 	;
+
+	enum_< Timer::Mode> ("Mode")
+		.value("WallClock", Timer::WallClock)
+		.value("UserCPU", Timer::UserCPU)
+		.value("SystemCPU", Timer::SystemCPU)
+		.export_values()
+		;
+
 }
 
 } // namespace IECorePython


### PR DESCRIPTION
We use quite an [old version](https://www.boost.org/doc/libs/1_61_0/libs/timer/doc/original_timer.html) of the boost timer library and this PR brings us up to date but gives us the option to query wall clock time instead of cpu time.

I've kept the default behaviour on user cpu but perhaps we should switch the default to wall clock?