### PR TITLE
TypedDataDispatch replacement

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -35,7 +35,6 @@
 #include "IECoreArnold/ParameterAlgo.h"
 
 #include "IECore/DataAlgo.h"
-#include "IECore/DespatchTypedData.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
@@ -561,9 +560,7 @@ AtArray *dataToArray( const IECore::Data *data, int aiType )
 		return array;
 	}
 
-	const void *dataAddress = despatchTypedData<TypedDataAddress, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( data ) );
-	size_t dataSize = despatchTypedData<TypedDataSize, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( data ) );
-	return AiArrayConvert( dataSize, 1, aiType, dataAddress );
+	return AiArrayConvert( size( data ), 1, aiType, address( data ) );
 }
 
 IECOREARNOLD_API AtArray *dataToArray( const std::vector<const IECore::Data *> &samples, int aiType )
@@ -578,7 +575,7 @@ IECOREARNOLD_API AtArray *dataToArray( const std::vector<const IECore::Data *> &
 		}
 	}
 
-	size_t arraySize = despatchTypedData<TypedDataSize, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( samples.front() ) );
+	const size_t arraySize = size( samples.front() );
 	ArrayPtr array(
 		AiArrayAllocate( arraySize, samples.size(), aiType ),
 		AiArrayDestroy
@@ -590,13 +587,11 @@ IECOREARNOLD_API AtArray *dataToArray( const std::vector<const IECore::Data *> &
 		{
 			throw IECore::Exception( "ParameterAlgo::dataToArray() : Mismatched sample types." );
 		}
-		const size_t dataSize = despatchTypedData<TypedDataSize, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( *it ) );
-		if( dataSize != arraySize )
+		if( size( *it ) != arraySize )
 		{
 			throw IECore::Exception( "ParameterAlgo::dataToArray() : Mismatched sample lengths." );
 		}
-		const void *dataAddress = despatchTypedData<TypedDataAddress, TypeTraits::IsTypedData, DespatchTypedDataIgnoreError>( const_cast<Data *>( *it ) );
-		AiArraySetKey( array.get(), /* key = */ it - samples.begin(), dataAddress );
+		AiArraySetKey( array.get(), /* key = */ it - samples.begin(), address( *it ) );
 	}
 
 	return array.release();

--- a/include/IECore/DataAlgo.h
+++ b/include/IECore/DataAlgo.h
@@ -50,6 +50,41 @@ IECORE_API void setGeometricInterpretation( IECore::Data *data, GeometricData::I
 /// Calculate the unique values in the TypedVectorData data
 IECORE_API IECore::DataPtr uniqueValues(const IECore::Data *data);
 
+/// Downcasts `data` to its true derived type and returns the result of calling `functor( derived )`.
+/// Functors may define arbitrary numbers of overloads to treat each type in a different way :
+///
+/// ```
+/// struct MyFunctor
+/// {
+///
+///     template<typename T>
+///     string operator()( const TypedData<vector<T>> *data )
+///     {
+///         return "Dispatched VectorTypedData of some sort";
+///     }
+///
+///     string operator()( const FloatData *data )
+///     {
+///         return "Dispatched FloatData";
+///     }
+///
+///     ...
+///
+///     string operator()( const Data *data )
+///     {
+///         // Didn't expect to have to handle any other types.
+///         throw exception( "Dispatched unknown type" );
+///     }
+///
+/// };
+/// ```
+template<typename F>
+typename std::result_of<F( Data * )>::type dispatch( Data *data, F &&functor );
+template<typename F>
+typename std::result_of<F( const Data * )>::type dispatch( const Data *data, F &&functor );
+
 } // namespace IECore
+
+#include "IECore/DataAlgo.inl"
 
 #endif // IECORE_DATAALGO_H

--- a/include/IECore/DataAlgo.h
+++ b/include/IECore/DataAlgo.h
@@ -62,6 +62,15 @@ IECORE_API size_t size( const IECore::Data *data );
 IECORE_API void *address( IECore::Data *data );
 IECORE_API const void *address( const IECore::Data *data );
 
+/// Returns true if the data has the specified trait, and false
+/// otherwise. For instance :
+///
+/// ```
+/// bool isNumeric = trait<IsNumericTypedData>( data );
+/// ```
+template<template<typename> class Trait>
+bool trait( const IECore::Data *data );
+
 /// Downcasts `data` to its true derived type and returns the result of calling `functor( derived )`.
 /// Functors may define arbitrary numbers of overloads to treat each type in a different way :
 ///

--- a/include/IECore/DataAlgo.h
+++ b/include/IECore/DataAlgo.h
@@ -50,6 +50,18 @@ IECORE_API void setGeometricInterpretation( IECore::Data *data, GeometricData::I
 /// Calculate the unique values in the TypedVectorData data
 IECORE_API IECore::DataPtr uniqueValues(const IECore::Data *data);
 
+/// For VectorTypedData, returns the size of the vector.
+/// For SimpleTypedData, returns 1. For all other types
+/// returns 0.
+IECORE_API size_t size( const IECore::Data *data );
+
+/// For VectorTypedData, returns the address of the first
+/// element in the vector. For SimpleTypedData, returns
+/// the address of the held type. For all other types,
+/// returns nullptr.
+IECORE_API void *address( IECore::Data *data );
+IECORE_API const void *address( const IECore::Data *data );
+
 /// Downcasts `data` to its true derived type and returns the result of calling `functor( derived )`.
 /// Functors may define arbitrary numbers of overloads to treat each type in a different way :
 ///

--- a/include/IECore/DataAlgo.inl
+++ b/include/IECore/DataAlgo.inl
@@ -41,6 +41,8 @@
 #include "IECore/TransformationMatrixData.h"
 #include "IECore/VectorTypedData.h"
 
+#include <type_traits>
+
 namespace IECore
 {
 
@@ -342,6 +344,34 @@ typename std::result_of<F( const Data * )>::type dispatch( const Data *data, F &
 		default :
 			throw InvalidArgumentException( "Data has unknown type" );
 	}
+}
+
+namespace Detail
+{
+
+template<template<typename> class Trait>
+struct TestTrait
+{
+
+	template<typename T>
+	bool operator()( const T *data, typename std::enable_if<Trait<T>::value>::type *enabler = nullptr )
+	{
+		return true;
+	}
+
+	bool operator()( const Data *data )
+	{
+		return false;
+	}
+
+};
+
+} // namespace Detail
+
+template<template<typename> class Trait>
+bool trait( const IECore::Data *data )
+{
+	return dispatch( data, Detail::TestTrait<Trait>() );
 }
 
 } // namespace IECore

--- a/include/IECore/DataAlgo.inl
+++ b/include/IECore/DataAlgo.inl
@@ -1,0 +1,349 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORE_DATAALGO_INL
+#define IECORE_DATAALGO_INL
+
+#include "IECore/DateTimeData.h"
+#include "IECore/SimpleTypedData.h"
+#include "IECore/SplineData.h"
+#include "IECore/TransformationMatrixData.h"
+#include "IECore/VectorTypedData.h"
+
+namespace IECore
+{
+
+template<class F>
+typename std::result_of<F( Data * )>::type dispatch( Data *data, F &&functor )
+{
+	switch( data->typeId() )
+	{
+		case BoolDataTypeId :
+			return functor( static_cast<BoolData *>( data ) );
+		case FloatDataTypeId :
+			return functor( static_cast<FloatData *>( data ) );
+		case DoubleDataTypeId :
+			return functor( static_cast<DoubleData *>( data ) );
+		case IntDataTypeId :
+			return functor( static_cast<IntData *>( data ) );
+		case UIntDataTypeId :
+			return functor( static_cast<UIntData *>( data ) );
+		case CharDataTypeId :
+			return functor( static_cast<CharData *>( data ) );
+		case UCharDataTypeId :
+			return functor( static_cast<UCharData *>( data ) );
+		case ShortDataTypeId :
+			return functor( static_cast<ShortData *>( data ) );
+		case UShortDataTypeId :
+			return functor( static_cast<UShortData *>( data ) );
+		case Int64DataTypeId :
+			return functor( static_cast<Int64Data *>( data ) );
+		case UInt64DataTypeId :
+			return functor( static_cast<UInt64Data *>( data ) );
+		case StringDataTypeId :
+			return functor( static_cast<StringData *>( data ) );
+		case InternedStringDataTypeId :
+			return functor( static_cast<InternedStringData *>( data ) );
+		case HalfDataTypeId :
+			return functor( static_cast<HalfData *>( data ) );
+		case V2iDataTypeId :
+			return functor( static_cast<V2iData *>( data ) );
+		case V3iDataTypeId :
+			return functor( static_cast<V3iData *>( data ) );
+		case V2fDataTypeId :
+			return functor( static_cast<V2fData *>( data ) );
+		case V3fDataTypeId :
+			return functor( static_cast<V3fData *>( data ) );
+		case V2dDataTypeId :
+			return functor( static_cast<V2dData *>( data ) );
+		case V3dDataTypeId :
+			return functor( static_cast<V3dData *>( data ) );
+		case Color3fDataTypeId :
+			return functor( static_cast<Color3fData *>( data ) );
+		case Color4fDataTypeId :
+			return functor( static_cast<Color4fData *>( data ) );
+		case Box2iDataTypeId :
+			return functor( static_cast<Box2iData *>( data ) );
+		case Box2fDataTypeId :
+			return functor( static_cast<Box2fData *>( data ) );
+		case Box3fDataTypeId :
+			return functor( static_cast<Box3fData *>( data ) );
+		case Box2dDataTypeId :
+			return functor( static_cast<Box2dData *>( data ) );
+		case Box3dDataTypeId :
+			return functor( static_cast<Box3dData *>( data ) );
+		case M33fDataTypeId :
+			return functor( static_cast<M33fData *>( data ) );
+		case M33dDataTypeId :
+			return functor( static_cast<M33dData *>( data ) );
+		case M44fDataTypeId :
+			return functor( static_cast<M44fData *>( data ) );
+		case M44dDataTypeId :
+			return functor( static_cast<M44dData *>( data ) );
+		case TransformationMatrixfDataTypeId :
+			return functor( static_cast<TransformationMatrixfData *>( data ) );
+		case TransformationMatrixdDataTypeId :
+			return functor( static_cast<TransformationMatrixdData *>( data ) );
+		case QuatfDataTypeId :
+			return functor( static_cast<QuatfData *>( data ) );
+		case QuatdDataTypeId :
+			return functor( static_cast<QuatdData *>( data ) );
+		case SplineffDataTypeId :
+			return functor( static_cast<SplineffData *>( data ) );
+		case SplineddDataTypeId :
+			return functor( static_cast<SplineddData *>( data ) );
+		case SplinefColor3fDataTypeId :
+			return functor( static_cast<SplinefColor3fData *>( data ) );
+		case SplinefColor4fDataTypeId :
+			return functor( static_cast<SplinefColor4fData *>( data ) );
+		case DateTimeDataTypeId :
+			return functor( static_cast<DateTimeData *>( data ) );
+		case BoolVectorDataTypeId :
+			return functor( static_cast<BoolVectorData *>( data ) );
+		case FloatVectorDataTypeId :
+			return functor( static_cast<FloatVectorData *>( data ) );
+		case DoubleVectorDataTypeId :
+			return functor( static_cast<DoubleVectorData *>( data ) );
+		case HalfVectorDataTypeId :
+			return functor( static_cast<HalfVectorData *>( data ) );
+		case IntVectorDataTypeId :
+			return functor( static_cast<IntVectorData *>( data ) );
+		case UIntVectorDataTypeId :
+			return functor( static_cast<UIntVectorData *>( data ) );
+		case CharVectorDataTypeId :
+			return functor( static_cast<CharVectorData *>( data ) );
+		case UCharVectorDataTypeId :
+			return functor( static_cast<UCharVectorData *>( data ) );
+		case ShortVectorDataTypeId :
+			return functor( static_cast<ShortVectorData *>( data ) );
+		case UShortVectorDataTypeId :
+			return functor( static_cast<UShortVectorData *>( data ) );
+		case Int64VectorDataTypeId :
+			return functor( static_cast<Int64VectorData *>( data ) );
+		case UInt64VectorDataTypeId :
+			return functor( static_cast<UInt64VectorData *>( data ) );
+		case StringVectorDataTypeId :
+			return functor( static_cast<StringVectorData *>( data ) );
+		case InternedStringVectorDataTypeId :
+			return functor( static_cast<InternedStringVectorData *>( data ) );
+		case V2iVectorDataTypeId :
+			return functor( static_cast<V2iVectorData *>( data ) );
+		case V2fVectorDataTypeId :
+			return functor( static_cast<V2fVectorData *>( data ) );
+		case V2dVectorDataTypeId :
+			return functor( static_cast<V2dVectorData *>( data ) );
+		case V3iVectorDataTypeId :
+			return functor( static_cast<V3iVectorData *>( data ) );
+		case V3fVectorDataTypeId :
+			return functor( static_cast<V3fVectorData *>( data ) );
+		case V3dVectorDataTypeId :
+			return functor( static_cast<V3dVectorData *>( data ) );
+		case Box3fVectorDataTypeId :
+			return functor( static_cast<Box3fVectorData *>( data ) );
+		case Box3dVectorDataTypeId :
+			return functor( static_cast<Box3dVectorData *>( data ) );
+		case M33fVectorDataTypeId :
+			return functor( static_cast<M33fVectorData *>( data ) );
+		case M33dVectorDataTypeId :
+			return functor( static_cast<M33dVectorData *>( data ) );
+		case M44fVectorDataTypeId :
+			return functor( static_cast<M44fVectorData *>( data ) );
+		case M44dVectorDataTypeId :
+			return functor( static_cast<M44dVectorData *>( data ) );
+		case QuatfVectorDataTypeId :
+			return functor( static_cast<QuatfVectorData *>( data ) );
+		case QuatdVectorDataTypeId :
+			return functor( static_cast<QuatdVectorData *>( data ) );
+		case Color3fVectorDataTypeId :
+			return functor( static_cast<Color3fVectorData *>( data ) );
+		case Color4fVectorDataTypeId :
+			return functor( static_cast<Color4fVectorData *>( data ) );
+		default :
+			throw InvalidArgumentException( "Data has unknown type" );
+	}
+}
+
+template<class F>
+typename std::result_of<F( const Data * )>::type dispatch( const Data *data, F &&functor )
+{
+	switch( data->typeId() )
+	{
+		case BoolDataTypeId :
+			return functor( static_cast<const BoolData *>( data ) );
+		case FloatDataTypeId :
+			return functor( static_cast<const FloatData *>( data ) );
+		case DoubleDataTypeId :
+			return functor( static_cast<const DoubleData *>( data ) );
+		case IntDataTypeId :
+			return functor( static_cast<const IntData *>( data ) );
+		case UIntDataTypeId :
+			return functor( static_cast<const UIntData *>( data ) );
+		case CharDataTypeId :
+			return functor( static_cast<const CharData *>( data ) );
+		case UCharDataTypeId :
+			return functor( static_cast<const UCharData *>( data ) );
+		case ShortDataTypeId :
+			return functor( static_cast<const ShortData *>( data ) );
+		case UShortDataTypeId :
+			return functor( static_cast<const UShortData *>( data ) );
+		case Int64DataTypeId :
+			return functor( static_cast<const Int64Data *>( data ) );
+		case UInt64DataTypeId :
+			return functor( static_cast<const UInt64Data *>( data ) );
+		case StringDataTypeId :
+			return functor( static_cast<const StringData *>( data ) );
+		case InternedStringDataTypeId :
+			return functor( static_cast<const InternedStringData *>( data ) );
+		case HalfDataTypeId :
+			return functor( static_cast<const HalfData *>( data ) );
+		case V2iDataTypeId :
+			return functor( static_cast<const V2iData *>( data ) );
+		case V3iDataTypeId :
+			return functor( static_cast<const V3iData *>( data ) );
+		case V2fDataTypeId :
+			return functor( static_cast<const V2fData *>( data ) );
+		case V3fDataTypeId :
+			return functor( static_cast<const V3fData *>( data ) );
+		case V2dDataTypeId :
+			return functor( static_cast<const V2dData *>( data ) );
+		case V3dDataTypeId :
+			return functor( static_cast<const V3dData *>( data ) );
+		case Color3fDataTypeId :
+			return functor( static_cast<const Color3fData *>( data ) );
+		case Color4fDataTypeId :
+			return functor( static_cast<const Color4fData *>( data ) );
+		case Box2iDataTypeId :
+			return functor( static_cast<const Box2iData *>( data ) );
+		case Box2fDataTypeId :
+			return functor( static_cast<const Box2fData *>( data ) );
+		case Box3fDataTypeId :
+			return functor( static_cast<const Box3fData *>( data ) );
+		case Box2dDataTypeId :
+			return functor( static_cast<const Box2dData *>( data ) );
+		case Box3dDataTypeId :
+			return functor( static_cast<const Box3dData *>( data ) );
+		case M33fDataTypeId :
+			return functor( static_cast<const M33fData *>( data ) );
+		case M33dDataTypeId :
+			return functor( static_cast<const M33dData *>( data ) );
+		case M44fDataTypeId :
+			return functor( static_cast<const M44fData *>( data ) );
+		case M44dDataTypeId :
+			return functor( static_cast<const M44dData *>( data ) );
+		case TransformationMatrixfDataTypeId :
+			return functor( static_cast<const TransformationMatrixfData *>( data ) );
+		case TransformationMatrixdDataTypeId :
+			return functor( static_cast<const TransformationMatrixdData *>( data ) );
+		case QuatfDataTypeId :
+			return functor( static_cast<const QuatfData *>( data ) );
+		case QuatdDataTypeId :
+			return functor( static_cast<const QuatdData *>( data ) );
+		case SplineffDataTypeId :
+			return functor( static_cast<const SplineffData *>( data ) );
+		case SplineddDataTypeId :
+			return functor( static_cast<const SplineddData *>( data ) );
+		case SplinefColor3fDataTypeId :
+			return functor( static_cast<const SplinefColor3fData *>( data ) );
+		case SplinefColor4fDataTypeId :
+			return functor( static_cast<const SplinefColor4fData *>( data ) );
+		case DateTimeDataTypeId :
+			return functor( static_cast<const DateTimeData *>( data ) );
+		case BoolVectorDataTypeId :
+			return functor( static_cast<const BoolVectorData *>( data ) );
+		case FloatVectorDataTypeId :
+			return functor( static_cast<const FloatVectorData *>( data ) );
+		case DoubleVectorDataTypeId :
+			return functor( static_cast<const DoubleVectorData *>( data ) );
+		case HalfVectorDataTypeId :
+			return functor( static_cast<const HalfVectorData *>( data ) );
+		case IntVectorDataTypeId :
+			return functor( static_cast<const IntVectorData *>( data ) );
+		case UIntVectorDataTypeId :
+			return functor( static_cast<const UIntVectorData *>( data ) );
+		case CharVectorDataTypeId :
+			return functor( static_cast<const CharVectorData *>( data ) );
+		case UCharVectorDataTypeId :
+			return functor( static_cast<const UCharVectorData *>( data ) );
+		case ShortVectorDataTypeId :
+			return functor( static_cast<const ShortVectorData *>( data ) );
+		case UShortVectorDataTypeId :
+			return functor( static_cast<const UShortVectorData *>( data ) );
+		case Int64VectorDataTypeId :
+			return functor( static_cast<const Int64VectorData *>( data ) );
+		case UInt64VectorDataTypeId :
+			return functor( static_cast<const UInt64VectorData *>( data ) );
+		case StringVectorDataTypeId :
+			return functor( static_cast<const StringVectorData *>( data ) );
+		case InternedStringVectorDataTypeId :
+			return functor( static_cast<const InternedStringVectorData *>( data ) );
+		case V2iVectorDataTypeId :
+			return functor( static_cast<const V2iVectorData *>( data ) );
+		case V2fVectorDataTypeId :
+			return functor( static_cast<const V2fVectorData *>( data ) );
+		case V2dVectorDataTypeId :
+			return functor( static_cast<const V2dVectorData *>( data ) );
+		case V3iVectorDataTypeId :
+			return functor( static_cast<const V3iVectorData *>( data ) );
+		case V3fVectorDataTypeId :
+			return functor( static_cast<const V3fVectorData *>( data ) );
+		case V3dVectorDataTypeId :
+			return functor( static_cast<const V3dVectorData *>( data ) );
+		case Box3fVectorDataTypeId :
+			return functor( static_cast<const Box3fVectorData *>( data ) );
+		case Box3dVectorDataTypeId :
+			return functor( static_cast<const Box3dVectorData *>( data ) );
+		case M33fVectorDataTypeId :
+			return functor( static_cast<const M33fVectorData *>( data ) );
+		case M33dVectorDataTypeId :
+			return functor( static_cast<const M33dVectorData *>( data ) );
+		case M44fVectorDataTypeId :
+			return functor( static_cast<const M44fVectorData *>( data ) );
+		case M44dVectorDataTypeId :
+			return functor( static_cast<const M44dVectorData *>( data ) );
+		case QuatfVectorDataTypeId :
+			return functor( static_cast<const QuatfVectorData *>( data ) );
+		case QuatdVectorDataTypeId :
+			return functor( static_cast<const QuatdVectorData *>( data ) );
+		case Color3fVectorDataTypeId :
+			return functor( static_cast<const Color3fVectorData *>( data ) );
+		case Color4fVectorDataTypeId :
+			return functor( static_cast<const Color4fVectorData *>( data ) );
+		default :
+			throw InvalidArgumentException( "Data has unknown type" );
+	}
+}
+
+} // namespace IECore
+
+#endif // IECORE_DATAALGO_INL

--- a/include/IECore/DespatchTypedData.h
+++ b/include/IECore/DespatchTypedData.h
@@ -85,35 +85,43 @@ namespace IECore
 /// \endcode
 ///
 /// Example uses can be found it the ImageWriter-derived classes
+///
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
 typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor, ErrorHandler &errorHandler );
 
 /// Convenience version of despatchTypedData which constructs an ErrorHandler using its default constructor
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
 typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData which constructs the ErrorHandler and Functor using their default constructors
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor, template<typename> class Enabler, typename ErrorHandler >
 typename Functor::ReturnType despatchTypedData( Data *data );
 
 /// Convenience version of despatchTypedData, which throws an InvalidArgumentException when data which doesn't match the Enabler
 /// is encountered
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor, template<typename> class Enabler >
 typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData, which throws an InvalidArgumentException when data which doesn't match the Enabler
 /// is encountered.
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor, template<typename> class Enabler >
 typename Functor::ReturnType despatchTypedData( Data *data );
 
 /// Convenience version of despatchTypedData which operates on all TypedData classes, and constructs an ErrorHandler
 /// using its default constructor
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor >
 typename Functor::ReturnType despatchTypedData( Data *data, Functor &functor );
 
 /// Convenience version of despatchTypedData which operates on all TypedData classes, constructs the ErrorHandler
 /// and Functor using their default constructors, and throws an InvalidArgumentException when data which isn't TypedData
 /// is encountered.
+/// \deprecated Use `DataAlgo::dispatch()` instead.
 template< class Functor >
 typename Functor::ReturnType despatchTypedData( Data *data );
 

--- a/src/IECore/DataAlgo.cpp
+++ b/src/IECore/DataAlgo.cpp
@@ -139,6 +139,77 @@ struct UniqueValueCollector
 		}
 };
 
+struct Size
+{
+
+	template<typename T>
+	size_t operator()( const TypedData<std::vector<T>> *data )
+	{
+		return data->readable().size();
+	}
+
+	template<typename T>
+	size_t operator()( const TypedData<T> *data )
+	{
+		return 1;
+	}
+
+	size_t operator()( const Data *data )
+	{
+		return 0;
+	}
+
+};
+
+struct Address
+{
+
+	void *operator()( BoolVectorData *data )
+	{
+		return nullptr;
+	}
+
+	const void *operator()( const BoolVectorData *data )
+	{
+		return nullptr;
+	}
+
+	template<typename T>
+	void *operator()( TypedData<std::vector<T>> *data )
+	{
+		return data->writable().data();
+	}
+
+	template<typename T>
+	const void *operator()( const TypedData<std::vector<T>> *data )
+	{
+		return data->readable().data();
+	}
+
+	template<typename T>
+	void *operator()( TypedData<T> *data )
+	{
+		return &data->writable();
+	}
+
+	template<typename T>
+	const void *operator()( const TypedData<T> *data )
+	{
+		return &data->readable();
+	}
+
+	void *operator()( Data *data )
+	{
+		return nullptr;
+	}
+
+	const void *operator()( const Data *data )
+	{
+		return nullptr;
+	}
+
+};
+
 } // namespace
 
 IECore::GeometricData::Interpretation IECore::getGeometricInterpretation( const IECore::Data *data )
@@ -155,3 +226,19 @@ IECore::DataPtr IECore::uniqueValues(const IECore::Data *data)
 {
 	return dispatch( data, UniqueValueCollector() );
 }
+
+IECORE_API size_t IECore::size( const IECore::Data *data )
+{
+	return dispatch( data, Size() );
+}
+
+IECORE_API void *IECore::address( IECore::Data *data )
+{
+	return dispatch( data, Address() );
+}
+
+IECORE_API const void *IECore::address( const IECore::Data *data )
+{
+	return dispatch( data, Address() );
+}
+

--- a/src/IECoreImage/ImagePrimitive.cpp
+++ b/src/IECoreImage/ImagePrimitive.cpp
@@ -34,7 +34,7 @@
 
 #include "IECoreImage/ImagePrimitive.h"
 
-#include "IECore/DespatchTypedData.h"
+#include "IECore/DataAlgo.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/MurmurHash.h"
 #include "IECore/TypeTraits.h"
@@ -391,7 +391,7 @@ bool ImagePrimitive::channelValid( const IECore::Data *data, std::string *reason
 		return false;
 	}
 
-	if( !despatchTraitsTest<TypeTraits::IsNumericVectorTypedData>( data ) )
+	if( !trait<TypeTraits::IsNumericVectorTypedData>( data ) )
 	{
 		if( reason )
 		{
@@ -400,7 +400,7 @@ bool ImagePrimitive::channelValid( const IECore::Data *data, std::string *reason
 		return false;
 	}
 
-	size_t size = despatchTypedData<TypedDataSize>( const_cast<Data *>( data ) );
+	size_t size = IECore::size( data );
 	size_t numPixels = channelSize();
 	if( size!=numPixels )
 	{

--- a/src/IECorePython/DataAlgoBinding.cpp
+++ b/src/IECorePython/DataAlgoBinding.cpp
@@ -41,6 +41,16 @@
 using namespace boost::python;
 using namespace IECore;
 
+namespace
+{
+
+PyObject *addressWrapper( Data *data )
+{
+	return PyLong_FromVoidPtr( address( data ) );
+}
+
+} // namespace
+
 namespace IECorePython
 {
 
@@ -50,6 +60,10 @@ void bindDataAlgo()
 	def( "setGeometricInterpretation", &setGeometricInterpretation );
 
 	def( "uniqueValues", &uniqueValues );
+
+	def( "size", &IECore::size );
+	def( "address", &addressWrapper );
+
 }
 
 } // namespace IECorePython

--- a/test/IECore/DataAlgoTest.py
+++ b/test/IECore/DataAlgoTest.py
@@ -33,6 +33,7 @@
 ##########################################################################
 
 import unittest
+import ctypes
 import math
 import imath
 import IECore
@@ -85,6 +86,32 @@ class DataAlgoTest( unittest.TestCase ) :
 		output = IECore.uniqueValues( data )
 
 		self.assertEqual( set( output ), set( IECore.IntVectorData( [1, 2] ) ) )
+
+	def testSize( self ) :
+
+		self.assertEqual(
+			IECore.size( IECore.StringData( "hi" ) ),
+			1
+		)
+
+		self.assertEqual(
+			IECore.size(
+				IECore.V3fVectorData( [ imath.V3f( 1 ), imath.V3f( 2 ) ] )
+			),
+			2
+		)
+
+	def testAddress( self ) :
+
+		v = IECore.IntVectorData( [ 1, 2, 3 ] )
+
+		p = ctypes.cast(
+			IECore.address( v ),
+			ctypes.POINTER( ctypes.c_int )
+		)
+
+		for i in range( 0, len( v ) ) :
+			self.assertEqual( p[i], v[i] )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This is something I prototyped while working on Gaffer's Instancer on my spare time. It made it trivial to write some code that would have been tricky with `despatchTypedData()`. Here I've tidied it up and applied it to a few spots in Cortex to see how it works there. I've commented on this in the commit logs.

Putting this up because @donboie showed an interest and I thought it was worth discussion. Personally I think it's probably a worthwhile improvement on the old method, but I'm open to opinions.