### PR TITLE
IECoreHoudini : Round trip arbitrarily named UVs from houdini to cortex and back

### DIFF
--- a/include/IECoreHoudini/ToHoudiniNumericAttribConverter.inl
+++ b/include/IECoreHoudini/ToHoudiniNumericAttribConverter.inl
@@ -95,6 +95,10 @@ struct GetInterpretation
 		{
 			m_attrRef.setTypeInfo( GA_TYPE_COLOR );
 		}
+		else if ( interp == IECore::GeometricData::UV )
+		{
+			m_attrRef.setTypeInfo( GA_TYPE_TEXTURE_COORD );
+		}
 	}
 };
 

--- a/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
@@ -409,7 +409,7 @@ void FromHoudiniGeometryConverter::transferElementAttribs( const GU_Detail *geo,
 		}
 
 		// special case for uvs
-		if( name.equal( "uv" ) )
+		if( attr->getOptions().typeInfo() == GA_TYPE_TEXTURE_COORD )
 		{
 			IntVectorDataPtr indexData = new IntVectorData;
 			std::vector<int> &indices = indexData->writable();
@@ -447,7 +447,7 @@ void FromHoudiniGeometryConverter::transferElementAttribs( const GU_Detail *geo,
 				}
 			}
 
-			result->variables["uv"] = PrimitiveVariable( interpolation, uvData, indexData );
+			result->variables[name.toStdString()] = PrimitiveVariable( interpolation, uvData, indexData );
 
 			continue;
 		}

--- a/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
@@ -884,6 +884,8 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 		self.assertEqual( sorted([ x.name() for x in geo.globalAttribs() ]), [] )
 
 		uvData = mesh["uv"].data
+		indices = mesh["uv"].indices
+
 		uvs = geo.findVertexAttrib( "uv" )
 
 		i = 0
@@ -892,8 +894,8 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 			verts.reverse()
 			for vert in verts :
 				uvValues = vert.attribValue( uvs )
-				self.assertAlmostEqual( uvValues[0], uvData[i][0] )
-				self.assertAlmostEqual( uvValues[1], uvData[i][1] )
+				self.assertAlmostEqual( uvValues[0], uvData[indices[i]][0] )
+				self.assertAlmostEqual( uvValues[1], uvData[indices[i]][1] )
 				i += 1
 
 		converter["convertStandardAttributes"].setTypedValue( False )
@@ -912,8 +914,8 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 			verts.reverse()
 			for vert in verts :
 				uvValues = vert.attribValue( uvs )
-				self.assertAlmostEqual( uvValues[0], uvData[i][0] )
-				self.assertAlmostEqual( uvValues[1], uvData[i][1] )
+				self.assertAlmostEqual( uvValues[0], uvData[indices[i]][0] )
+				self.assertAlmostEqual( uvValues[1], uvData[indices[i]][1] )
 				i += 1
 
 	def testCannotTransformRest( self ) :


### PR DESCRIPTION
Previously only attributes called *uv* were being deduplicated and set to the correct *UV geometric interpretation* 

Now if the attribute has the *GA_TYPE_TEXTURE_COORD* typeInfo we proceed to convert like a UV and in the reverse direction we set the type info correctly in *GetInterpretation*

