### PR TITLE
IECoreGL : CachedConverter fixed thread safety of deferredRemovals

### DIFF
--- a/src/IECoreGL/CachedConverter.cpp
+++ b/src/IECoreGL/CachedConverter.cpp
@@ -44,6 +44,8 @@
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"
 
+#include "tbb/concurrent_vector.h"
+
 using namespace IECoreGL;
 
 namespace
@@ -115,7 +117,7 @@ struct CachedConverter::MemberData
 
 	typedef IECore::LRUCache<IECore::MurmurHash, IECore::RunTimeTypedPtr, IECore::LRUCachePolicy::Parallel, CacheGetterKey> Cache;
 	Cache cache;
-	std::vector<IECore::RunTimeTypedPtr> deferredRemovals;
+	tbb::concurrent_vector<IECore::RunTimeTypedPtr> deferredRemovals;
 
 };
 


### PR DESCRIPTION
Just to give context to this bug ASAN reported the following:

```
==63842==ERROR: AddressSanitizer: attempting double-free on 0x606004cc3ca0 in thread T49:
==64012==AddressSanitizer: failed to intercept '__isoc99_printf'
==64012==AddressSanitizer: failed to intercept '__isoc99_sprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_snprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_fprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_vprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_vsprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_vsnprintf'
==64012==AddressSanitizer: failed to intercept '__isoc99_vfprintf'
==64012==AddressSanitizer: libc interceptors initialized
|| `[0x10007fff8000, 0x7fffffffffff]` || HighMem    ||
|| `[0x02008fff7000, 0x10007fff7fff]` || HighShadow ||
|| `[0x00008fff7000, 0x02008fff6fff]` || ShadowGap  ||
|| `[0x00007fff8000, 0x00008fff6fff]` || LowShadow  ||
|| `[0x000000000000, 0x00007fff7fff]` || LowMem     ||
MemToShadow(shadow): 0x00008fff7000 0x000091ff6dff 0x004091ff6e00 0x02008fff6fff
redzone=16
max_redzone=2048
quarantine_size_mb=256M
thread_local_quarantine_size_kb=1024K
malloc_context_size=30
SHADOW_SCALE: 3
SHADOW_GRANULARITY: 8
SHADOW_OFFSET: 0x7fff8000
==64012==Installed the sigaction for signal 11
==64012==Installed the sigaction for signal 7
==64012==Installed the sigaction for signal 8
==64012==T0: stack [0x7fff165c9000,0x7fff16dc9000) size 0x800000; local=0x7fff16d89320
==64012==AddressSanitizer Init done
    #0 0x7f992b0945f0 in operator delete(void*) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_new_delete.cc:137
    #1 0x7f990d6d79f0 in __gnu_cxx::new_allocator<boost::intrusive_ptr<IECore::RunTimeTyped> >::deallocate(boost::intrusive_ptr<IECore::RunTimeTyped>*, unsigned long) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/ext/new_allocator.h:110:9
    #2 0x7f990d6d79f0 in std::_Vector_base<boost::intrusive_ptr<IECore::RunTimeTyped>, std::allocator<boost::intrusive_ptr<IECore::RunTimeTyped> > >::_M_deallocate(boost::intrusive_ptr<IECore::RunTimeTyped>*, unsigned long) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/bits/stl_vector.h:174
    #3 0x7f990d6d79f0 in void std::vector<boost::intrusive_ptr<IECore::RunTimeTyped>, std::allocator<boost::intrusive_ptr<IECore::RunTimeTyped> > >::_M_emplace_back_aux<boost::intrusive_ptr<IECore::RunTimeTyped> const&>(boost::intrusive_ptr<IECore::RunTimeTyped> const&) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/bits/vector.tcc:430
    #4 0x7f9906f271cc in boost::function2<void, IECore::MurmurHash const&, boost::intrusive_ptr<IECore::RunTimeTyped> const&>::operator()(IECore::MurmurHash const&, boost::intrusive_ptr<IECore::RunTimeTyped> const&) const /software/tools/include/cent7.x86_64/boost/1.61.0/boost/function/function_template.hpp:770:14
    #5 0x7f9906f271cc in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::eraseInternal(IECore::MurmurHash const&, IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::CacheEntry&) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:756
    #6 0x7f9906f271cc in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::limitCost(unsigned long) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:776
    #7 0x7f9906f23255 in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::get((anonymous namespace)::CacheGetterKey const&) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:679:3
    #8 0x7f9906f23255 in IECoreGL::CachedConverter::convert(IECore::Object const*) /disk1/don/dev/cortex/src/IECoreGL/CachedConverter.cpp:134
    #9 0x7f98d7cfb90d in (anonymous namespace)::objectToRenderable(IECore::Object const*) /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:87:96
    #10 0x7f98d7cfb90d in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:530
    #11 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #12 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #13 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #14 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #15 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #16 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #17 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #18 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #19 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #20 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #21 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #22 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #23 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #24 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #25 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #26 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #27 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #28 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #29 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #30 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #31 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #32 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #33 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #34 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #35 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #36 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #37 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #38 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #39 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #40 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #41 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #42 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #43 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #44 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #45 0x7f9919093310 in tbb::internal::arena::process(tbb::internal::generic_scheduler&) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/arena.cpp:96
    #46 0x7f9919092582 in tbb::internal::market::process(rml::job&) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/market.cpp:495
    #47 0x7f991908e6a6 in tbb::internal::rml::private_worker::run() /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/private_server.cpp:275
    #48 0x7f991908e8c8 in tbb::internal::rml::private_worker::thread_routine(void*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/private_server.cpp:228
    #49 0x7f992a94bdf4 in start_thread (/lib64/libpthread.so.0+0x7df4)
    #50 0x7f9929f701ac in __clone (/lib64/libc.so.6+0xf61ac)

0x606004cc3ca0 is located 0 bytes inside of 64-byte region [0x606004cc3ca0,0x606004cc3ce0)
freed by thread T37 here:
==63842==AddressSanitizer CHECK failed: /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_descriptions.cc:176 "((id)) != (0)" (0x0, 0x0)
    #0 0x7f992b08e80f in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_rtl.cc:69
    #1 0x7f992af9be85 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/sanitizer_common/sanitizer_termination.cc:79
    #2 0x7f992afba08f in GetStackTraceFromId /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_descriptions.cc:176
    #3 0x7f992afba08f in __asan::HeapAddressDescription::Print() const /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_descriptions.cc:398
    #4 0x7f992afbb5ac in __asan::ErrorDoubleFree::Print() /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_errors.cc:117
    #5 0x7f992b08a57b in __asan::ErrorDescription::Print() /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_errors.h:374
    #6 0x7f992b08a57b in ~ScopedInErrorReport /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_report.cc:177
    #7 0x7f992b08a57b in __asan::ReportDoubleFree(unsigned long, __sanitizer::BufferedStackTrace*) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_report.cc:279
    #8 0x7f992afb595a in __asan::Allocator::ReportInvalidFree(void*, unsigned char, __sanitizer::BufferedStackTrace*) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_allocator.cc:652
    #9 0x7f992afb595a in __asan::Allocator::AtomicallySetQuarantineFlagIfAllocated(__asan::AsanChunk*, void*, __sanitizer::BufferedStackTrace*) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_allocator.cc:523
    #10 0x7f992afb595a in __asan::Allocator::Deallocate(void*, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_allocator.cc:597
    #11 0x7f992afb595a in __asan::asan_free(void*, __sanitizer::BufferedStackTrace*, __asan::AllocType) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_allocator.cc:805
    #12 0x7f992b0945c6 in operator delete(void*) /disk1/chrisba/llvm-5.0.1.src/projects/compiler-rt/lib/asan/asan_new_delete.cc:137
    #13 0x7f990d6d79f0 in __gnu_cxx::new_allocator<boost::intrusive_ptr<IECore::RunTimeTyped> >::deallocate(boost::intrusive_ptr<IECore::RunTimeTyped>*, unsigned long) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/ext/new_allocator.h:110:9
    #14 0x7f990d6d79f0 in std::_Vector_base<boost::intrusive_ptr<IECore::RunTimeTyped>, std::allocator<boost::intrusive_ptr<IECore::RunTimeTyped> > >::_M_deallocate(boost::intrusive_ptr<IECore::RunTimeTyped>*, unsigned long) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/bits/stl_vector.h:174
    #15 0x7f990d6d79f0 in void std::vector<boost::intrusive_ptr<IECore::RunTimeTyped>, std::allocator<boost::intrusive_ptr<IECore::RunTimeTyped> > >::_M_emplace_back_aux<boost::intrusive_ptr<IECore::RunTimeTyped> const&>(boost::intrusive_ptr<IECore::RunTimeTyped> const&) /usr/lib/gcc/x86_64-redhat-linux/4.8.3/../../../../include/c++/4.8.3/bits/vector.tcc:430
    #16 0x7f9906f271cc in boost::function2<void, IECore::MurmurHash const&, boost::intrusive_ptr<IECore::RunTimeTyped> const&>::operator()(IECore::MurmurHash const&, boost::intrusive_ptr<IECore::RunTimeTyped> const&) const /software/tools/include/cent7.x86_64/boost/1.61.0/boost/function/function_template.hpp:770:14
    #17 0x7f9906f271cc in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::eraseInternal(IECore::MurmurHash const&, IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::CacheEntry&) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:756
    #18 0x7f9906f271cc in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::limitCost(unsigned long) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:776
    #19 0x7f9906f23255 in IECore::LRUCache<IECore::MurmurHash, boost::intrusive_ptr<IECore::RunTimeTyped>, IECore::LRUCachePolicy::Parallel, (anonymous namespace)::CacheGetterKey>::get((anonymous namespace)::CacheGetterKey const&) /disk1/don/dev/cortex/include/IECore/LRUCache.inl:679:3
    #20 0x7f9906f23255 in IECoreGL::CachedConverter::convert(IECore::Object const*) /disk1/don/dev/cortex/src/IECoreGL/CachedConverter.cpp:134
    #21 0x7f98d7cfb90d in (anonymous namespace)::objectToRenderable(IECore::Object const*) /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:87:96
    #22 0x7f98d7cfb90d in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:530
    #23 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #24 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #25 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #26 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #27 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #28 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #29 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #30 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #31 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #32 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #33 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #34 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #35 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #36 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #37 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #38 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #39 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #40 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #41 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #42 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #43 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #44 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #45 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #46 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #47 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #48 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #49 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #50 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #51 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #52 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #53 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #54 0x7f98d7cfd253 in tbb::task::wait_for_all() /software/tools/include/cent7.x86_64/tbb/4.4/tbb/task.h:744:25
    #55 0x7f98d7cfd253 in GafferSceneUI::SceneGadget::UpdateTask::execute() /disk1/don/dev/gaffer/src/GafferSceneUI/SceneGadget.cpp:630
    #56 0x7f9919098cf1 in tbb::internal::custom_scheduler<tbb::internal::IntelSchedulerTraits>::local_wait_for_all(tbb::task&, tbb::task*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/custom_scheduler.h:474
    #57 0x7f9919093310 in tbb::internal::arena::process(tbb::internal::generic_scheduler&) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/arena.cpp:96
    #58 0x7f9919092582 in tbb::internal::market::process(rml::job&) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/market.cpp:495
    #59 0x7f991908e6a6 in tbb::internal::rml::private_worker::run() /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/private_server.cpp:275
    #60 0x7f991908e8c8 in tbb::internal::rml::private_worker::thread_routine(void*) /disk2/build/a-gcc-4.8.3/tbb43_20150424oss/build/linux_intel64_gcc_cc4.8.3_libc2.17_kernel3.10.0_release/../../src/tbb/private_server.cpp:228
    #61 0x7f992a94bdf4 in start_thread (/lib64/libpthread.so.0+0x7df4)
    #62 0x7f9929f701ac in __clone (/lib64/libc.so.6+0xf61ac)
```