### PR TITLE
MeshPrimitive::createSphere : Round the number of segments

### DIFF
--- a/src/IECoreScene/MeshPrimitive.cpp
+++ b/src/IECoreScene/MeshPrimitive.cpp
@@ -432,10 +432,10 @@ MeshPrimitivePtr MeshPrimitive::createSphere( float radius, float zMin, float zM
 
 	float oMin = Math<float>::asin( zMin );
 	float oMax = Math<float>::asin( zMax );
-	const unsigned int nO = max( 4u, (unsigned int)( ( divisions.x + 1 ) * (oMax - oMin) / M_PI ) );
+	const unsigned int nO = max( 4u, (unsigned int)round( divisions.x * (oMax - oMin) / M_PI ) + 1 );
 
 	float thetaMaxRad = thetaMax / 180.0f * M_PI;
-	const unsigned int nT = max( 7u, (unsigned int)( ( divisions.y + 1 ) * thetaMaxRad / (M_PI*2) ) );
+	const unsigned int nT = max( 7u, (unsigned int)round( divisions.y * thetaMaxRad / (M_PI*2) ) + 1 );
 
 	for ( unsigned int i=0; i<nO; i++ )
 	{


### PR DESCRIPTION
Previously we were flooring the number of segments, which created precision problems right around whole numbers of segments.

Unfortunately, one of the spots where this precision issue shows up happens to be on the default Gaffer sphere - it requests 40 segments, but was only getting 39 due to this precision issue.  I was quite puzzled why the default Gaffer sphere had an odd number of segments when it was clearly requesting an even number.

I also moved the +1 from inside the multiply to outside - it makes more sense for a half sphere to have half the number of segments, rather than half the number of vertices ( the difference would be visible when using an even number of segments and comparing thetaMax = 179.99 vs 180 ).