### PR TITLE
IECore : Add Canceller class

### DIFF
--- a/include/IECore/Canceller.h
+++ b/include/IECore/Canceller.h
@@ -1,0 +1,107 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORE_CANCELLER_H
+#define IECORE_CANCELLER_H
+
+#include "IECore/Export.h"
+
+#include "boost/noncopyable.hpp"
+
+#include <atomic>
+
+namespace IECore
+{
+
+/// Exception thrown by `Canceller::check()`.
+/// Deliberately _not_ derived from `std::exception`
+/// to minimise the chances of it being accidentally
+/// suppressed or mistaken for an error. In typical
+/// use there is no need to catch exceptions of this
+/// type.
+struct Cancelled
+{
+};
+
+/// Class used to cancel long-running background
+/// operations.
+///
+/// Example :
+///
+/// ```
+/// Canceller c;
+/// thread t(
+///     [&c] {
+///         while( 1 ) {
+///             Canceller::check( &c );
+///         }
+///     }
+/// );
+/// c.cancel();
+/// t.join();
+/// ```
+class IECORE_API Canceller : public boost::noncopyable
+{
+
+	public :
+
+		Canceller()
+			:	m_cancelled( false )
+		{
+		}
+
+		void cancel()
+		{
+			m_cancelled = true;
+		}
+
+		static void check( const Canceller *canceller )
+		{
+			/// \todo Can we reduce overhead by reading
+			/// with a more relaxed memory ordering here?
+			if( canceller && canceller->m_cancelled )
+			{
+				throw Cancelled();
+			}
+		}
+
+	private :
+
+		std::atomic_bool m_cancelled;
+
+};
+
+}; // namespace IECore
+
+#endif // IECORE_CANCELLER_H

--- a/include/IECorePython/CancellerBinding.h
+++ b/include/IECorePython/CancellerBinding.h
@@ -1,0 +1,47 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_CANCELLERBINDING_H
+#define IECOREPYTHON_CANCELLERBINDING_H
+
+#include "IECorePython/Export.h"
+
+namespace IECorePython
+{
+
+IECOREPYTHON_API void bindCanceller();
+
+} // namespace IECorePython
+
+#endif // IECOREPYTHON_CANCELLERBINDING_H

--- a/src/IECorePython/CancellerBinding.cpp
+++ b/src/IECorePython/CancellerBinding.cpp
@@ -1,0 +1,71 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+// This include needs to be the very first to prevent problems with warnings
+// regarding redefinition of _POSIX_C_SOURCE
+#include "boost/python.hpp"
+
+#include "IECorePython/CancellerBinding.h"
+
+#include "IECore/Canceller.h"
+
+using namespace boost::python;
+using namespace IECore;
+
+namespace IECorePython
+{
+
+void bindCanceller()
+{
+	class_<Cancelled>( "Cancelled");
+
+	class_<Canceller, boost::noncopyable>( "Canceller" )
+		.def( "cancel", &Canceller::cancel )
+		.def( "check", &Canceller::check )
+		.staticmethod( "check" )
+	;
+
+	register_ptr_to_python<std::shared_ptr<Canceller>>();
+
+	register_exception_translator<Cancelled>(
+		[]( const Cancelled &e ) {
+			object o( e );
+			Py_INCREF( o.ptr() );
+			PyErr_SetObject( (PyObject *)o.ptr()->ob_type, o.ptr() );
+		}
+	);
+}
+
+} // namespace IECorePython
+

--- a/src/IECorePythonModule/IECore.cpp
+++ b/src/IECorePythonModule/IECore.cpp
@@ -153,6 +153,7 @@
 #include "IECorePython/RandomAlgoBinding.h"
 #include "IECorePython/StringAlgoBinding.h"
 #include "IECorePython/PathMatcherBinding.h"
+#include "IECorePython/CancellerBinding.h"
 #include "IECore/IECore.h"
 
 using namespace IECorePython;
@@ -292,6 +293,7 @@ BOOST_PYTHON_MODULE(_IECore)
 	bindRandomAlgo();
 	bindStringAlgo();
 	bindPathMatcher();
+	bindCanceller();
 
 	def( "majorVersion", &IECore::majorVersion );
 	def( "minorVersion", &IECore::minorVersion );

--- a/test/IECore/All.py
+++ b/test/IECore/All.py
@@ -152,6 +152,7 @@ from ReprTest import ReprTest
 from StringAlgoTest import StringAlgoTest
 from PathMatcherTest import PathMatcherTest
 from PathMatcherDataTest import PathMatcherDataTest
+from CancellerTest import CancellerTest
 
 unittest.TestProgram(
 	testRunner = unittest.TextTestRunner(

--- a/test/IECore/CancellerTest.py
+++ b/test/IECore/CancellerTest.py
@@ -1,0 +1,55 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#      * Redistributions of source code must retain the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer.
+#
+#      * Redistributions in binary form must reproduce the above
+#        copyright notice, this list of conditions and the following
+#        disclaimer in the documentation and/or other materials provided with
+#        the distribution.
+#
+#      * Neither the name of John Haddon nor the names of
+#        any other contributors to this software may be used to endorse or
+#        promote products derived from this software without specific prior
+#        written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+
+class CancellerTest( unittest.TestCase ) :
+
+	def testCheck( self ) :
+
+		IECore.Canceller.check( None )
+
+		c = IECore.Canceller()
+		IECore.Canceller.check( c )
+		c.cancel()
+
+		with self.assertRaises( IECore.Cancelled ) :
+			IECore.Canceller.check( c )
+
+if __name__ == "__main__":
+	unittest.main()


### PR DESCRIPTION
This will be used to cancel long-running background processes in Gaffer. In time we'll also add optional `const Canceller *canceller` arguments to all Cortex algorithms so that we can cancel out of their inner loops as well as being able to cancel at a per-compute level in Gaffer. That will come in follow-up PRs though; at this stage I'm just getting the bare bones in place to make a working proof of concept.