### PR TITLE
IECoreScene : Copy interpretation in reample algos.

### DIFF
--- a/src/IECoreScene/CurvesAlgo.cpp
+++ b/src/IECoreScene/CurvesAlgo.cpp
@@ -119,6 +119,10 @@ struct  CurvesUniformToVertex
 				trg.push_back( *srcIt );
 			}
 		}
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data.get(), result.get() );
+
 		return result;
 	}
 
@@ -157,6 +161,9 @@ struct  CurvesVertexToUniform
 			trg.push_back( total / *oIt );
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -187,6 +194,9 @@ struct  CurvesUniformToVarying
 				trg.push_back( *srcIt );
 			}
 		}
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data.get(), result.get() );
 
 		return result;
 	}
@@ -226,6 +236,9 @@ struct  CurvesVaryingToUniform
 
 			trg.push_back( total / varyingSize );
 		}
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
 
 		return result;
 	}
@@ -278,6 +291,9 @@ struct  CurvesVertexToVarying
 			}
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -329,6 +345,9 @@ struct CurvesVaryingToVertex
 				trg.push_back( evalPrimVar<typename From::ValueType::value_type>( evaluatorResult.get(), *primVar ) );
 			}
 		}
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
 
 		return result;
 	}

--- a/src/IECoreScene/FaceVaryingPromotionOp.cpp
+++ b/src/IECoreScene/FaceVaryingPromotionOp.cpp
@@ -35,6 +35,7 @@
 #include "IECoreScene/FaceVaryingPromotionOp.h"
 
 #include "IECoreScene/PolygonVertexIterator.h"
+#include "IECoreScene/private/PrimitiveVariableAlgos.h"
 
 #include "IECore/CompoundParameter.h"
 #include "IECore/DespatchTypedData.h"
@@ -177,6 +178,9 @@ struct FaceVaryingPromotionOp::Promoter
 		}
 
 		assert( result->readable().size() == m_vertIds.size() );
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<T> copier;
+		copier( data, result.get() );
 
 		return result;
 	}

--- a/src/IECoreScene/MeshAlgoResample.cpp
+++ b/src/IECoreScene/MeshAlgoResample.cpp
@@ -35,6 +35,7 @@
 #include "IECoreScene/FaceVaryingPromotionOp.h"
 #include "IECoreScene/MeshAlgo.h"
 #include "IECoreScene/private/PrimitiveAlgoUtils.h"
+#include "IECoreScene/private/PrimitiveVariableAlgos.h"
 
 #include "IECore/DespatchTypedData.h"
 
@@ -83,6 +84,9 @@ struct MeshVertexToUniform
 			trg.push_back( total / *it );
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -126,6 +130,9 @@ struct MeshUniformToVertex
 			*trgIt /= *cIt;
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -167,6 +174,9 @@ struct MeshFaceVaryingToVertex
 			*trgIt /= *cIt;
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -206,6 +216,9 @@ struct MeshFaceVaryingToUniform
 
 			trg.push_back( total / *it );
 		}
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
 
 		return result;
 	}

--- a/src/IECoreScene/PointsAlgo.cpp
+++ b/src/IECoreScene/PointsAlgo.cpp
@@ -73,6 +73,9 @@ struct PointsVertexToUniform
 			trg.push_back( std::accumulate( src.begin() + 1, src.end(), *src.begin() ) / src.size() );
 		}
 
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
+
 		return result;
 	}
 
@@ -94,6 +97,9 @@ struct PointsUniformToVertex
 		const typename From::ValueType::const_iterator srcIt = data->readable().begin();
 
 		trg.resize( m_points->variableSize( PrimitiveVariable::Vertex ), *srcIt );
+
+		IECoreScene::PrimitiveVariableAlgos::GeometricInterpretationCopier<From> copier;
+		copier( data, result.get() );
 
 		return result;
 	}

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -91,6 +91,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		testObject["h"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( range( 0, 3 ) ), IECore.IntVectorData( [ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2 ] ) )
 		testObject["i"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( range( 0, 3 ) ), IECore.IntVectorData( [ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2 ] ) )
 
+		# with geometric interpretation
+		testObject["uniform_UV_V2f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V2fVectorData( [imath.V2f(0,1), imath.V2f(2,3)], IECore.GeometricData.Interpretation.UV ) )
+		testObject["vertex_Point_V3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [imath.V3f(i, i, i) for i in range(0, 16)], IECore.GeometricData.Interpretation.Point ) )
+		testObject["varying_Color_V3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.V3fVectorData( [imath.V3f(i, i, i) for i in range(0, 12)], IECore.GeometricData.Interpretation.Color ) )
+		testObject["facevarying_Normal_V3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.V3fVectorData( [imath.V3f(i, i, i) for i in range(0, 12)], IECore.GeometricData.Interpretation.Normal) )
+
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
 		return testObject
@@ -182,6 +188,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( ( [ 0 ] * 8 ) + ( [ 1 ] * 8 ) ) )
 
+		p = curves["uniform_UV_V2f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex)
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		actual = p.data
+		expected = IECore.V2fVectorData( ( [ imath.V2f(0, 1) ] * 8 ) + ( [ imath.V2f(2, 3) ] * 8 ), IECore.GeometricData.Interpretation.UV )
+
+		self.assertEqual( actual, expected )
+
 	def testBSplineCurvesUniformToVarying( self ) :
 		curves = self.curvesBSpline()
 		p = curves["c"]
@@ -189,6 +205,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( ( [ 0 ] * 6 ) + ( [ 1 ] * 6 ) ) )
+
+		p = curves["uniform_UV_V2f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		actual = p.data
+		expected = IECore.V2fVectorData( ( [ imath.V2f(0, 1) ] * 6 ) + ( [ imath.V2f(2, 3) ] * 6 ), IECore.GeometricData.Interpretation.UV )
+
+		self.assertEqual( actual, expected )
 
 	def testBSplineCurvesUniformToFaceVarying( self ) :
 
@@ -198,6 +224,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( ( [ 0 ] * 6 ) + ( [ 1 ] * 6 ) ) )
+
+		p = curves["uniform_UV_V2f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		actual = p.data
+		expected = IECore.V2fVectorData( ( [ imath.V2f(0, 1) ] * 6 ) + ( [ imath.V2f(2, 3) ] * 6 ), IECore.GeometricData.Interpretation.UV )
+
+		self.assertEqual( actual, expected )
 
 	def testBSplineCurvesVaryingToConstant( self ) :
 		curves = self.curvesBSpline()
@@ -215,6 +251,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 6, 6.625, 7.25, 7.875, 8.5, 9.125, 9.75, 10.375 ] ) )
 
+		p = curves["varying_Color_V3f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		actual = p.data
+		expected = IECore.V3fVectorData( [ imath.V3f(i, i, i) for i in [ 0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 6, 6.625, 7.25, 7.875, 8.5, 9.125, 9.75, 10.375 ] ], IECore.GeometricData.Interpretation.Color )
+
+		self.assertEqual( actual, expected )
+
 	def testBSplineCurvesVaryingToUniform( self ) :
 		curves = self.curvesBSpline()
 		p = curves["d"]
@@ -223,6 +269,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ sum(range(0,6))/6., sum(range(6,12))/6. ] ) )
 
+		p = curves["varying_Color_V3f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		actual = p.data
+		expected = IECore.V3fVectorData( [ imath.V3f(i, i, i) for i in [ sum(range(0,6))/6., sum(range(6,12))/6. ] ], IECore.GeometricData.Interpretation.Color )
+
+		self.assertEqual( actual, expected )
+
 	def testBSplineCurvesVaryingToFaceVarying( self ) :
 		curves = self.curvesBSpline()
 		p = curves["d"]
@@ -230,6 +286,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( range( 0, 12 ) ) )
+
+		p = curves["varying_Color_V3f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		actual = p.data
+		expected = IECore.V3fVectorData( [ imath.V3f(i, i, i) for i in IECore.FloatVectorData( range( 0, 12 ) ) ], IECore.GeometricData.Interpretation.Color )
+
+		self.assertEqual( actual, expected )
 
 	def testBSplineCurvesFaceVaryingToConstant( self ) :
 		curves = self.curvesBSpline()
@@ -247,6 +313,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 6, 6.625, 7.25, 7.875, 8.5, 9.125, 9.75, 10.375 ] ) )
 
+		p = curves["facevarying_Normal_V3f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		actual = p.data
+		expected = IECore.V3fVectorData( [ imath.V3f(i, i, i) for i in  [ 0, 0.625, 1.25, 1.875, 2.5, 3.125, 3.75, 4.375, 6, 6.625, 7.25, 7.875, 8.5, 9.125, 9.75, 10.375 ] ], IECore.GeometricData.Interpretation.Normal )
+
+		self.assertEqual( actual, expected )
+
 	def testBSplineCurvesFaceVaryingToUniform( self ) :
 		curves = self.curvesBSpline()
 		p = curves["e"]
@@ -262,6 +338,16 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( range( 0, 12 ) ) )
+
+		p = curves["facevarying_Normal_V3f"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		actual = p.data
+		expected = IECore.V3fVectorData( [ imath.V3f(i, i, i) for i in  IECore.FloatVectorData( range( 0, 12 ) ) ], IECore.GeometricData.Interpretation.Normal )
+
+		self.assertEqual( actual, expected )
 
 	def testBSplineCurvesIndexedVertexToUniform( self ) :
 		curves = self.curvesBSpline()

--- a/test/IECoreScene/PointsAlgoTest.py
+++ b/test/IECoreScene/PointsAlgoTest.py
@@ -58,6 +58,10 @@ class PointsAlgoTest( unittest.TestCase ) :
 		testObject["h"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( range( 0, 3 ) ), IECore.IntVectorData( [ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0 ] ) )
 		testObject["i"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( range( 0, 3 ) ), IECore.IntVectorData( [ 0, 1, 2, 0, 1, 2, 0, 1, 2, 0 ] ) )
 
+		testObject["uniform_V3f_Point"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f() ], IECore.GeometricData.Interpretation.Point ) )
+		testObject["vertex_V3f_Normal"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+		 	IECore.V3fVectorData( [imath.V3f( i, i, i ) for i in range( 0, 10 )], IECore.GeometricData.Interpretation.Normal ) )
+
 		testObject["j"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "test" ) )
 
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
@@ -118,6 +122,13 @@ class PointsAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ sum(range(0,10))/10. ] ) )
 
+		p = points["vertex_V3f_Normal"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.V3fVectorData( [imath.V3f(i,i,i) for i in [ sum(range(0,10))/10. ] ], IECore.GeometricData.Interpretation.Normal ) )
+
+
 	def testPointsVertexToUniformZeroPointCount( self ) :
 		def makeEmptyPoints() :
 			testObject = IECoreScene.PointsPrimitive( IECore.V3fVectorData() )
@@ -163,9 +174,15 @@ class PointsAlgoTest( unittest.TestCase ) :
 		points = self.points()
 		p = points["c"]
 		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		d = [ 0 ] * 10
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.FloatVectorData( d ) )
+
+		p = points["uniform_V3f_Point"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
-		self.assertEqual( p.data, IECore.FloatVectorData( [ 0 ] * 10 ) )
+		self.assertEqual( p.data, IECore.V3fVectorData( [imath.V3f(i,i,i) for i in d ], IECore.GeometricData.Interpretation.Point ) )
 
 	def testPointsUniformToVarying( self ) :
 		points = self.points()


### PR DESCRIPTION
The geometric interpretation wasn't copied in the various resample functions. 