### PR TITLE
LiveScene : Allow maya defined attributes on SceneShapes

### DIFF
--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -461,7 +461,7 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 	for ( std::vector< CustomAttributeReader >::const_reverse_iterator it = attributeReaders.rbegin(); it != attributeReaders.rend(); ++it )
 	{
 		ConstObjectPtr attr = it->m_read( m_dagPath, name );
-		if( !attr )
+		if( !attr || attr == IECore::NullObject::defaultNullObject() )
 		{
 			continue;
 		}


### PR DESCRIPTION
If an attribute is defined on a SceneShape then we report it correctly in the SceneInterface::AttributeNames but it's always IECore::NullObject::defaultNullObject(). 

This is a hopefully an inelegant but reasonably low risk change which allows the maya defined value to queried from LiveScene. 