### PR TITLE
Segment Primitive performance improvements

### DIFF
--- a/include/IECore/TypeTraits.h
+++ b/include/IECore/TypeTraits.h
@@ -293,6 +293,11 @@ template<typename T, typename U> struct IsSpline< const Spline<T, U> > : public 
 /// IsSplineTypedData
 template< typename T > struct IsSplineTypedData : boost::mpl::and_< IsTypedData<T>, IsSpline< typename ValueType<T>::type > > {};
 
+/// IsStringVectorTypeData
+template<typename T> struct IsStringVectorTypedData : public boost::false_type {};
+template<> struct IsStringVectorTypedData< TypedData<std::vector<std::string> > > : public boost::true_type {};
+template<> struct IsStringVectorTypedData< TypedData<std::vector<IECore::InternedString> > > : public boost::true_type {};
+
 
 } // namespace TypeTraits
 

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -582,14 +582,13 @@ void LiveScene::readTags( NameList &tags, int filter ) const
 			{
 				for( auto primVarIt : splitObject->variables )
 				{
-					BoolVectorDataPtr boolData = splitObject->variableData<IECore::BoolVectorData>( primVarIt.first );
-
 					boost::smatch sm;
-
-					if( boolData && boost::regex_match( primVarIt.first, sm, tagGroupEx) )
+					auto it = splitObject->variables.find( primVarIt.first );
+					if( it != splitObject->variables.end() && boost::regex_match( primVarIt.first, sm, tagGroupEx ) )
 					{
-						const auto &readable = boolData->readable();
-						for( auto b : readable )
+						PrimitiveVariable::IndexedView<bool> view( it->second );
+
+						for( auto b : view )
 						{
 							if( b )
 							{

--- a/src/IECoreScene/CurvesAlgoSegment.cpp
+++ b/src/IECoreScene/CurvesAlgoSegment.cpp
@@ -69,7 +69,10 @@ std::vector<CurvesPrimitivePtr> IECoreScene::CurvesAlgo::segment( const CurvesPr
 		}
 	}
 
-	// todo throw an exception if the primvar is not on the input curves
+	if( primitiveVariableName == "" )
+	{
+		throw IECore::InvalidArgumentException( "IECoreScene::CurvesAlgo::segment : Primitive variable not found CurvesPrimitive " );
+	}
 
 
 	auto f = CurvesAlgo::deleteCurves;

--- a/src/IECoreScene/CurvesAlgoSegment.cpp
+++ b/src/IECoreScene/CurvesAlgoSegment.cpp
@@ -34,6 +34,7 @@
 
 
 #include "IECoreScene/CurvesAlgo.h"
+#include "IECoreScene/private/PrimitiveAlgoUtils.h"
 
 #include "IECore/DataAlgo.h"
 #include "IECore/DespatchTypedData.h"
@@ -48,85 +49,6 @@ using namespace IECore;
 using namespace IECoreScene;
 using namespace Imath;
 
-namespace
-{
-
-class Segmenter
-{
-	public:
-		Segmenter( const CurvesPrimitive &curves, Data *data, const IntVectorData *indices ) : m_curves( curves ), m_data( data ), m_indices( indices )
-		{
-		}
-
-		typedef std::vector<CurvesPrimitivePtr> ReturnType;
-
-		template<typename T>
-		ReturnType operator()( T *array )
-		{
-			T *segments = IECore::runTimeCast<T>( m_data );
-			if ( !segments )
-			{
-				throw IECore::InvalidArgumentException(
-					(
-						boost::format( "Segment keys type '%s' doesn't match primitive variable type '%s'" ) %
-							m_data->typeName() %
-							array->typeName()
-					).str()
-				);
-			}
-
-			const auto &segmentsReadable = segments->readable();
-
-			ReturnType results;
-			results.resize( segmentsReadable.size() );
-			const auto &readable = array->readable();
-
-			tbb::parallel_for(
-				tbb::blocked_range<size_t>(0, segmentsReadable.size() ), [this, &readable, &segmentsReadable, &results] ( const tbb::blocked_range<size_t> &r)
-				{
-					BoolVectorDataPtr deletionArray = new BoolVectorData();
-					auto &writable = deletionArray->writable();
-					for (size_t j = r.begin(); j < r.end(); ++j)
-					{
-						if( m_indices )
-						{
-							auto &readableIndices = m_indices->readable();
-							writable.resize( readableIndices.size() );
-
-							for( size_t i = 0; i < readableIndices.size(); ++i )
-							{
-								size_t index = readableIndices[i];
-								writable[i] = segmentsReadable[j] != readable[index];
-							}
-						}
-						else
-						{
-							writable.resize( readable.size() );
-							for( size_t i = 0; i < readable.size(); ++i )
-							{
-								writable[i] =  segmentsReadable[j] != readable[i];
-							}
-						}
-
-						IECoreScene::PrimitiveVariable delPrimVar( IECoreScene::PrimitiveVariable::Uniform, deletionArray );
-						results[j] = CurvesAlgo::deleteCurves( &m_curves, delPrimVar, false ) ;
-					}
-				}
-			);
-
-
-			return results;
-		}
-
-	private:
-		const CurvesPrimitive &m_curves;
-		Data *m_data;
-		const IntVectorData *m_indices;
-
-};
-
-} // namespace
-
 
 std::vector<CurvesPrimitivePtr> IECoreScene::CurvesAlgo::segment( const CurvesPrimitive *curves, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues )
 {
@@ -138,7 +60,21 @@ std::vector<CurvesPrimitivePtr> IECoreScene::CurvesAlgo::segment( const CurvesPr
 		segmentValues = data.get();
 	}
 
-	Segmenter segmenter( *curves, const_cast<IECore::Data*> (segmentValues), primitiveVariable.indices.get() );
+	std::string primitiveVariableName;
+	for (const auto &pv : curves->variables )
+	{
+		if ( pv.second == primitiveVariable )
+		{
+			primitiveVariableName = pv.first;
+		}
+	}
 
-	return despatchTypedData<Segmenter, IECore::TypeTraits::HasVectorValueType>(  primitiveVariable.data.get(), segmenter );
+	// todo throw an exception if the primvar is not on the input curves
+
+
+	auto f = CurvesAlgo::deleteCurves;
+
+	IECoreScene::Detail::TaskSegmenter<IECoreScene::CurvesPrimitive, decltype(f) > segmenter( curves, const_cast<IECore::Data*> ( segmentValues ), primitiveVariableName, f );
+
+	return dispatch( primitiveVariable.data.get(), segmenter );
 }

--- a/src/IECoreScene/MeshAlgoSegment.cpp
+++ b/src/IECoreScene/MeshAlgoSegment.cpp
@@ -44,12 +44,168 @@
 #include "tbb/blocked_range.h"
 #include "tbb/parallel_for.h"
 
+#include <unordered_set>
+
 using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 
+/// template to dispatch only primvars which are supported by the SplitTask
+/// Numeric & stiring like arrays, which contain elements which can be added to a std::set
+template<typename T> struct IsDeletablePrimVar : boost::mpl::or_< IECore::TypeTraits::IsStringVectorTypedData<T>, IECore::TypeTraits::IsNumericVectorTypedData<T> > {};
+
 namespace
 {
+
+template<typename T>
+class SplitTask : public tbb::task
+{
+	public:
+		SplitTask(const std::vector<T> &segments, MeshPrimitive *mesh, const std::string &primvarName, std::vector<MeshPrimitivePtr> &outputMeshes,  size_t offset, size_t depth = 0)
+		: m_segments(segments), m_mesh(mesh), m_primvarName(primvarName), m_outputMeshes(outputMeshes), m_offset(offset), m_depth(depth)
+		{
+		}
+
+		task *execute() override
+		{
+
+			if ( m_mesh->numFaces() == 0 && !m_segments.empty() )
+			{
+				m_outputMeshes[m_offset] = m_mesh;
+				return nullptr;
+			}
+
+			if ( m_segments.size () == 0 )
+			{
+				return nullptr;
+			}
+
+			size_t offset = m_segments.size() / 2;
+			typename std::vector<T>::iterator mid = m_segments.begin() + offset;
+
+			IECoreScene::PrimitiveVariable segmentPrimVar = m_mesh->variables.find( m_primvarName )->second;
+
+			std::vector<T> lowerSegments (m_segments.begin(), mid);
+			std::vector<T> upperSegments (mid, m_segments.end());
+
+			std::set<T> lowerSegmentsSet ( m_segments.begin(), mid );
+			std::set<T> upperSegmentsSet (mid, m_segments.end());
+
+			const auto &readable = runTimeCast<IECore::TypedData<std::vector<T> > >( segmentPrimVar.data )->readable();
+
+			BoolVectorDataPtr deletionArrayLower = new BoolVectorData();
+			auto &writableLower = deletionArrayLower->writable();
+
+			BoolVectorDataPtr deletionArrayUpper = new BoolVectorData();
+			auto &writableUpper = deletionArrayUpper->writable();
+
+			size_t deleteCount = 0;
+			if( segmentPrimVar.indices )
+			{
+				auto &readableIndices = segmentPrimVar.indices->readable();
+				writableLower.resize( readableIndices.size() );
+				writableUpper.resize( readableIndices.size() );
+
+				for( size_t i = 0; i < readableIndices.size(); ++i )
+				{
+					size_t index = readableIndices[i];
+					writableLower[i] = lowerSegmentsSet.find( readable[index] ) == lowerSegmentsSet.end();
+					writableUpper[i] = upperSegmentsSet.find( readable[index] ) == upperSegmentsSet.end();
+
+					deleteCount += ( writableLower[i] && !lowerSegments.empty() ) || ( writableUpper[i] && !upperSegments.empty() ) ? 1 : 0;
+				}
+			}
+			else
+			{
+				writableLower.resize( readable.size() );
+				writableUpper.resize( readable.size() );
+
+				for( size_t i = 0; i < readable.size(); ++i )
+				{
+					writableLower[i] = lowerSegmentsSet.find( readable[i] ) == lowerSegmentsSet.end();
+					writableUpper[i] = upperSegmentsSet.find( readable[i] ) == upperSegmentsSet.end();
+					deleteCount += ( writableLower[i] && !lowerSegments.empty() ) || ( writableUpper[i] && !upperSegments.empty() ) ? 1 : 0;
+				}
+			}
+
+			if ( m_segments.size() == 1 && deleteCount == 0)
+			{
+				m_outputMeshes[m_offset] = m_mesh;
+				return nullptr;
+			}
+
+			IECoreScene::PrimitiveVariable delPrimVarLower( IECoreScene::PrimitiveVariable::Uniform, deletionArrayLower );
+			IECoreScene::MeshPrimitivePtr a = MeshAlgo::deleteFaces( m_mesh, delPrimVarLower, false ) ;
+
+			IECoreScene::PrimitiveVariable delPrimVarUpper( IECoreScene::PrimitiveVariable::Uniform, deletionArrayUpper);
+			IECoreScene::MeshPrimitivePtr b = MeshAlgo::deleteFaces( m_mesh, delPrimVarUpper, false ) ;
+
+			size_t numSplits = 2;
+
+			set_ref_count( 1 + numSplits);
+
+			SplitTask *tA = new( allocate_child() ) SplitTask( lowerSegments, a.get(), m_primvarName, m_outputMeshes, m_offset, m_depth + 1);
+			spawn( *tA );
+
+			SplitTask *tB = new( allocate_child() ) SplitTask( upperSegments, b.get(), m_primvarName, m_outputMeshes, m_offset + offset, m_depth + 1 );
+			spawn( *tB );
+
+			wait_for_all();
+
+			return nullptr;
+		}
+
+	private:
+		std::vector<T> m_segments;
+		MeshPrimitive *m_mesh;
+		std::string m_primvarName;
+		std::vector<MeshPrimitivePtr> &m_outputMeshes;
+		size_t m_offset;
+		size_t m_depth;
+};
+
+class TaskSegmenter
+{
+	public:
+		TaskSegmenter( ConstMeshPrimitivePtr mesh, Data *data, const std::string &primVarName ) : m_mesh( mesh ), m_data( data ), m_primVarName( primVarName )
+		{
+		}
+
+		typedef std::vector<MeshPrimitivePtr> ReturnType;
+
+		template<typename T>
+		ReturnType operator()( T *array )
+		{
+			T *segments = IECore::runTimeCast<T>( m_data );
+
+			if ( !segments )
+			{
+				throw IECore::InvalidArgumentException(
+					(
+						boost::format( "Segment keys type '%s' doesn't match primitive variable type '%s'" ) %
+							m_data->typeName() %
+							array->typeName()
+					).str()
+				);
+			}
+
+			const auto &segmentsReadable = segments->readable();
+
+			ReturnType results( segmentsReadable.size() );
+
+			SplitTask<typename T::ValueType::value_type> *task = new( tbb::task::allocate_root() ) SplitTask<typename T::ValueType::value_type> ( segmentsReadable, const_cast<MeshPrimitive*>(m_mesh.get()), m_primVarName, results, 0 );
+			tbb::task::spawn_root_and_wait( *task );
+
+			return results;
+
+		}
+
+	private:
+		ConstMeshPrimitivePtr m_mesh;
+		Data *m_data;
+		std::string m_primVarName;
+
+};
 
 class Segmenter
 {
@@ -132,6 +288,13 @@ class Segmenter
 
 std::vector<MeshPrimitivePtr> IECoreScene::MeshAlgo::segment( const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues )
 {
+	MeshPrimitivePtr meshCopy = mesh->copy();
+
+	for (const auto &pv : meshCopy->variables )
+	{
+		meshCopy->variables[pv.first] = PrimitiveVariable( pv.second.interpolation, pv.second.expandedData() );
+	}
+
 	DataPtr data;
 	if( !segmentValues )
 	{
@@ -139,7 +302,16 @@ std::vector<MeshPrimitivePtr> IECoreScene::MeshAlgo::segment( const MeshPrimitiv
 		segmentValues = data.get();
 	}
 
-	Segmenter segmenter( *mesh, const_cast<IECore::Data*> (segmentValues), primitiveVariable.indices.get() );
+	std::string primitiveVariableName;
+	for (const auto &pv : mesh->variables )
+	{
+		if ( pv.second == primitiveVariable )
+		{
+			primitiveVariableName = pv.first;
+		}
+	}
 
-	return despatchTypedData<Segmenter, IECore::TypeTraits::HasVectorValueType>(  primitiveVariable.data.get(), segmenter );
+	TaskSegmenter taskSegmenter( meshCopy.get(), const_cast<IECore::Data*> (segmentValues), primitiveVariableName );
+
+	return despatchTypedData<TaskSegmenter, IsDeletablePrimVar>(  primitiveVariable.data.get(), taskSegmenter );
 }

--- a/src/IECoreScene/MeshAlgoSegment.cpp
+++ b/src/IECoreScene/MeshAlgoSegment.cpp
@@ -66,7 +66,10 @@ std::vector<MeshPrimitivePtr> IECoreScene::MeshAlgo::segment( const MeshPrimitiv
 		}
 	}
 
-	// todo throw an exception if the primvar is not on the input mesh
+	if( primitiveVariableName == "" )
+	{
+		throw IECore::InvalidArgumentException( "IECoreScene::MeshAlgo::segment : Primitive variable not found on Mesh Primitive " );
+	}
 
 	auto f = MeshAlgo::deleteFaces;
 

--- a/src/IECoreScene/MeshAlgoSegment.cpp
+++ b/src/IECoreScene/MeshAlgoSegment.cpp
@@ -37,280 +37,18 @@
 #include "IECore/DespatchTypedData.h"
 #include "IECore/DataAlgo.h"
 
+
 #include "IECoreScene/MeshAlgo.h"
+#include "IECoreScene/private/PrimitiveAlgoUtils.h"
 
-#include "boost/format.hpp"
-
-#include "tbb/blocked_range.h"
-#include "tbb/parallel_for.h"
-
-#include <unordered_set>
-#include <type_traits>
 
 using namespace Imath;
 using namespace IECore;
 using namespace IECoreScene;
 
-/// template to dispatch only primvars which are supported by the SplitTask
-/// Numeric & string like arrays, which contain elements which can be added to a std::set
-template<typename T> struct IsDeletablePrimVar : boost::mpl::or_< IECore::TypeTraits::IsStringVectorTypedData<T>, IECore::TypeTraits::IsNumericVectorTypedData<T> > {};
-
-namespace
-{
-
-template<typename T>
-class SplitTask : public tbb::task
-{
-	public:
-		SplitTask(const std::vector<T> &segments, MeshPrimitive *mesh, const std::string &primvarName, std::vector<MeshPrimitivePtr> &outputMeshes,  size_t offset, size_t depth = 0)
-		: m_segments(segments), m_mesh(mesh), m_primvarName(primvarName), m_outputMeshes(outputMeshes), m_offset(offset), m_depth(depth)
-		{
-		}
-
-		task *execute() override
-		{
-
-			if ( m_mesh->numFaces() == 0 && !m_segments.empty() )
-			{
-				m_outputMeshes[m_offset] = m_mesh;
-				return nullptr;
-			}
-
-			if ( m_segments.size () == 0 )
-			{
-				return nullptr;
-			}
-
-			size_t offset = m_segments.size() / 2;
-			typename std::vector<T>::iterator mid = m_segments.begin() + offset;
-
-			IECoreScene::PrimitiveVariable segmentPrimVar = m_mesh->variables.find( m_primvarName )->second;
-
-			std::vector<T> lowerSegments (m_segments.begin(), mid);
-			std::vector<T> upperSegments (mid, m_segments.end());
-
-			std::set<T> lowerSegmentsSet ( m_segments.begin(), mid );
-			std::set<T> upperSegmentsSet (mid, m_segments.end());
-
-			const auto &readable = runTimeCast<IECore::TypedData<std::vector<T> > >( segmentPrimVar.data )->readable();
-
-			BoolVectorDataPtr deletionArrayLower = new BoolVectorData();
-			auto &writableLower = deletionArrayLower->writable();
-
-			BoolVectorDataPtr deletionArrayUpper = new BoolVectorData();
-			auto &writableUpper = deletionArrayUpper->writable();
-
-			size_t deleteCount = 0;
-			if( segmentPrimVar.indices )
-			{
-				auto &readableIndices = segmentPrimVar.indices->readable();
-				writableLower.resize( readableIndices.size() );
-				writableUpper.resize( readableIndices.size() );
-
-				for( size_t i = 0; i < readableIndices.size(); ++i )
-				{
-					size_t index = readableIndices[i];
-					writableLower[i] = lowerSegmentsSet.find( readable[index] ) == lowerSegmentsSet.end();
-					writableUpper[i] = upperSegmentsSet.find( readable[index] ) == upperSegmentsSet.end();
-
-					deleteCount += ( writableLower[i] && !lowerSegments.empty() ) || ( writableUpper[i] && !upperSegments.empty() ) ? 1 : 0;
-				}
-			}
-			else
-			{
-				writableLower.resize( readable.size() );
-				writableUpper.resize( readable.size() );
-
-				for( size_t i = 0; i < readable.size(); ++i )
-				{
-					writableLower[i] = lowerSegmentsSet.find( readable[i] ) == lowerSegmentsSet.end();
-					writableUpper[i] = upperSegmentsSet.find( readable[i] ) == upperSegmentsSet.end();
-					deleteCount += ( writableLower[i] && !lowerSegments.empty() ) || ( writableUpper[i] && !upperSegments.empty() ) ? 1 : 0;
-				}
-			}
-
-			if ( m_segments.size() == 1 && deleteCount == 0)
-			{
-				m_outputMeshes[m_offset] = m_mesh;
-				return nullptr;
-			}
-
-			IECoreScene::PrimitiveVariable delPrimVarLower( IECoreScene::PrimitiveVariable::Uniform, deletionArrayLower );
-			IECoreScene::MeshPrimitivePtr a = MeshAlgo::deleteFaces( m_mesh, delPrimVarLower, false ) ;
-
-			IECoreScene::PrimitiveVariable delPrimVarUpper( IECoreScene::PrimitiveVariable::Uniform, deletionArrayUpper);
-			IECoreScene::MeshPrimitivePtr b = MeshAlgo::deleteFaces( m_mesh, delPrimVarUpper, false ) ;
-
-			size_t numSplits = 2;
-
-			set_ref_count( 1 + numSplits);
-
-			SplitTask *tA = new( allocate_child() ) SplitTask( lowerSegments, a.get(), m_primvarName, m_outputMeshes, m_offset, m_depth + 1);
-			spawn( *tA );
-
-			SplitTask *tB = new( allocate_child() ) SplitTask( upperSegments, b.get(), m_primvarName, m_outputMeshes, m_offset + offset, m_depth + 1 );
-			spawn( *tB );
-
-			wait_for_all();
-
-			return nullptr;
-		}
-
-	private:
-		std::vector<T> m_segments;
-		MeshPrimitive *m_mesh;
-		std::string m_primvarName;
-		std::vector<MeshPrimitivePtr> &m_outputMeshes;
-		size_t m_offset;
-		size_t m_depth;
-};
-
-class TaskSegmenter
-{
-	public:
-		TaskSegmenter( ConstMeshPrimitivePtr mesh, Data *data, const std::string &primVarName ) : m_mesh( mesh ), m_data( data ), m_primVarName( primVarName )
-		{
-		}
-
-		typedef std::vector<MeshPrimitivePtr> ReturnType;
-
-		template<typename T>
-		ReturnType operator()(
-			const IECore::TypedData<std::vector<T>> *array,
-			typename std::enable_if<IsDeletablePrimVar<IECore::TypedData<std::vector<T>>>::value>::type *enabler = nullptr
-		)
-		{
-			IECore::TypedData<std::vector<T> > *segments = IECore::runTimeCast<IECore::TypedData<std::vector<T> > >( m_data );
-
-			if ( !segments )
-			{
-				throw IECore::InvalidArgumentException(
-					(
-						boost::format( "Segment keys type '%s' doesn't match primitive variable type '%s'" ) %
-							m_data->typeName() %
-							array->typeName()
-					).str()
-				);
-			}
-
-			const auto &segmentsReadable = segments->readable();
-
-			ReturnType results( segmentsReadable.size() );
-
-			SplitTask<T> *task = new( tbb::task::allocate_root() ) SplitTask<T>(
-				segmentsReadable,
-				const_cast<MeshPrimitive *>(m_mesh.get()),
-				m_primVarName,
-				results,
-				0
-			);
-			tbb::task::spawn_root_and_wait( *task );
-
-			return results;
-
-		}
-
-		ReturnType operator()( const Data *data )
-		{
-			throw IECore::Exception(
-				boost::str( boost::format( "Unexpected Data: %1%" ) % ( data ? data->typeName() : std::string( "nullptr" ) ) )
-			);
-		}
-
-	private:
-		ConstMeshPrimitivePtr m_mesh;
-		Data *m_data;
-		std::string m_primVarName;
-
-};
-
-class Segmenter
-{
-	public:
-		Segmenter( const MeshPrimitive &mesh, Data *data, const IntVectorData *indices ) : m_mesh( mesh ), m_data( data ), m_indices( indices )
-		{
-		}
-
-		typedef std::vector<MeshPrimitivePtr> ReturnType;
-
-		template<typename T>
-		ReturnType operator()( T *array )
-		{
-			T *segments = IECore::runTimeCast<T>( m_data );
-
-			if ( !segments )
-			{
-				throw IECore::InvalidArgumentException(
-					(
-						boost::format( "Segment keys type '%s' doesn't match primitive variable type '%s'" ) %
-							m_data->typeName() %
-							array->typeName()
-					).str()
-				);
-			}
-
-			const auto &segmentsReadable = segments->readable();
-
-			ReturnType results;
-			results.resize( segmentsReadable.size() );
-			const auto &readable = array->readable();
-
-			tbb::parallel_for(
-				tbb::blocked_range<size_t>( 0, segmentsReadable.size() ), [this, &readable, &segmentsReadable, &results]( const tbb::blocked_range<size_t> &r )
-				{
-					BoolVectorDataPtr deletionArray = new BoolVectorData();
-					auto &writable = deletionArray->writable();
-
-					for (size_t j = r.begin(); j < r.end(); ++j)
-					{
-						if( m_indices )
-						{
-							auto &readableIndices = m_indices->readable();
-							writable.resize( readableIndices.size() );
-
-							for( size_t i = 0; i < readableIndices.size(); ++i )
-							{
-								size_t index = readableIndices[i];
-								writable[i] = segmentsReadable[j] != readable[index];
-							}
-						}
-						else
-						{
-							writable.resize( readable.size() );
-							for( size_t i = 0; i < readable.size(); ++i )
-							{
-								writable[i] = segmentsReadable[j] != readable[i];
-							}
-						}
-
-						IECoreScene::PrimitiveVariable delPrimVar( IECoreScene::PrimitiveVariable::Uniform, deletionArray );
-						results[j] = MeshAlgo::deleteFaces( &m_mesh, delPrimVar, false ) ;
-					}
-				}
-			);
-
-			return results;
-		}
-
-	private:
-		const MeshPrimitive &m_mesh;
-		Data *m_data;
-		const IntVectorData *m_indices;
-
-};
-
-} // namespace
-
-
 
 std::vector<MeshPrimitivePtr> IECoreScene::MeshAlgo::segment( const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues )
 {
-	MeshPrimitivePtr meshCopy = mesh->copy();
-
-	for (const auto &pv : meshCopy->variables )
-	{
-		meshCopy->variables[pv.first] = PrimitiveVariable( pv.second.interpolation, pv.second.expandedData() );
-	}
 
 	DataPtr data;
 	if( !segmentValues )
@@ -328,7 +66,11 @@ std::vector<MeshPrimitivePtr> IECoreScene::MeshAlgo::segment( const MeshPrimitiv
 		}
 	}
 
-	TaskSegmenter taskSegmenter( meshCopy.get(), const_cast<IECore::Data*> (segmentValues), primitiveVariableName );
+	// todo throw an exception if the primvar is not on the input mesh
+
+	auto f = MeshAlgo::deleteFaces;
+
+	IECoreScene::Detail::TaskSegmenter<IECoreScene::MeshPrimitive, decltype(f) > taskSegmenter( mesh, const_cast<IECore::Data*> (segmentValues), primitiveVariableName, f );
 
 	return dispatch( primitiveVariable.data.get(), taskSegmenter );
 }

--- a/src/IECoreScene/PointsAlgo.cpp
+++ b/src/IECoreScene/PointsAlgo.cpp
@@ -287,7 +287,9 @@ PointsPrimitivePtr deletePoints( const PointsPrimitive *pointsPrimitive, const P
 
 	if( pointsToDelete.interpolation != PrimitiveVariable::Vertex )
 	{
-		throw InvalidArgumentException( "PointsAlgo::deletePoints requires a Vertex [Int|Bool|Float]VectorData primitiveVariable " );
+		throw InvalidArgumentException(
+			boost::str ( boost::format( "PointsAlgo::deletePoints requires a Vertex [Int|Bool|Float]VectorData primitiveVariable. %1% interpolation found " ) % pointsToDelete.interpolation )
+		);
 	}
 
 	if( runTimeCast<const IntVectorData>( pointsToDelete.data.get() ) )

--- a/src/IECoreScene/PointsAlgoSegment.cpp
+++ b/src/IECoreScene/PointsAlgoSegment.cpp
@@ -71,7 +71,10 @@ std::vector<PointsPrimitivePtr> IECoreScene::PointsAlgo::segment(
 		}
 	}
 
-	// todo throw an exception if the primvar is not on the input curves
+	if( primitiveVariableName == "" )
+	{
+		throw IECore::InvalidArgumentException( "IECoreScene::PointsAlgo::segment : Primitive variable not found on Points Primitive" );
+	}
 
 	auto f = PointsAlgo::deletePoints;
 	IECoreScene::Detail::TaskSegmenter<IECoreScene::PointsPrimitive, decltype(f) > segmenter( points, const_cast<IECore::Data*> (segmentValues), primitiveVariableName, f);

--- a/test/IECore/TypeTraitsTest.cpp
+++ b/test/IECore/TypeTraitsTest.cpp
@@ -180,3 +180,8 @@ BOOST_STATIC_ASSERT( (IsSplineTypedData<SplineddData>::value) );
 BOOST_STATIC_ASSERT( (IsSplineTypedData<SplinefColor3fData>::value) );
 BOOST_STATIC_ASSERT( (boost::mpl::not_< IsSplineTypedData< Imath::V2f > >::value) );
 BOOST_STATIC_ASSERT( (boost::mpl::not_< IsSplineTypedData< FloatData > >::value) );
+
+/// IsStringVectorTypedData
+BOOST_STATIC_ASSERT( ( boost::mpl::not_< IsStringVectorTypedData<IntVectorData> >::value) );
+BOOST_STATIC_ASSERT( ( IsStringVectorTypedData<StringVectorData>::value ) );
+BOOST_STATIC_ASSERT( ( IsStringVectorTypedData<InternedStringVectorData>::value ) );

--- a/test/IECoreScene/MeshAlgoSegmentTest.py
+++ b/test/IECoreScene/MeshAlgoSegmentTest.py
@@ -184,21 +184,20 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 		self.assertEqual( segments[0]["s"].data, IECore.StringVectorData( ["b"] ) )
 
 
-	def testSegmentUsingIndexedPrimitiveVariable( self ) :
-
-		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 3 ) )
-
-		segmentValues  = IECore.StringVectorData( ["a", "b"] )
-
-		mesh["s"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
-			segmentValues, IECore.IntVectorData( [0, 0, 0, 0, 0, 1, 1, 1, 1] ) )
-
-		segments = IECoreScene.MeshAlgo.segment( mesh, mesh["s"], segmentValues )
-
-		self.assertEqual( len(segments), 2)
-		self.assertEqual( segments[0].numFaces(), 5)
-		self.assertEqual( segments[1].numFaces(), 4)
-
+	# def testSegmentUsingIndexedPrimitiveVariable( self ) :
+	#
+	# 	mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 3 ) )
+	#
+	# 	segmentValues  = IECore.StringVectorData( ["a", "b"] )
+	#
+	# 	mesh["s"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+	# 		segmentValues, IECore.IntVectorData( [0, 0, 0, 0, 0, 1, 1, 1, 1] ) )
+	#
+	# 	segments = IECoreScene.MeshAlgo.segment( mesh, mesh["s"], segmentValues )
+	#
+	# 	self.assertEqual( len(segments), 2)
+	# 	self.assertEqual( segments[0].numFaces(), 5)
+	# 	self.assertEqual( segments[1].numFaces(), 4)
 
 if __name__ == "__main__" :
 	unittest.main()

--- a/test/IECoreScene/MeshAlgoSegmentTest.py
+++ b/test/IECoreScene/MeshAlgoSegmentTest.py
@@ -184,20 +184,20 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 		self.assertEqual( segments[0]["s"].data, IECore.StringVectorData( ["b"] ) )
 
 
-	# def testSegmentUsingIndexedPrimitiveVariable( self ) :
-	#
-	# 	mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 3 ) )
-	#
-	# 	segmentValues  = IECore.StringVectorData( ["a", "b"] )
-	#
-	# 	mesh["s"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
-	# 		segmentValues, IECore.IntVectorData( [0, 0, 0, 0, 0, 1, 1, 1, 1] ) )
-	#
-	# 	segments = IECoreScene.MeshAlgo.segment( mesh, mesh["s"], segmentValues )
-	#
-	# 	self.assertEqual( len(segments), 2)
-	# 	self.assertEqual( segments[0].numFaces(), 5)
-	# 	self.assertEqual( segments[1].numFaces(), 4)
+	def testSegmentUsingIndexedPrimitiveVariable( self ) :
+
+		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 3 ) )
+
+		segmentValues  = IECore.StringVectorData( ["a", "b"] )
+
+		mesh["s"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+			segmentValues, IECore.IntVectorData( [0, 0, 0, 0, 0, 1, 1, 1, 1] ) )
+
+		segments = IECoreScene.MeshAlgo.segment( mesh, mesh["s"], segmentValues )
+
+		self.assertEqual( len(segments), 2)
+		self.assertEqual( segments[0].numFaces(), 5)
+		self.assertEqual( segments[1].numFaces(), 4)
 
 if __name__ == "__main__" :
 	unittest.main()


### PR DESCRIPTION
The cortex segment algo is used by the houdini LiveScene (and therefore exporter), it was implemented by deleting all primitives apart from the part being segmented out, which has horrendous performance as the number of segments increases. 

We now recursively split the primitive into two parts and dispatch these sub partitions as TBB tasks. 

Performance could be improved further by 

- not building a set on each split level and using iterators into a sorted vector
- rewriting the segment completely inserting each segment into a primitive directly perhaps.
- multithreading the deleteCurves / Faces / Points algos, perhaps dispatching a primvar as a task? As the first split is single threaded the thread utilization increases after the first couple of rounds.

**Export timing scene split into 11500 meshes**
before: > 30 minutes
after: 45 seconds




