### PR TITLE
IECoreScene : LinkedScene - only read path in dtor if readable.

### DIFF
--- a/src/IECoreScene/LinkedScene.cpp
+++ b/src/IECoreScene/LinkedScene.cpp
@@ -146,11 +146,15 @@ LinkedScene::LinkedScene(
 
 LinkedScene::~LinkedScene()
 {
-	SceneInterface::Path p;
-	LinkedScene::path( p );
-	if( !m_readOnly && p.empty() )
+	if( !m_readOnly  )
 	{
-		m_mainScene->writeAttribute( "linkLocations", m_linkLocationsData.get(), 0 );
+		SceneInterface::Path p;
+		LinkedScene::path( p );
+
+		if ( p.empty() )
+		{
+			m_mainScene->writeAttribute( "linkLocations", m_linkLocationsData.get(), 0 );
+		}
 	}
 }
 


### PR DESCRIPTION
Prevents a crash when destructing a LinkedScene with a LiveScene main scene when creating a new maya scene.