### PR TITLE
SceneAlgo - copy

### DIFF
--- a/include/IECoreScene/SceneAlgo.h
+++ b/include/IECoreScene/SceneAlgo.h
@@ -1,0 +1,74 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORESCENE_SCENEALGO_H
+#define IECORESCENE_SCENEALGO_H
+
+#include "IECoreScene/Export.h"
+
+#include "IECoreScene/SceneInterface.h"
+
+#include <map>
+#include <string>
+
+namespace IECoreScene
+{
+
+namespace SceneAlgo
+{
+
+enum ProcessFlags
+{
+	None = 0,
+	Bounds = 1 << 0,
+	Transforms = 1 << 1,
+	Attributes = 1 << 2,
+	Tags = 1 << 3,
+	Sets = 1 << 4,
+	Objects = 1 << 5,
+	All = Bounds | Transforms | Attributes | Tags | Sets | Objects
+};
+
+typedef std::map<std::string, size_t> SceneStats;
+
+IECORESCENE_API SceneStats parallelReadAll( const SceneInterface *src, int startFrame, int endFrame, float frameRate, unsigned int flags );
+
+/// copy from one scene to another.
+IECORESCENE_API void copy( const SceneInterface *src, SceneInterface *dst, int startFrame, int endFrame, float frameRate, unsigned int flags );
+
+} // SceneAlgo
+
+} // IECoreScene
+
+#endif // IECORESCENE_SCENEALGO_H

--- a/src/IECoreScene/SceneAlgo.cpp
+++ b/src/IECoreScene/SceneAlgo.cpp
@@ -1,0 +1,295 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreScene/SceneAlgo.h"
+
+#include "IECoreScene/CurvesPrimitive.h"
+#include "IECoreScene/MeshPrimitive.h"
+#include "IECoreScene/PointsPrimitive.h"
+#include "IECoreScene/SceneInterface.h"
+
+#include "tbb/task.h"
+
+#include <atomic>
+
+using namespace IECore;
+using namespace IECoreScene;
+
+namespace
+{
+
+template<typename LocationFn>
+class Task : public tbb::task
+{
+
+	public :
+
+		Task(
+			const SceneInterface *src, SceneInterface *dst, LocationFn &locationFn, double time, unsigned int flags
+		) : m_src( src ), m_dst( dst ), m_locationFn( locationFn ), m_time( time ), m_flags( flags )
+		{
+		}
+
+		~Task() override
+		{
+		}
+
+		task *execute() override
+		{
+			m_locationFn( m_src, m_dst, m_time, m_flags );
+
+			SceneInterface::NameList childNames;
+			m_src->childNames( childNames );
+
+			set_ref_count( 1 + childNames.size() );
+
+			std::vector<SceneInterfacePtr> childSceneInterfaces;
+			childSceneInterfaces.reserve( childNames.size() );
+
+			std::vector<ConstSceneInterfacePtr> srcChildSceneInterfaces;
+			srcChildSceneInterfaces.reserve( childNames.size() );
+
+			for( const auto &childName : childNames )
+			{
+				SceneInterfacePtr dstChild = m_dst ? m_dst->child( childName, SceneInterface::CreateIfMissing ) : nullptr;
+				if( dstChild )
+				{
+					childSceneInterfaces.push_back( dstChild );
+				}
+
+				ConstSceneInterfacePtr srcChild = m_src->child( childName );
+				srcChildSceneInterfaces.push_back( srcChild );
+
+				Task *t = new( allocate_child() ) Task( srcChild.get(), dstChild.get(), m_locationFn, m_time, m_flags );
+				spawn( *t );
+			}
+			wait_for_all();
+
+			return nullptr;
+		}
+
+	private :
+
+		const SceneInterface *m_src;
+		SceneInterface *m_dst;
+		LocationFn &m_locationFn;
+		double m_time;
+		unsigned int m_flags;
+
+};
+
+template<typename T>
+struct CopyInfo
+{
+	CopyInfo() : polygonCount( 0 ), curveCount( 0 ), pointCount( 0 ), attributeCount( 0 ), tagCount( 0 ), setCount( 0 )
+	{
+	}
+
+	T polygonCount;
+	T curveCount;
+	T pointCount;
+
+	T attributeCount;
+	T tagCount;
+	T setCount;
+};
+
+CopyInfo<size_t> handleLocation( const SceneInterface *src, SceneInterface *dst, double time, unsigned int flags )
+{
+	SceneInterface::Path path;
+	src->path( path );
+	bool isRoot = path.empty();
+	CopyInfo<size_t> copyInfo;
+
+	if( flags & SceneAlgo::Bounds )
+	{
+		auto bound = src->readBound( time );
+		if( dst )
+		{
+			dst->writeBound( bound, time );
+		}
+	}
+
+	if( flags & SceneAlgo::Transforms )
+	{
+		IECore::ConstDataPtr transform = src->readTransform( time );
+		if( dst && !isRoot )
+		{
+			dst->writeTransform( transform.get(), time );
+		}
+	}
+
+	if( flags & SceneAlgo::Attributes )
+	{
+		SceneInterface::NameList attributeNames;
+		src->attributeNames( attributeNames );
+
+		copyInfo.attributeCount += attributeNames.size();
+		for( const auto &attributeName : attributeNames )
+		{
+			IECore::ConstObjectPtr attr = src->readAttribute( attributeName, time );
+			if( dst )
+			{
+				dst->writeAttribute( attributeName, attr.get(), time );
+			}
+		}
+	}
+
+	if( flags & SceneAlgo::Tags )
+	{
+		SceneInterface::NameList tags;
+		src->readTags( tags );
+		copyInfo.tagCount += tags.size();
+		if( dst )
+		{
+			dst->writeTags( tags );
+		}
+	}
+
+	if( flags & SceneAlgo::Sets && isRoot )
+	{
+		SceneInterface::NameList setNames = src->setNames();
+		copyInfo.setCount += setNames.size();
+		for( const auto &setName : setNames )
+		{
+			PathMatcher set = src->readSet( setName );
+			if( dst )
+			{
+				dst->writeSet( setName, set );
+			}
+		}
+	}
+
+	if( flags & SceneAlgo::Objects && src->hasObject() )
+	{
+		IECore::ConstObjectPtr obj = src->readObject( time );
+
+		if( IECoreScene::MeshPrimitive::ConstPtr mesh = IECore::runTimeCast<const IECoreScene::MeshPrimitive>( obj ) )
+		{
+			copyInfo.polygonCount += mesh->numFaces();
+		}
+		else if( IECoreScene::CurvesPrimitive::ConstPtr curves = IECore::runTimeCast<const IECoreScene::CurvesPrimitive>( obj ) )
+		{
+			copyInfo.curveCount += curves->numCurves();
+		}
+		else if( IECoreScene::PointsPrimitive::ConstPtr points = IECore::runTimeCast<const IECoreScene::PointsPrimitive>( obj ) )
+		{
+			copyInfo.pointCount += points->getNumPoints();
+		}
+		if( dst )
+		{
+			dst->writeObject( obj.get(), time );
+		}
+	}
+
+	return copyInfo;
+
+}
+
+template<typename LocationFn>
+void copy( const SceneInterface *src, SceneInterface *dst, double time, unsigned int flags, LocationFn &locationFn )
+{
+	locationFn( src, dst, time, flags );
+
+	SceneInterface::NameList childNames;
+	src->childNames( childNames );
+
+	for( const auto &childName : childNames )
+	{
+		SceneInterfacePtr dstChild = dst->child( childName, SceneInterface::CreateIfMissing );
+		::copy( src->child( childName ).get(), dstChild.get(), time, flags, locationFn );
+	}
+}
+
+} // namespace
+
+namespace IECoreScene
+{
+
+namespace SceneAlgo
+{
+
+SceneStats parallelReadAll( const SceneInterface *src, int startFrame, int endFrame, float frameRate, unsigned int flags )
+{
+	std::atomic<size_t> locationCount( 0 );
+	::CopyInfo<std::atomic<size_t> > copyInfos;
+
+	auto locationFn = [&locationCount, &copyInfos]( const SceneInterface *src, SceneInterface *dst, double time, unsigned int flags )
+	{
+		locationCount++;
+		::CopyInfo<size_t> copyInfo = ::handleLocation( src, nullptr, time, flags );
+
+		copyInfos.polygonCount += copyInfo.polygonCount;
+		copyInfos.tagCount += copyInfo.tagCount;
+		copyInfos.attributeCount += copyInfo.attributeCount;
+		copyInfos.curveCount += copyInfo.curveCount;
+		copyInfos.pointCount += copyInfo.pointCount;
+	};
+
+	for( int f = startFrame; f <= endFrame; ++f )
+	{
+		double time = f / frameRate;
+		Task<decltype( locationFn )> *task = new( tbb::task::allocate_root() ) Task<decltype( locationFn )>( src, nullptr, locationFn, time, flags );
+		tbb::task::spawn_root_and_wait( *task );
+	}
+
+	SceneStats stats;
+	stats["locations"] = locationCount;
+	stats["polygons"] = copyInfos.polygonCount;
+	stats["curves"] = copyInfos.curveCount;
+	stats["points"] = copyInfos.pointCount;
+	stats["tags"] = copyInfos.tagCount;
+	stats["sets"] = copyInfos.setCount;
+	stats["attributes"] = copyInfos.attributeCount;
+	return stats;
+}
+
+void copy( const SceneInterface *src, SceneInterface *dst, int startFrame, int endFrame, float frameRate, unsigned int flags )
+{
+	for( int f = startFrame; f <= endFrame; ++f )
+	{
+		double time = f / frameRate;
+		// disable copying tags for all frame apart from the first.
+		if( f != startFrame )
+		{
+			flags &= ~Tags;
+		}
+
+		::copy( src, dst, time, flags, ::handleLocation );
+	}
+}
+
+} // SceneAlgo
+
+} // IECoreScene

--- a/src/IECoreScene/bindings/IECoreScene.cpp
+++ b/src/IECoreScene/bindings/IECoreScene.cpp
@@ -117,6 +117,7 @@
 #include "TypedObjectParameterBinding.h"
 #include "TypedPrimitiveOpBinding.h"
 #include "VisibleRenderableBinding.h"
+#include "SceneAlgoBinding.h"
 
 #include "tbb/tbb_thread.h"
 
@@ -216,5 +217,6 @@ BOOST_PYTHON_MODULE(_IECoreScene)
 	bindPointsAlgo();
 	bindTypedObjectParameter();
 	bindTypeId();
+	bindSceneAlgo();
 
 }

--- a/src/IECoreScene/bindings/SceneAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/SceneAlgoBinding.cpp
@@ -1,0 +1,97 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "SceneAlgoBinding.h"
+
+#include "IECoreScene/SceneAlgo.h"
+
+#include "IECorePython/ScopedGILRelease.h"
+
+
+using namespace boost::python;
+using namespace IECore;
+using namespace IECoreScene;
+
+namespace
+{
+
+dict parallelReadAll( const SceneInterface *src, int startFrame, int endFrame, float frameRate, unsigned int flags )
+{
+	SceneAlgo::SceneStats stats;
+	{
+		IECorePython::ScopedGILRelease scopedGILRelease;
+		stats = SceneAlgo::parallelReadAll( src, startFrame, endFrame, frameRate, flags );
+	}
+
+	dict result;
+	for (const auto &stat : stats )
+	{
+		result[stat.first] = stat.second;
+	}
+
+	return result;
+}
+
+} // namespace
+
+namespace IECoreSceneModule
+{
+
+void bindSceneAlgo()
+{
+	object module( borrowed( PyImport_AddModule( "IECoreScene.SceneAlgo" ) ) );
+	scope().attr( "SceneAlgo" ) = module;
+
+	scope _scope( module );
+
+	enum_< SceneAlgo::ProcessFlags > ("ProcessFlags")
+		.value("None", SceneAlgo::None )
+		.value("Bounds", SceneAlgo::Bounds )
+		.value("Transforms", SceneAlgo::Transforms )
+		.value("Attributes", SceneAlgo::Attributes )
+		.value("Tags", SceneAlgo::Tags )
+		.value("Sets", SceneAlgo::Sets )
+		.value("Objects", SceneAlgo::Objects)
+		.value("All", SceneAlgo::All)
+		.export_values()
+		;
+
+	def( "copy", &SceneAlgo::copy );
+
+	def( "parallelReadAll", &::parallelReadAll);
+}
+
+} // namespace IECoreSceneModule

--- a/src/IECoreScene/bindings/SceneAlgoBinding.h
+++ b/src/IECoreScene/bindings/SceneAlgoBinding.h
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORESCENEMODULE_SCENEALGOBINDING_H
+#define IECORESCENEMODULE_SCENEALGOBINDING_H
+
+namespace IECoreSceneModule
+{
+
+void bindSceneAlgo();
+
+}
+
+#endif // IECORESCENEMODULE_SCENEALGOBINDING_H

--- a/test/IECoreScene/All.py
+++ b/test/IECoreScene/All.py
@@ -106,6 +106,7 @@ from MeshAlgoTest import *
 from CurvesAlgoTest import *
 from PointsAlgoTest import *
 from ObjectInterpolationTest import ObjectInterpolationTest
+from SceneAlgo import *
 
 if IECore.withFreeType() :
 	from FontTest import *

--- a/test/IECoreScene/SceneAlgo.py
+++ b/test/IECoreScene/SceneAlgo.py
@@ -1,0 +1,173 @@
+##########################################################################
+#
+#  Copyright (c) 2013-2014, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+
+import unittest
+import IECore
+import IECoreScene
+
+import imath
+
+
+class SceneAlgoTest( unittest.TestCase ) :
+	__testFile = "/tmp/test.scc"
+	__testFile2 = "/tmp/test2.scc"
+
+	def writeSCC( self ) :
+		m = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Write )
+		m.writeAttribute( "w", IECore.BoolData( True ), 1.0 )
+
+		t = m.createChild( "t" )
+		t.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ), 1.0 )
+		t.writeAttribute( "wuh", IECore.BoolData( True ), 1.0 )
+
+		s = t.createChild( "s" )
+		s.writeObject( IECoreScene.SpherePrimitive( 1 ), 1.0 )
+		s.writeAttribute( "glah", IECore.IntData( 15 ), 1.0 )
+
+		s.writeTags( ["tagA", "tagB"] )
+
+		del s, t, m
+
+
+	def writeBigSCC( self ):
+		m = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Write )
+		t = m.createChild( "t" )
+
+		for i in range(4096):
+			box = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(-i,-i,-i), imath.V3f(i,i,i)))
+			r = t.createChild("t{0}".format(i))
+			r.writeObject( box, 1.0 )
+			r.writeAttribute("foo", IECore.IntData(1), 1.0)
+
+	def testCopySceneHierarchyOnly( self ) :
+		self.writeSCC()
+
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Read )
+		dst = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Write )
+
+		IECoreScene.SceneAlgo.copy( src, dst, 1, 1, 1.0, IECoreScene.SceneAlgo.ProcessFlags.None )
+
+		del src, dst
+
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( src.childNames(), ['t'] )
+		self.assertFalse( src.hasAttribute( "w" ) )
+
+		t = src.child( "t" )
+
+		self.assertEqual( t.readTransform( 1.0 ), IECore.M44dData( imath.M44d() ) )
+		self.assertFalse( t.hasAttribute( "wuh" ) )
+
+		self.assertEqual( t.childNames(), ["s"] )
+		s = t.child( "s" )
+		self.assertFalse( s.hasObject() )
+		self.assertFalse( s.hasAttribute( "glah" ) )
+
+		self.assertEqual( s.readTags(), [] )
+
+	def testCopySceneEverything( self ) :
+		self.writeSCC()
+
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Read )
+		dst = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Write )
+
+		IECoreScene.SceneAlgo.copy( src, dst, 1, 1, 1.0, IECoreScene.SceneAlgo.ProcessFlags.All )
+
+		del src, dst
+
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( src.childNames(), ['t'] )
+		self.assertTrue( src.hasAttribute( "w" ) )
+
+		t = src.child( "t" )
+
+		self.assertEqual( t.readTransform( 1.0 ), IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) ) )
+		self.assertTrue( t.hasAttribute( "wuh" ) )
+		self.assertEqual( t.readAttribute( "wuh", 1.0 ), IECore.BoolData( True ) )
+
+		self.assertEqual( t.childNames(), ["s"] )
+		s = t.child( "s" )
+		self.assertTrue( s.hasObject() )
+
+		object = s.readObject( 1.0 )
+		self.assertIsInstance( object, IECoreScene.SpherePrimitive )
+
+		self.assertTrue( s.hasAttribute( "glah" ) )
+		self.assertEqual( s.readAttribute( "glah", 1.0 ), IECore.IntData( 15 ) )
+
+		self.assertTrue( "tagA" in s.readTags() )
+		self.assertTrue( "tagB" in s.readTags() )
+
+
+	def testMultithreadedCopy( self ):
+		self.writeBigSCC()
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Read )
+		dst = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Write )
+
+		with IECore.tbb_task_scheduler_init(max_threads = 15) as taskScheduler:
+			IECoreScene.SceneAlgo.copy( src, dst, 1, 1, 1.0, IECoreScene.SceneAlgo.ProcessFlags.All )
+
+		del dst, src
+
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile2, IECore.IndexedIO.OpenMode.Read )
+
+		t = src.child("t")
+		self.assertEqual( len( t.childNames()), 4096 )
+
+
+	def testMultithreadedRead( self ):
+
+		self.writeBigSCC()
+		src = IECoreScene.SceneCache( SceneAlgoTest.__testFile, IECore.IndexedIO.OpenMode.Read )
+
+		for t in range(1, 16):
+			# set thread
+			with IECore.tbb_task_scheduler_init(max_threads = t) as taskScheduler:
+				stats = IECoreScene.SceneAlgo.parallelReadAll( src, 1, 1, 1.0, IECoreScene.SceneAlgo.ProcessFlags.All )
+
+				self.assertEqual(stats["locations"], 4096 + 2)
+				self.assertEqual(stats["polygons"], 4096 * 6 ) # 4096 cubes each with 6 faces
+				self.assertEqual(stats["curves"], 0)
+				self.assertEqual(stats["points"], 0)
+				self.assertEqual(stats["tags"], 4096 ) # default tag for polygon mesh
+				self.assertEqual(stats["sets"], 0)
+				self.assertEqual(stats["attributes"], 4096 * 2 )  # default attribute & custom attribute 'foo'
+
+
+
+if __name__ == "__main__" :
+	unittest.main()


### PR DESCRIPTION
Utility function to copy from one scene interface to another. This is useful for SceneInterface performance tests.


