### PR TITLE
SConstruct : Make IECoreAlembic module depend on IECoreScene

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2948,6 +2948,7 @@ if doConfigure :
 		)
 		alembicPythonModule = alembicPythonModuleEnv.SharedLibrary( "contrib/IECoreAlembic/python/IECoreAlembic/_IECoreAlembic", alembicPythonSources )
 		alembicPythonModuleEnv.Depends( alembicPythonModule, alembicLibrary )
+		alembicPythonModuleEnv.Depends( alembicPythonModule, scenePythonModule )
 
 		alembicPythonModuleInstall = alembicPythonModuleEnv.Install( "$INSTALL_PYTHON_DIR/IECoreAlembic", alembicPythonScripts + alembicPythonModule )
 		alembicPythonModuleEnv.AddPostAction( "$INSTALL_PYTHON_DIR/IECoreAlembic", lambda target, source, env : makeSymLinks( alembicPythonModuleEnv, alembicPythonModuleEnv["INSTALL_PYTHON_DIR"] ) )


### PR DESCRIPTION
This stops the IECoreAlembic tests from being run before the IECoreScene module has been compiled.