### PR TITLE
IECore : StreamIndexedIO - platform specific offset read if possible.

### DIFF
--- a/include/IECore/StreamIndexedIO.h
+++ b/include/IECore/StreamIndexedIO.h
@@ -52,7 +52,6 @@
 namespace IECore
 {
 
-class PlatformReader;
 
 /// Abstract base class implementation of IndexedIO which operates with a stream file handle.
 /// It handles data instancing transparently for compact file sizes.
@@ -151,6 +150,8 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 		void read(const IndexedIO::EntryID &name, unsigned char &x) const override;
 		void read(const IndexedIO::EntryID &name, short &x) const override;
 		void read(const IndexedIO::EntryID &name, unsigned short &x) const override;
+
+		class PlatformReader;
 
 	protected:
 

--- a/include/IECore/StreamIndexedIO.h
+++ b/include/IECore/StreamIndexedIO.h
@@ -51,6 +51,9 @@
 
 namespace IECore
 {
+
+class PlatformReader;
+
 /// Abstract base class implementation of IndexedIO which operates with a stream file handle.
 /// It handles data instancing transparently for compact file sizes.
 /// Read operations are thread safe on read-only opened files.
@@ -165,6 +168,11 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 			public:
 				~StreamFile() override;
 
+				/// read 'size' bytes at 'pos' offset in the file into buffer
+				/// favour this method over seekg / read as it will not lock
+				/// see 'setInput'
+				void read( char *buffer, size_t size, size_t pos);
+
 				void seekg( size_t pos, std::ios_base::seekdir dir );
 				void seekp( size_t pos, std::ios_base::seekdir dir );
 				void read( char *buffer, size_t size );
@@ -190,9 +198,10 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 			protected:
 
 				StreamFile( IndexedIO::OpenMode mode );
-				/// called once after construction. Assigns a stream and tells if the stream is empty.
-				// This function allocates and if in read-mode also reads the Index of the file.
-				void setStream( std::iostream *stream, bool emptyFile );
+
+				/// Called during construction of derived classes. Assigns a stream and tells if the stream is empty.
+				/// Optionally provide a filename to use for lock free reading
+				void setInput( std::iostream *stream, bool emptyFile, const std::string& fileName );
 
 				IndexedIO::OpenMode m_openmode;
 				std::iostream *m_stream;
@@ -200,6 +209,10 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 
 				unsigned long m_ioBufferLen;
 				char *m_ioBuffer;
+
+				/// platform specific utility object to provide lock free reads to the referenced
+				/// stream. Can be null and the locking stream reads will be used.
+				std::unique_ptr<PlatformReader> m_platformReader;
 		};
 		IE_CORE_DECLAREPTR( StreamFile );
 

--- a/src/IECore/FileIndexedIO.cpp
+++ b/src/IECore/FileIndexedIO.cpp
@@ -79,7 +79,7 @@ FileIndexedIO::StreamFile::StreamFile( const std::string &filename, IndexedIO::O
 		{
 			throw IOException( "FileIndexedIO: Cannot open '" + filename + "' for writing" );
 		}
-		setStream( f, true );
+		setInput( f, true, "");
 	}
 	else if (mode & IndexedIO::Append)
 	{
@@ -92,7 +92,7 @@ FileIndexedIO::StreamFile::StreamFile( const std::string &filename, IndexedIO::O
 			{
 				throw IOException( "FileIndexedIO: Cannot open '" + filename + "' for append" );
 			}
-			setStream( f, true );
+			setInput( f, true, "" );
 		}
 		else
 		{
@@ -106,7 +106,7 @@ FileIndexedIO::StreamFile::StreamFile( const std::string &filename, IndexedIO::O
 
 			try
 			{
-				setStream( f, false );
+				setInput( f, false, filename);
 			}
 			catch ( Exception &e )
 			{
@@ -132,7 +132,7 @@ FileIndexedIO::StreamFile::StreamFile( const std::string &filename, IndexedIO::O
 
 		try
 		{
-			setStream( f, false );
+			setInput( f, false, filename );
 		}
 		catch ( Exception &e )
 		{

--- a/src/IECore/MemoryIndexedIO.cpp
+++ b/src/IECore/MemoryIndexedIO.cpp
@@ -68,7 +68,7 @@ MemoryIndexedIO::StreamFile::StreamFile( const char *buf, size_t size, IndexedIO
 	if (mode & IndexedIO::Write)
 	{
 		std::stringstream *f = new std::stringstream( std::ios::trunc | std::ios::binary | std::ios::in | std::ios::out );
-		setStream( f, true );
+		setInput( f, true, "" );
 	}
 	else if (mode & IndexedIO::Append)
 	{
@@ -76,7 +76,7 @@ MemoryIndexedIO::StreamFile::StreamFile( const char *buf, size_t size, IndexedIO
 		{
 			/// Create new file
 			std::stringstream *f = new std::stringstream(  std::ios::trunc | std::ios::binary | std::ios::in | std::ios::out );
-			setStream( f, true );
+			setInput( f, true, "" );
 		}
 		else
 		{
@@ -85,7 +85,7 @@ MemoryIndexedIO::StreamFile::StreamFile( const char *buf, size_t size, IndexedIO
 
 			/// Read existing file
 			std::stringstream *f = new std::stringstream( std::string(buf, size), std::ios::binary | std::ios::in | std::ios::out );
-			setStream( f, false );
+			setInput( f, false, "" );
 		}
 	}
 	else
@@ -93,7 +93,7 @@ MemoryIndexedIO::StreamFile::StreamFile( const char *buf, size_t size, IndexedIO
 		assert( buf );
 		assert( mode & IndexedIO::Read );
 		std::stringstream *f = new std::stringstream( std::string(buf, size), std::ios::binary | std::ios::in | std::ios::out );
-		setStream( f, false );
+		setInput( f, false, "" );
 	}
 }
 

--- a/src/IECore/StreamIndexedIO.cpp
+++ b/src/IECore/StreamIndexedIO.cpp
@@ -149,7 +149,7 @@ namespace IECore
 {
 
 /// Base class for providing lock free reads
-class PlatformReader
+class StreamIndexedIO::PlatformReader
 {
 	public:
 		virtual ~PlatformReader();
@@ -158,7 +158,7 @@ class PlatformReader
 };
 
 /// Posix Reader for Linux & OSX
-class PosixPlatformReader : public PlatformReader
+class PosixPlatformReader : public StreamIndexedIO::PlatformReader
 {
 	public:
 		~PosixPlatformReader();
@@ -168,14 +168,14 @@ class PosixPlatformReader : public PlatformReader
 		int m_fileHandle;
 };
 
-PlatformReader::~PlatformReader()
+StreamIndexedIO::PlatformReader::~PlatformReader()
 {
 }
 
-std::unique_ptr<PlatformReader> PlatformReader::create( const std::string& fileName )
+std::unique_ptr<StreamIndexedIO::PlatformReader> StreamIndexedIO::PlatformReader::create( const std::string& fileName )
 {
 	PlatformReader* p = new PosixPlatformReader( fileName );
-	return std::unique_ptr<PlatformReader>(p);
+	return std::unique_ptr<StreamIndexedIO::PlatformReader>(p);
 }
 
 PosixPlatformReader::PosixPlatformReader( const std::string &fileName )

--- a/src/IECore/StreamIndexedIO.cpp
+++ b/src/IECore/StreamIndexedIO.cpp
@@ -59,6 +59,8 @@
 #include <map>
 #include <set>
 
+#include <fcntl.h>
+#include <unistd.h>
 #include <stdint.h>
 
 #define HARDLINK				127
@@ -142,6 +144,63 @@ void readLittleEndian( F &f, T &n )
 		/// Already little endian
 	}
 }
+
+namespace IECore
+{
+
+/// Base class for providing lock free reads
+class PlatformReader
+{
+	public:
+		virtual ~PlatformReader();
+		virtual bool read( char *buffer, size_t size, size_t pos ) = 0;
+		static std::unique_ptr<PlatformReader> create( const std::string &fileName );
+};
+
+/// Posix Reader for Linux & OSX
+class PosixPlatformReader : public PlatformReader
+{
+	public:
+		~PosixPlatformReader();
+		PosixPlatformReader( const std::string &fileName );
+		bool read( char *buffer, size_t size, size_t pos ) override;
+	private:
+		int m_fileHandle;
+};
+
+PlatformReader::~PlatformReader()
+{
+}
+
+std::unique_ptr<PlatformReader> PlatformReader::create( const std::string& fileName )
+{
+	PlatformReader* p = new PosixPlatformReader( fileName );
+	return std::unique_ptr<PlatformReader>(p);
+}
+
+PosixPlatformReader::PosixPlatformReader( const std::string &fileName )
+{
+	m_fileHandle = ::open( fileName.c_str(), O_RDONLY);
+}
+
+PosixPlatformReader::~PosixPlatformReader()
+{
+	::close(m_fileHandle);
+}
+
+bool PosixPlatformReader::read( char *buffer, size_t size, size_t pos )
+{
+	ssize_t result = pread(m_fileHandle, buffer, size, pos);
+
+	if (result < 0)
+	{
+		return false;
+	}
+
+	return (size_t) result == size;
+}
+
+}// IECore
 
 class StreamIndexedIO::StringCache
 {
@@ -2025,12 +2084,17 @@ IndexedIO::OpenMode StreamIndexedIO::StreamFile::openMode() const
 	return m_openmode;
 }
 
-void StreamIndexedIO::StreamFile::setStream( std::iostream *stream, bool emptyFile )
+void StreamIndexedIO::StreamFile::setInput( std::iostream *stream, bool emptyFile, const std::string& fileName )
 {
 	m_stream = stream;
 	if ( m_openmode & IndexedIO::Append && emptyFile )
 	{
 		m_openmode = (m_openmode ^ IndexedIO::Append) | IndexedIO::Write;
+	}
+
+	if ( fileName != "" && getenv("IECORE_OFFSETREAD_DISABLED") == nullptr )
+	{
+		m_platformReader = PlatformReader::create( fileName );
 	}
 }
 
@@ -2078,6 +2142,16 @@ bool StreamIndexedIO::StreamFile::canRead( std::iostream &f )
 	else
 	{
 		return false;
+	}
+}
+
+void StreamIndexedIO::StreamFile::read( char *buffer, size_t size, size_t pos )
+{
+	if ( !m_platformReader || ( !m_platformReader->read( buffer, size, pos ) ) )
+	{
+		MutexLock lock( m_mutex );
+		seekg( pos, std::ios::beg );
+		read( buffer, size );
 	}
 }
 
@@ -2498,20 +2572,7 @@ void StreamIndexedIO::read(const IndexedIO::EntryID &name, InternedString *&x, u
 	Imf::Int64 *ids = new Imf::Int64[arrayLength];
 
 	StreamIndexedIO::StreamFile &f = streamFile();
-	{
-		StreamFile::MutexLock lock( f.mutex() );
-		f.seekg( dataOffset, std::ios::beg );
-
-#ifdef IE_CORE_LITTLE_ENDIAN
-		// raw read
-		f.read( (char*)ids, dataSize );
-	}
-#else
-		char *data = f.ioBuffer(dataSize);
-		f.read( data, dataSize );
-	}
-	IndexedIO::DataFlattenTraits<Imf::Int64*>::unflatten( data, ids, arrayLength );
-#endif
+	f.read( (char*) ids, dataSize, dataOffset );
 
 	const StringCache &stringCache = m_node->m_idx->stringCache();
 	if (!x)
@@ -2603,14 +2664,9 @@ void StreamIndexedIO::read(const IndexedIO::EntryID &name, T *&x, unsigned long 
 		throw IOException( "StreamIndexedIO::read: Data entry not found '" + name.value() + "'" );
 	}
 
-	StreamIndexedIO::StreamFile &f = streamFile();
-	{
-		StreamFile::MutexLock lock( f.mutex() );
-		char *data = f.ioBuffer(dataSize);
-		f.seekg( dataOffset, std::ios::beg );
-		f.read( data, dataSize );
-		IndexedIO::DataFlattenTraits<T*>::unflatten( data, x, arrayLength );
-	}
+	std::vector<char> buffer ( dataSize );
+	streamFile().read( buffer.data(), dataSize, dataOffset );
+	IndexedIO::DataFlattenTraits<T*>::unflatten( buffer.data(), x, arrayLength );
 }
 
 template<typename T>
@@ -2631,12 +2687,7 @@ void StreamIndexedIO::rawRead(const IndexedIO::EntryID &name, T *&x, unsigned lo
 		x = new T[arrayLength];
 	}
 
-	StreamIndexedIO::StreamFile &f = streamFile();
-	{
-		StreamFile::MutexLock lock( f.mutex() );
-		f.seekg( dataOffset, std::ios::beg );
-		f.read( (char*)x, dataSize );
-	}
+	streamFile().read( (char*) x, dataSize, dataOffset);
 }
 
 template<typename T>
@@ -2652,14 +2703,11 @@ void StreamIndexedIO::read(const IndexedIO::EntryID &name, T &x) const
 		throw IOException( "StreamIndexedIO::read Data entry not found '" + name.value() + "'" );
 	}
 
-	StreamIndexedIO::StreamFile &f = streamFile();
-	{
-		StreamFile::MutexLock lock( f.mutex() );
-		char *data = f.ioBuffer(dataSize);
-		f.seekg( dataOffset, std::ios::beg );
-		f.read( data, dataSize );
-		IndexedIO::DataFlattenTraits<T>::unflatten( data, x );
-	}
+	std::vector<char> buffer(dataSize);
+
+	streamFile().read( buffer.data(), dataSize, dataOffset);
+	IndexedIO::DataFlattenTraits<T>::unflatten( buffer.data(), x );
+
 }
 
 template<typename T>
@@ -2675,12 +2723,7 @@ void StreamIndexedIO::rawRead(const IndexedIO::EntryID &name, T &x) const
 		throw IOException( "StreamIndexedIO::rawRead: Data entry not found '" + name.value() + "'" );
 	}
 
-	StreamIndexedIO::StreamFile &f = streamFile();
-	{
-		StreamFile::MutexLock lock( f.mutex() );
-		f.seekg( dataOffset, std::ios::beg );
-		f.read( (char*)&x, dataSize );
-	}
+	streamFile().read( (char*)&x, dataSize, dataOffset);
 }
 
 #ifdef IE_CORE_LITTLE_ENDIAN


### PR DESCRIPTION
IndexedIO reads were basically serial. Note this change does not go far enough to fix multithreaded performance in IndexedIO but introducing large scale changes feels unwise at this point in the cortex 10 release cycle.

- The seekg & read functions are left in place as the are used for index loading
- renamed setStream to setInput to reflect the change in behaviour
- Added private PlatformReader abstraction for housing platform specific calls
- IECORE_OFFSETREAD_DISABLED environment variable can be set to disable the **offset read** code path for comparative profiling.

Test Data generated using the IndexedIOAlgo & SceneAlgo copy functions in https://github.com/ImageEngine/cortex/pull/766 and https://github.com/ImageEngine/cortex/pull/767

#### Performance before this PR (IECORE_OFFSETREAD_DISABLED =1)

thread count  | IndexedIO read time / ms  | SceneInterface read time / ms
------------------| ------------------------------------|-------------
1                    | 398.2                                 | 1286.0
2                    | 521.8                                 | 1615.0
4                    | 621.6                                 | 1865.8
8                    | 640.0                                 | 1714.9
16                  | 591.5                                 | 1697.8

#### Performance after this PR ((IECORE_OFFSETREAD_DISABLED =0)

thread count  | IndexedIO read time / ms  | SceneInterface read time / ms
------------------| ------------------------------------|-------------
1                    | 304.8                                 | 963.6
2                    | 207.7                                 | 650.5 
4                    | 131.0                                 | 420.5
8                    | 72.7                                   | 300.3   
16                  | 63.7                                   | 256.2
