### PR TITLE
IndexedIOAlgo

### DIFF
--- a/include/IECore/IndexedIOAlgo.h
+++ b/include/IECore/IndexedIOAlgo.h
@@ -1,0 +1,187 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IE_CORE_INDEXEDIOALGO_H
+#define IE_CORE_INDEXEDIOALGO_H
+
+#include "IECore/Export.h"
+
+#include "IECore/IndexedIO.h"
+
+#include <iostream>
+#include <iomanip>
+
+
+namespace IECore
+{
+namespace IndexedIOAlgo
+{
+
+/// Histogram of blockSize and byte totals for 64 power 2 bins.
+/// Template function so we can use atomics for multithreaded writes but can be converted
+/// easily to another integer type.
+template<typename T>
+struct FileStats
+{
+	static constexpr unsigned int numBins = 64;
+	/// number of bytes per bin
+	std::array<T, numBins> numBytes;
+	/// number of blocks per bin
+	std::array<T, numBins> numBlocks;
+
+	FileStats()
+	{
+		for (unsigned int i = 0; i < numBins;++i)
+		{
+			numBytes[i] = 0UL;
+			numBlocks[i] = 0UL;
+		}
+	}
+
+	template<typename S>
+	FileStats(const FileStats<S> &other )
+	{
+		for (unsigned int i = 0; i < numBins;++i)
+		{
+			numBytes[i] = other.numBytes[i];
+			numBlocks[i] = other.numBlocks[i];
+		}
+
+	}
+
+	void addBlock(size_t blockSize)
+	{
+		for (unsigned int i = 0; i < numBins; ++i)
+		{
+			if ( blockSize <= (1U << i) )
+			{
+				numBlocks[i]++;
+				numBytes[i]+= blockSize;
+				break;
+			}
+		}
+	}
+
+	int maxNonZeroBin() const
+	{
+		int maxBlock = 0;
+		for (unsigned int i = 0; i < numBins; ++i)
+		{
+			if (numBlocks[i] > 0)
+			{
+				maxBlock = i;
+			}
+		}
+		return maxBlock;
+	}
+
+	size_t totalBlocks() const
+	{
+		size_t total = 0;
+		for (unsigned int i = 0; i < numBins;++i)
+		{
+			total += numBlocks[i];
+		}
+		return total;
+	}
+
+	size_t totalBytes() const
+	{
+		size_t total = 0;
+		for (unsigned int i = 0; i < numBins;++i)
+		{
+			total += numBytes[i];
+		}
+		return total;
+	}
+};
+
+/// Recursively copy from 'src' to 'dst'
+IECORE_API void copy(const IndexedIO *src, IndexedIO *dst );
+
+/// Completely read an IndexedIO in parallel gathering statistics as we read.
+/// This function is used for performance monitoring
+IECORE_API FileStats<size_t> parallelReadAll( const IndexedIO *src );
+
+template<typename T>
+inline std::ostream &operator <<( std::ostream &s, const FileStats<T> &stats)
+{
+	int column0 = 8;
+	int column1 = 24;
+	int column2 = 16;
+	int column3 = 22;
+	int column4 = 16;
+	int column5 = 22;
+
+	s << std::setw(column0) << "bin" << std::setw( column1 ) << "bin Size" << std::setw( column2 );
+	s << "num blocks" << std::setw(column3) << "\% blocks";
+	s << std::setw( column4 ) <<  "num bytes" <<  std::setw(column5) << "\% bytes" << std::endl;
+	s << std::setw(column0) << std::string( column0 - 1, '-' )
+	  << std::setw(column1) << std::string( column1 - 1, '-' )
+	  << std::setw(column2) << std::string( column2 - 1, '-' )
+	  << std::setw(column3) << std::string( column3 - 1, '-' )
+	  << std::setw(column4) << std::string( column4 - 1, '-' )
+	  << std::setw(column4) << std::string( column5 - 1, '-' )
+	  << std::endl;
+
+	size_t totalBlocks = stats.totalBlocks();
+	size_t totalBytes = stats.totalBytes();
+
+	size_t previousBinSize = 0;
+	for (int i = 0; i <= stats.maxNonZeroBin(); ++i )
+	{
+		size_t binSize = 1 << i;
+		std::stringstream ss;
+		ss << "(" << previousBinSize << " - " << binSize << "]";
+
+		s << std::setw( column0 ) << i <<  std::setw( column1 ) << ss.str()
+		  << std::setw( column2 ) << stats.numBlocks[i] << std::setw( column3 ) << std::string( stats.numBlocks[i] * 20 / totalBlocks, '*' )
+		  << std::setw( column4 ) << stats.numBytes[i] << std::setw( column5 ) << std::string( stats.numBytes[i] * 20 / totalBytes, '*' )
+		  << std::endl;
+
+		previousBinSize = binSize;
+	}
+
+	s << std::setw( column0 ) << "" << std::setw( column1 ) << "" << std::setw( column2 ) << totalBlocks << std::setw( column3 ) << "" << std::setw( column4 ) <<  totalBytes << std::endl;
+
+	return s;
+}
+
+}
+}
+
+
+
+
+#endif // IE_CORE_INDEXEDIOALGO_H

--- a/include/IECorePython/IndexedIOAlgoBinding.h
+++ b/include/IECorePython/IndexedIOAlgoBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_INDEXEDIOALGOBINDING_H
+#define IECOREPYTHON_INDEXEDIOALGOBINDING_H
+
+#include "IECorePython/Export.h"
+
+namespace IECorePython
+{
+
+IECOREPYTHON_API void bindIndexedIOAlgo();
+
+}
+
+#endif // IECOREPYTHON_INDEXEDIOALGOBINDING_H

--- a/src/IECore/IndexedIOAlgo.cpp
+++ b/src/IECore/IndexedIOAlgo.cpp
@@ -1,0 +1,314 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECore/IndexedIOAlgo.h"
+
+#include "tbb/task_scheduler_init.h"
+#include "tbb/task.h"
+
+#include <atomic>
+
+using namespace IECore;
+using namespace IECore::IndexedIOAlgo;
+
+namespace
+{
+
+template<typename T, typename Callback>
+class Copier
+{
+	public:
+		void handleValue( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+			T value;
+			src->read( entry.id(), value );
+			dst->write( entry.id(), value );
+		}
+
+		void handleArray( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+			std::vector<T> array( entry.arrayLength() );
+			T *ptr = array.data();
+			src->read( entry.id(), ptr, entry.arrayLength() );
+			dst->write( entry.id(), ptr, entry.arrayLength() );
+		}
+};
+
+template<typename T, typename Callback>
+class Reader
+{
+	public:
+		void handleValue( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+			T value;
+			src->read( entry.id(), value );
+
+			callback( sizeof( T ) );
+		}
+
+		void handleArray( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+			std::vector<T> array( entry.arrayLength() );
+			T *ptr = array.data();
+			src->read( entry.id(), ptr, entry.arrayLength() );
+
+			callback( sizeof( T ) * entry.arrayLength() );
+		}
+};
+
+template<typename Callback>
+class Reader<std::string, Callback>
+{
+	public:
+		void handleValue( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+			std::string value;
+			src->read( entry.id(), value );
+
+			callback( value.size() );
+		}
+
+		void handleArray( const IndexedIO *src, IndexedIO *dst, const IndexedIO::Entry &entry, Callback &callback )
+		{
+
+			std::vector<std::string> array( entry.arrayLength() );
+			std::string *ptr = array.data();
+			src->read( entry.id(), ptr, entry.arrayLength() );
+
+			size_t numBytes = 0;
+			for( const auto &str : array )
+			{
+				numBytes += str.size();
+			}
+
+			callback( numBytes );
+		}
+};
+
+template<template<typename, typename> class Handler, typename Callback>
+void handleFile( const IndexedIO *src, IndexedIO *dst, IndexedIO::EntryID fileName, Callback &c )
+{
+	IndexedIO::Entry entry = src->entry( fileName );
+
+	switch( entry.dataType() )
+	{
+		case IndexedIO::Invalid:
+			break;
+		case IndexedIO::Float:
+			Handler<float, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::FloatArray:
+			Handler<float, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Double:
+			Handler<double, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::DoubleArray:
+			Handler<double, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Int:
+			Handler<int, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::IntArray:
+			Handler<int, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Long:
+			Handler<long, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::LongArray:
+			Handler<long, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::String:
+			Handler<std::string, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::StringArray:
+			Handler<std::string, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::UInt:
+			Handler<unsigned int, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::UIntArray:
+			Handler<unsigned int, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Char:
+			Handler<char, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::CharArray:
+			Handler<char, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::UChar:
+			Handler<unsigned char, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::UCharArray:
+			Handler<unsigned char, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Half:
+			Handler<half, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::HalfArray:
+			Handler<half, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Short:
+			Handler<short, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::ShortArray:
+			Handler<short, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::UShort:
+			Handler<unsigned short, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::UShortArray:
+			Handler<unsigned short, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::Int64:
+			Handler<int64_t, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::Int64Array:
+			Handler<int64_t, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::UInt64:
+			Handler<uint64_t, Callback>().handleValue( src, dst, entry, c );
+			break;
+		case IndexedIO::UInt64Array:
+			Handler<uint64_t, Callback>().handleArray( src, dst, entry, c );
+			break;
+		case IndexedIO::InternedStringArray:
+			Handler<InternedString, Callback>().handleArray( src, dst, entry, c );
+			break;
+	}
+}
+
+void recursiveCopy( const IndexedIO *src, IndexedIO *dst )
+{
+	IndexedIO::EntryIDList fileNames;
+	src->entryIds( fileNames, IndexedIO::EntryType::File );
+
+	for( const auto &fileName : fileNames )
+	{
+		int dummy = 0;
+		handleFile<Copier, int>( src, dst, fileName, dummy );
+	}
+
+	IndexedIO::EntryIDList directoryNames;
+	src->entryIds( directoryNames, IndexedIO::EntryType::Directory );
+
+	for( const auto &directoryName : directoryNames )
+	{
+		IndexedIOPtr childDst = dst->subdirectory( directoryName, IndexedIO::CreateIfMissing );
+		recursiveCopy( src->subdirectory( directoryName, IndexedIO::ThrowIfMissing ).get(), childDst.get() );
+	}
+}
+
+//! Task for traversing all files in parallel. New tasks are spawned for each directory
+template<template<typename, typename> class FileHandler, typename FileCallback>
+class FileTask : public tbb::task
+{
+
+	public :
+
+		FileTask( const IndexedIO *src, FileCallback &fileCallback )
+		: m_src( src ), m_fileCallback( fileCallback )
+		{
+		}
+
+		~FileTask() override
+		{
+		}
+
+		task *execute() override
+		{
+			IndexedIO::EntryIDList fileNames;
+			m_src->entryIds( fileNames, IndexedIO::EntryType::File );
+
+			for( const auto &fileName : fileNames )
+			{
+				handleFile<FileHandler, FileCallback>( m_src, nullptr, fileName, m_fileCallback );
+			}
+
+			IndexedIO::EntryIDList directoryNames;
+			m_src->entryIds( directoryNames, IndexedIO::EntryType::Directory );
+
+			set_ref_count( 1 + directoryNames.size() );
+
+			std::vector<ConstIndexedIOPtr> childDirectories;
+			childDirectories.reserve(directoryNames.size());
+			for( const auto &directoryName : directoryNames )
+			{
+				childDirectories.push_back( m_src->subdirectory( directoryName, IndexedIO::ThrowIfMissing ) );
+			}
+
+			for( const auto &childDirectory : childDirectories )
+			{
+				FileTask *t = new( allocate_child() ) FileTask( childDirectory.get() , m_fileCallback );
+				spawn( *t );
+			}
+
+			wait_for_all();
+
+			return nullptr;
+		}
+
+	private :
+		const IndexedIO *m_src;
+		FileCallback &m_fileCallback;
+};
+
+} // namespace
+
+namespace IECore
+{
+namespace IndexedIOAlgo
+{
+
+void copy( const IndexedIO *src, IndexedIO *dst )
+{
+	::recursiveCopy( src, dst );
+}
+
+FileStats<size_t> parallelReadAll( const IndexedIO *src )
+{
+	FileStats<std::atomic<size_t> > fileStats;
+
+	auto fileCallback = [&fileStats]( size_t numBytes )
+	{
+		fileStats.addBlock( numBytes );
+	};
+
+	FileTask<Reader, decltype( fileCallback )> *task = new( tbb::task::allocate_root() ) FileTask<Reader, decltype( fileCallback )>( src, fileCallback );
+	tbb::task::spawn_root_and_wait( *task );
+	return fileStats;
+}
+
+} // IndexedIOAlgo
+} // IECore

--- a/src/IECorePython/IndexedIOAlgoBinding.cpp
+++ b/src/IECorePython/IndexedIOAlgoBinding.cpp
@@ -1,0 +1,88 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECorePython/IndexedIOAlgoBinding.h"
+
+#include "IECore/IndexedIOAlgo.h"
+
+using namespace boost::python;
+using namespace IECore;
+
+namespace
+{
+
+list parallelReadAll( const IndexedIO* src )
+{
+	IECore::IndexedIOAlgo::FileStats<size_t> stats = IECore::IndexedIOAlgo::parallelReadAll( src );
+
+	list result;
+	list blockCounts;
+	list blockSizes;
+
+	int maxBin = stats.maxNonZeroBin();
+
+	for( int i = 0; i <= maxBin; ++i )
+	{
+		blockCounts.append( stats.numBlocks[i] );
+		blockSizes.append( stats.numBytes[i] );
+	}
+
+	result.append( blockCounts );
+	result.append( blockSizes );
+
+	return result;
+}
+
+}
+
+namespace IECorePython
+{
+
+void bindIndexedIOAlgo()
+{
+
+	object module( borrowed( PyImport_AddModule( "IECore.IndexedIOAlgo" ) ) );
+	scope().attr( "IndexedIOAlgo" ) = module;
+
+	scope meshAlgoScope( module );
+
+	def( "copy", &IndexedIOAlgo::copy );
+	def( "parallelReadAll", &::parallelReadAll );
+}
+
+} //IECorePython
+
+

--- a/src/IECorePythonModule/IECore.cpp
+++ b/src/IECorePythonModule/IECore.cpp
@@ -155,6 +155,7 @@
 #include "IECorePython/PathMatcherBinding.h"
 #include "IECorePython/CancellerBinding.h"
 #include "IECorePython/TaskSchedulerInit.h"
+#include "IECorePython/IndexedIOAlgoBinding.h"
 
 #include "IECore/IECore.h"
 
@@ -297,6 +298,7 @@ BOOST_PYTHON_MODULE(_IECore)
 	bindPathMatcher();
 	bindCanceller();
 	bindTaskSchedulerInit();
+	bindIndexedIOAlgo();
 
 	def( "majorVersion", &IECore::majorVersion );
 	def( "minorVersion", &IECore::minorVersion );

--- a/test/IECore/All.py
+++ b/test/IECore/All.py
@@ -49,6 +49,7 @@ from CompoundObject import *
 from Imath import *
 from ImathVectorData import *
 from IndexedIO import *
+from IndexedIOAlgo import *
 from KDTree import *
 from BoundedKDTree import *
 from MessageHandler import *

--- a/test/IECore/IndexedIOAlgo.py
+++ b/test/IECore/IndexedIOAlgo.py
@@ -1,0 +1,193 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+
+import os
+import unittest
+import IECore
+
+
+class TestIndexedIOAlgo( unittest.TestCase ) :
+
+	def remove( self, paths ) :
+		for path in paths :
+			if os.path.isfile( path ) :
+				os.remove( path )
+
+	def setUp( self ) :
+		self.remove( ["./test/FileIndexedIO.fio", "./test/FileIndexedIO2.fio"] )
+
+	def tearDown( self ) :
+		self.remove( ["./test/FileIndexedIO.fio", "./test/FileIndexedIO2.fio"] )
+
+	def makeTestFile( self ) :
+		f = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Write )
+		f = f.subdirectory( "sub1", IECore.IndexedIO.MissingBehaviour.CreateIfMissing )
+
+		fv = IECore.FloatVectorData()
+
+		for n in range( 0, 1024 ) :
+			fv.append( n % 3 )
+
+		name = "myFloatVector"
+		f.write( name, fv )
+
+		del f
+
+		return fv
+
+	def makeManyDirectoryTestFile( self ) :
+		f = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Write )
+
+		for d in range( 512 ) :
+			subdir = f.subdirectory( "sub_{0}".format( d ), IECore.IndexedIO.MissingBehaviour.CreateIfMissing )
+
+			fv = IECore.FloatVectorData()
+
+			for n in range( d ) :
+				fv.append( n % 3 )
+
+			name = "myFloatVector"
+			subdir.write( name, fv )
+
+		del f
+
+
+	def testCanCopyFile( self ) :
+		fv = self.makeTestFile()
+		src = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Read )
+		dst = IECore.FileIndexedIO( "./test/FileIndexedIO2.fio", [], IECore.IndexedIO.OpenMode.Write )
+		IECore.IndexedIOAlgo.copy( src, dst )
+
+		del src
+		del dst
+
+		src = IECore.FileIndexedIO( "./test/FileIndexedIO2.fio", [], IECore.IndexedIO.OpenMode.Read )
+
+		sub1 = src.subdirectory( "sub1" )
+
+		name = "myFloatVector"
+		gv = sub1.read( name )
+
+		self.assertEqual( len( fv ), len( gv ) )
+
+		for n in range( 0, 1000 ) :
+			self.assertEqual( fv[n], gv[n] )
+
+	def testCanReadFileStats( self ) :
+		self.makeTestFile()
+		src = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Read )
+
+		# todo
+		# set thread count to 1
+
+		copyStats = IECore.IndexedIOAlgo.parallelReadAll( src )
+
+		self.assertEqual( copyStats[0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1] )
+		self.assertEqual( copyStats[1], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4096] )
+
+		self.makeManyDirectoryTestFile()
+		src2 = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Read )
+
+		# set thread count to 1
+		with IECore.tbb_task_scheduler_init( 1 ) as taskScheduler:
+			copyStats1thread = IECore.IndexedIOAlgo.parallelReadAll( src2 )
+
+		# set thread count to 8
+		with IECore.tbb_task_scheduler_init( 8 ) as taskScheduler:
+			copyStats8threads = IECore.IndexedIOAlgo.parallelReadAll( src2 )
+
+		self.assertEqual( copyStats1thread, copyStats8threads )
+
+		# 512 directories each containingn an increasing number of floats
+		# sub_0 : 0 * sizeof(4) = 1 block  = 0 bytes  [1,0]
+		#											  [0, 0] no blocks > 1 byte <= 2 bytes
+		# sub_1 : 1 * sizeof(4) = 1 block  = 4 bytes  [1,4]
+		# sub_2 : 2 * sizeof(4) = 2 blocks = 8 bytes  [1, 8]
+		# sub_3 : 3 * sizeof(4) = 3 blocks = 12 bytes
+		# sub_4 : 4 * sizeof(4) = 4 blocks = 16 bytes [2, 28]
+
+		self.assertEqual( copyStats1thread[0], [1, 0, 1, 1, 2, 4, 8, 16, 32, 64, 128, 255] )
+		self.assertEqual( copyStats1thread[1], [0, 0, 4, 8, 28, 104, 400, 1568, 6208, 24704, 98560, 391680] )
+
+	def testCopyFileWithVariousTypes( self ) :
+
+		f = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Write )
+		s = f.subdirectory( "sub", IECore.IndexedIO.MissingBehaviour.CreateIfMissing )
+
+		s.write( "intS", 1 )
+		s.write( "intA", IECore.IntVectorData( [0, 1, 2] ) )
+
+		s.write( "floatS", 1.0 )
+		s.write( "floatA", IECore.DoubleVectorData( [0.0, 1.0, 2.0] ) )
+
+		s.write( "stringS", "foo" )
+		s.write( "stringA", IECore.StringVectorData( ["foo_0", "foo_1", "foo_2"] ) )
+
+		del s, f
+
+		src = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Read )
+		dst = IECore.FileIndexedIO( "./test/FileIndexedIO2.fio", [], IECore.IndexedIO.OpenMode.Write )
+
+		IECore.IndexedIOAlgo.copy( src, dst )
+
+		del src, dst
+
+		f = IECore.FileIndexedIO( "./test/FileIndexedIO2.fio", [], IECore.IndexedIO.OpenMode.Read )
+		s = f.subdirectory( "sub", IECore.IndexedIO.MissingBehaviour.CreateIfMissing )
+
+		self.assertEqual( s.read( "intS" ), IECore.IntData( 1 ) )
+		self.assertEqual( s.read( "intA" ), IECore.IntVectorData( [0, 1, 2] ) )
+		self.assertEqual( s.read( "floatS" ), IECore.DoubleData( 1.0 ) )
+		self.assertEqual( s.read( "floatA" ), IECore.DoubleVectorData( [0.0, 1.0, 2.0] ) )
+		self.assertEqual( s.read( "stringS" ), IECore.StringData( "foo" ) )
+		self.assertEqual( s.read( "stringA" ), IECore.StringVectorData( ["foo_0", "foo_1", "foo_2"] ) )
+
+	def testStringFileStats( self ) :
+		f = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Write )
+		s = f.subdirectory( "sub", IECore.IndexedIO.MissingBehaviour.CreateIfMissing )
+
+		s.write( "stringS", "123456789" )
+		s.write( "stringA", IECore.StringVectorData( ["123", "123456", "123456789"] ) )
+
+		del s, f
+
+		src = IECore.FileIndexedIO( "./test/FileIndexedIO.fio", [], IECore.IndexedIO.OpenMode.Read )
+		stats = IECore.IndexedIOAlgo.parallelReadAll( src )
+
+		self.assertEqual( stats[0], [0, 0, 0, 0, 1, 1] )
+		self.assertEqual( stats[1], [0, 0, 0, 0, 9, 18] )
+
+if __name__ == "__main__" :
+	unittest.main()


### PR DESCRIPTION
Added new function to copy from one IndexedIO to another. 

This function has a few potential uses:
- low level performance testing 
- gathering stats on IndexedIO block sizes 
- updating IndexIO based files to newer formats


