### PR TITLE
Timer: add depth and channel features

### DIFF
--- a/include/IECore/Timer.h
+++ b/include/IECore/Timer.h
@@ -40,6 +40,7 @@
 #include "boost/timer/timer.hpp"
 
 #include <string>
+#include <map>
 
 namespace IECore
 {
@@ -92,13 +93,25 @@ class IECORE_API Timer
 
 class IECORE_API ScopedTimer
 {
+	typedef std::string Channel;
+
 	public:
-		ScopedTimer( const std::string &name );
+		ScopedTimer( const std::string &name, const Channel &channel = "" );
 		~ScopedTimer();
+
+		static void printChannel( const Channel &channel );
+		static void printAllChannels();
+		static void resetChannel( const Channel &channel );
+		static void resetAllChannels();
 
 	private:
 		IECore::Timer m_timer;
 		std::string m_name;
+		Channel m_channel;
+		size_t m_depth;
+
+		static std::map<Channel, double> s_channelMap;
+		static size_t s_depth;
 };
 
 } // namespace IECore


### PR DESCRIPTION
I'm splitting this off the viewport work I'm doing currently in order to check that there are no issues with the code. This is supposed to extend Don's earlier work by adding a feature that let's us accumulate timings from different `Timers` as long as they've been assigned the same `Channel`. It's been of use to me to time sub-steps in a visitor while traversing a scene hierarchy recursively. Adding the depth-based indention is purely for aesthetics at this point, but potentially allows us to draw flame graphs some time in the future.

Don, would you take a look at this, please? Thanks :)
