### PR TITLE
IECore : Don't modify `sys` module's dlopenflags

### DIFF
--- a/python/IECore/__init__.py
+++ b/python/IECore/__init__.py
@@ -38,20 +38,6 @@
 #
 # Some parts of the IECore library are defined purely in Python. These are shown below.
 
-# Turn on RTLD_GLOBAL to avoid the dreaded cross module RTTI
-# errors on Linux. This causes libIECore etc to be loaded into
-# the global symbol table and those symbols to be shared between
-# modules. Without it, different python modules and/or libraries
-# can end up with their own copies of symbols, which breaks a
-# great many things.
-#
-# We use the awkward "__import__" approach to avoid importing sys
-# and ctypes into the IECore namespace.
-
-__import__( "sys" ).setdlopenflags(
-	__import__( "sys" ).getdlopenflags() | __import__( "ctypes" ).RTLD_GLOBAL
-)
-
 __import__( "imath" )
 
 from _IECore import *


### PR DESCRIPTION
We needed this in the past because we were not managing symbol visibility correctly, so each module had different typeinfo symbols for the same type (for template types, on linux). We now only emit the typeinfo in the module that "owns" the type, so no longer need RTLD_GLOBAL.

This change was motivated by an obscure crash when generating the Gaffer documentation with the Mesa drivers in a Docker container. As far as I can tell, RTLD_GLOBAL was causing conflicts between the LLVM in the Mesa driver and the LLVM in Arnold, which caused crashes at shutdown.

I'm offering this PR somewhat optimistically, to provoke discussion and hopefully some testing in the pipeline at IE. For the most part it is working for me here, but I have an issue with GafferOSL that needs resolving (LLVM complains about not finding symbols at runtime). I do believe we'll be in a better place if we can get away from RTLD_GLOBAL, but recognise that getting there might be risky right now. If testing, note that we set it in a few other spots still ([here](https://github.com/GafferHQ/gaffer/blob/master/bin/gaffer.py#L46) for instance), so you may need to disable to be sure you're testing what you think you are...

I have a sketchy alternative fix for the original Gaffer documentation crash, which is much more isolated in its effects. I'll PR that as well if I can't find something better after a bit more experimentation...