### PR TITLE
LiveScene - maya ieAttr_* should override custom readers. 

### DIFF
--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -458,17 +458,6 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 		return new BoolData( true );
 	}
 
-	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
-	for ( std::vector< CustomAttributeReader >::const_reverse_iterator it = attributeReaders.rbegin(); it != attributeReaders.rend(); ++it )
-	{
-		ConstObjectPtr attr = it->m_read( m_dagPath, name );
-		if( !attr )
-		{
-			continue;
-		}
-		return attr;
-	}
-
 	if( strstr( name.c_str(), "user:" ) == name.c_str() )
 	{
 
@@ -484,6 +473,17 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 			}
 			return plugConverter->convert();
 		}
+	}
+
+	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
+	for ( std::vector< CustomAttributeReader >::const_reverse_iterator it = attributeReaders.rbegin(); it != attributeReaders.rend(); ++it )
+	{
+		ConstObjectPtr attr = it->m_read( m_dagPath, name );
+		if( !attr )
+		{
+			continue;
+		}
+		return attr;
 	}
 
 	return IECore::NullObject::defaultNullObject();

--- a/src/IECoreMaya/SceneShape.cpp
+++ b/src/IECoreMaya/SceneShape.cpp
@@ -303,7 +303,7 @@ ConstObjectPtr SceneShape::readSceneShapeAttribute( const MDagPath &p, SceneInte
 	SceneShape *sceneShape = findScene( p, false, &dagPath );
 	if ( !sceneShape )
 	{
-		return 0;
+		return nullptr;
 	}
 
 	MFnDagNode fnChildDag( dagPath );

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -874,8 +874,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 			self.assertEqual( len( transformScene.attributeNames() ), 2 )
 			self.assertEqual( set( transformScene.attributeNames() ), set( ["scene:visible", "user:test"] ) )
 
-			# The custom reader should override the ieAttr_
-			self.failUnless( isinstance( transformScene.readAttribute( "user:test", 0 ), IECore.IntData ) )
+			# The ieAttr_ should override the custom reader
+			self.failUnless( isinstance( transformScene.readAttribute( "user:test", 0 ), IECore.BoolData ) )
 		finally:
 			doDuplicateNameTest = False
 


### PR DESCRIPTION
Nobody can remember why the custom reader took priority over the maya defined ieAttr_* attributes and everyone here thinks it should be the other way around.