### PR TITLE
MeshAlgoWinding : Prefer `DataAlgo::dispatch` to `despatchTypedData()` 

### DIFF
--- a/src/IECore/DataAlgo.cpp
+++ b/src/IECore/DataAlgo.cpp
@@ -34,7 +34,6 @@
 
 #include "IECore/DataAlgo.h"
 
-#include "IECore/DespatchTypedData.h"
 #include "IECore/TypedData.h"
 #include "IECore/TypeTraits.h"
 #include "IECore/VectorTypedData.h"

--- a/src/IECoreScene/MeshAlgoWinding.cpp
+++ b/src/IECoreScene/MeshAlgoWinding.cpp
@@ -35,7 +35,7 @@
 #include "IECoreScene/MeshAlgo.h"
 #include "IECoreScene/PolygonIterator.h"
 
-#include "IECore/DespatchTypedData.h"
+#include "IECore/DataAlgo.h"
 
 using namespace Imath;
 using namespace IECore;
@@ -60,16 +60,19 @@ void reverseWinding( MeshPrimitive *mesh, T &values )
 struct ReverseWindingFunctor
 {
 
-	typedef void ReturnType;
-
 	ReverseWindingFunctor( MeshPrimitive *mesh ) : m_mesh( mesh )
 	{
 	}
 
 	template<typename T>
-	void operator()( T *data )
+	void operator()( TypedData<std::vector<T>> *data )
 	{
 		reverseWinding( m_mesh, data->writable() );
+	}
+
+	void operator()( Data *data )
+	{
+		throw IECore::Exception( "Expected VectorTypedData" );
 	}
 
 	private :
@@ -102,7 +105,7 @@ void IECoreScene::MeshAlgo::reverseWinding( MeshPrimitive *mesh )
 			}
 			else
 			{
-				despatchTypedData<ReverseWindingFunctor, TypeTraits::IsVectorTypedData>( it.second.data.get(), reverseWindingFunctor );
+				dispatch( it.second.data.get(), reverseWindingFunctor );
 			}
 		}
 	}


### PR DESCRIPTION
Just a quick PR to update one more thing to use `DataAlgo::dispatch()`. I'm going to try to drip feed this sort of refactoring in amongst my bigger tasks.