### PR TITLE
 DataAlgo : Add additional `Args&&...` arguments to `dispatch()` 

### DIFF
--- a/include/IECore/DataAlgo.h
+++ b/include/IECore/DataAlgo.h
@@ -71,7 +71,7 @@ IECORE_API const void *address( const IECore::Data *data );
 template<template<typename> class Trait>
 bool trait( const IECore::Data *data );
 
-/// Downcasts `data` to its true derived type and returns the result of calling `functor( derived )`.
+/// Downcasts `data` to its true derived type and returns the result of calling `functor( derived, args )`.
 /// Functors may define arbitrary numbers of overloads to treat each type in a different way :
 ///
 /// ```
@@ -99,10 +99,10 @@ bool trait( const IECore::Data *data );
 ///
 /// };
 /// ```
-template<typename F>
-typename std::result_of<F( Data * )>::type dispatch( Data *data, F &&functor );
-template<typename F>
-typename std::result_of<F( const Data * )>::type dispatch( const Data *data, F &&functor );
+template<typename F, typename... Args>
+typename std::result_of<F( Data *, Args&&... )>::type dispatch( Data *data, F &&functor, Args&&... args );
+template<typename F, typename... Args>
+typename std::result_of<F( const Data *, Args&&... )>::type dispatch( const Data *data, F &&functor, Args&&... args );
 
 } // namespace IECore
 

--- a/include/IECore/DataAlgo.inl
+++ b/include/IECore/DataAlgo.inl
@@ -46,305 +46,305 @@
 namespace IECore
 {
 
-template<class F>
-typename std::result_of<F( Data * )>::type dispatch( Data *data, F &&functor )
+template<class F, typename... Args>
+typename std::result_of<F( Data *, Args&&... )>::type dispatch( Data *data, F &&functor, Args&&... args )
 {
 	IECore::TypeId typeId = data->typeId();
 
 	switch( typeId )
 	{
 		case BoolDataTypeId :
-			return functor( static_cast<BoolData *>( data ) );
+			return functor( static_cast<BoolData *>( data ), std::forward<Args>( args )... );
 		case FloatDataTypeId :
-			return functor( static_cast<FloatData *>( data ) );
+			return functor( static_cast<FloatData *>( data ), std::forward<Args>( args )... );
 		case DoubleDataTypeId :
-			return functor( static_cast<DoubleData *>( data ) );
+			return functor( static_cast<DoubleData *>( data ), std::forward<Args>( args )... );
 		case IntDataTypeId :
-			return functor( static_cast<IntData *>( data ) );
+			return functor( static_cast<IntData *>( data ), std::forward<Args>( args )... );
 		case UIntDataTypeId :
-			return functor( static_cast<UIntData *>( data ) );
+			return functor( static_cast<UIntData *>( data ), std::forward<Args>( args )... );
 		case CharDataTypeId :
-			return functor( static_cast<CharData *>( data ) );
+			return functor( static_cast<CharData *>( data ), std::forward<Args>( args )... );
 		case UCharDataTypeId :
-			return functor( static_cast<UCharData *>( data ) );
+			return functor( static_cast<UCharData *>( data ), std::forward<Args>( args )... );
 		case ShortDataTypeId :
-			return functor( static_cast<ShortData *>( data ) );
+			return functor( static_cast<ShortData *>( data ), std::forward<Args>( args )... );
 		case UShortDataTypeId :
-			return functor( static_cast<UShortData *>( data ) );
+			return functor( static_cast<UShortData *>( data ), std::forward<Args>( args )... );
 		case Int64DataTypeId :
-			return functor( static_cast<Int64Data *>( data ) );
+			return functor( static_cast<Int64Data *>( data ), std::forward<Args>( args )... );
 		case UInt64DataTypeId :
-			return functor( static_cast<UInt64Data *>( data ) );
+			return functor( static_cast<UInt64Data *>( data ), std::forward<Args>( args )... );
 		case StringDataTypeId :
-			return functor( static_cast<StringData *>( data ) );
+			return functor( static_cast<StringData *>( data ), std::forward<Args>( args )... );
 		case InternedStringDataTypeId :
-			return functor( static_cast<InternedStringData *>( data ) );
+			return functor( static_cast<InternedStringData *>( data ), std::forward<Args>( args )... );
 		case HalfDataTypeId :
-			return functor( static_cast<HalfData *>( data ) );
+			return functor( static_cast<HalfData *>( data ), std::forward<Args>( args )... );
 		case V2iDataTypeId :
-			return functor( static_cast<V2iData *>( data ) );
+			return functor( static_cast<V2iData *>( data ), std::forward<Args>( args )... );
 		case V3iDataTypeId :
-			return functor( static_cast<V3iData *>( data ) );
+			return functor( static_cast<V3iData *>( data ), std::forward<Args>( args )... );
 		case V2fDataTypeId :
-			return functor( static_cast<V2fData *>( data ) );
+			return functor( static_cast<V2fData *>( data ), std::forward<Args>( args )... );
 		case V3fDataTypeId :
-			return functor( static_cast<V3fData *>( data ) );
+			return functor( static_cast<V3fData *>( data ), std::forward<Args>( args )... );
 		case V2dDataTypeId :
-			return functor( static_cast<V2dData *>( data ) );
+			return functor( static_cast<V2dData *>( data ), std::forward<Args>( args )... );
 		case V3dDataTypeId :
-			return functor( static_cast<V3dData *>( data ) );
+			return functor( static_cast<V3dData *>( data ), std::forward<Args>( args )... );
 		case Color3fDataTypeId :
-			return functor( static_cast<Color3fData *>( data ) );
+			return functor( static_cast<Color3fData *>( data ), std::forward<Args>( args )... );
 		case Color4fDataTypeId :
-			return functor( static_cast<Color4fData *>( data ) );
+			return functor( static_cast<Color4fData *>( data ), std::forward<Args>( args )... );
 		case Box2iDataTypeId :
-			return functor( static_cast<Box2iData *>( data ) );
+			return functor( static_cast<Box2iData *>( data ), std::forward<Args>( args )... );
 		case Box2fDataTypeId :
-			return functor( static_cast<Box2fData *>( data ) );
+			return functor( static_cast<Box2fData *>( data ), std::forward<Args>( args )... );
 		case Box3fDataTypeId :
-			return functor( static_cast<Box3fData *>( data ) );
+			return functor( static_cast<Box3fData *>( data ), std::forward<Args>( args )... );
 		case Box2dDataTypeId :
-			return functor( static_cast<Box2dData *>( data ) );
+			return functor( static_cast<Box2dData *>( data ), std::forward<Args>( args )... );
 		case Box3dDataTypeId :
-			return functor( static_cast<Box3dData *>( data ) );
+			return functor( static_cast<Box3dData *>( data ), std::forward<Args>( args )... );
 		case M33fDataTypeId :
-			return functor( static_cast<M33fData *>( data ) );
+			return functor( static_cast<M33fData *>( data ), std::forward<Args>( args )... );
 		case M33dDataTypeId :
-			return functor( static_cast<M33dData *>( data ) );
+			return functor( static_cast<M33dData *>( data ), std::forward<Args>( args )... );
 		case M44fDataTypeId :
-			return functor( static_cast<M44fData *>( data ) );
+			return functor( static_cast<M44fData *>( data ), std::forward<Args>( args )... );
 		case M44dDataTypeId :
-			return functor( static_cast<M44dData *>( data ) );
+			return functor( static_cast<M44dData *>( data ), std::forward<Args>( args )... );
 		case TransformationMatrixfDataTypeId :
-			return functor( static_cast<TransformationMatrixfData *>( data ) );
+			return functor( static_cast<TransformationMatrixfData *>( data ), std::forward<Args>( args )... );
 		case TransformationMatrixdDataTypeId :
-			return functor( static_cast<TransformationMatrixdData *>( data ) );
+			return functor( static_cast<TransformationMatrixdData *>( data ), std::forward<Args>( args )... );
 		case QuatfDataTypeId :
-			return functor( static_cast<QuatfData *>( data ) );
+			return functor( static_cast<QuatfData *>( data ), std::forward<Args>( args )... );
 		case QuatdDataTypeId :
-			return functor( static_cast<QuatdData *>( data ) );
+			return functor( static_cast<QuatdData *>( data ), std::forward<Args>( args )... );
 		case SplineffDataTypeId :
-			return functor( static_cast<SplineffData *>( data ) );
+			return functor( static_cast<SplineffData *>( data ), std::forward<Args>( args )... );
 		case SplineddDataTypeId :
-			return functor( static_cast<SplineddData *>( data ) );
+			return functor( static_cast<SplineddData *>( data ), std::forward<Args>( args )... );
 		case SplinefColor3fDataTypeId :
-			return functor( static_cast<SplinefColor3fData *>( data ) );
+			return functor( static_cast<SplinefColor3fData *>( data ), std::forward<Args>( args )... );
 		case SplinefColor4fDataTypeId :
-			return functor( static_cast<SplinefColor4fData *>( data ) );
+			return functor( static_cast<SplinefColor4fData *>( data ), std::forward<Args>( args )... );
 		case DateTimeDataTypeId :
-			return functor( static_cast<DateTimeData *>( data ) );
+			return functor( static_cast<DateTimeData *>( data ), std::forward<Args>( args )... );
 		case BoolVectorDataTypeId :
-			return functor( static_cast<BoolVectorData *>( data ) );
+			return functor( static_cast<BoolVectorData *>( data ), std::forward<Args>( args )... );
 		case FloatVectorDataTypeId :
-			return functor( static_cast<FloatVectorData *>( data ) );
+			return functor( static_cast<FloatVectorData *>( data ), std::forward<Args>( args )... );
 		case DoubleVectorDataTypeId :
-			return functor( static_cast<DoubleVectorData *>( data ) );
+			return functor( static_cast<DoubleVectorData *>( data ), std::forward<Args>( args )... );
 		case HalfVectorDataTypeId :
-			return functor( static_cast<HalfVectorData *>( data ) );
+			return functor( static_cast<HalfVectorData *>( data ), std::forward<Args>( args )... );
 		case IntVectorDataTypeId :
-			return functor( static_cast<IntVectorData *>( data ) );
+			return functor( static_cast<IntVectorData *>( data ), std::forward<Args>( args )... );
 		case UIntVectorDataTypeId :
-			return functor( static_cast<UIntVectorData *>( data ) );
+			return functor( static_cast<UIntVectorData *>( data ), std::forward<Args>( args )... );
 		case CharVectorDataTypeId :
-			return functor( static_cast<CharVectorData *>( data ) );
+			return functor( static_cast<CharVectorData *>( data ), std::forward<Args>( args )... );
 		case UCharVectorDataTypeId :
-			return functor( static_cast<UCharVectorData *>( data ) );
+			return functor( static_cast<UCharVectorData *>( data ), std::forward<Args>( args )... );
 		case ShortVectorDataTypeId :
-			return functor( static_cast<ShortVectorData *>( data ) );
+			return functor( static_cast<ShortVectorData *>( data ), std::forward<Args>( args )... );
 		case UShortVectorDataTypeId :
-			return functor( static_cast<UShortVectorData *>( data ) );
+			return functor( static_cast<UShortVectorData *>( data ), std::forward<Args>( args )... );
 		case Int64VectorDataTypeId :
-			return functor( static_cast<Int64VectorData *>( data ) );
+			return functor( static_cast<Int64VectorData *>( data ), std::forward<Args>( args )... );
 		case UInt64VectorDataTypeId :
-			return functor( static_cast<UInt64VectorData *>( data ) );
+			return functor( static_cast<UInt64VectorData *>( data ), std::forward<Args>( args )... );
 		case StringVectorDataTypeId :
-			return functor( static_cast<StringVectorData *>( data ) );
+			return functor( static_cast<StringVectorData *>( data ), std::forward<Args>( args )... );
 		case InternedStringVectorDataTypeId :
-			return functor( static_cast<InternedStringVectorData *>( data ) );
+			return functor( static_cast<InternedStringVectorData *>( data ), std::forward<Args>( args )... );
 		case V2iVectorDataTypeId :
-			return functor( static_cast<V2iVectorData *>( data ) );
+			return functor( static_cast<V2iVectorData *>( data ), std::forward<Args>( args )... );
 		case V2fVectorDataTypeId :
-			return functor( static_cast<V2fVectorData *>( data ) );
+			return functor( static_cast<V2fVectorData *>( data ), std::forward<Args>( args )... );
 		case V2dVectorDataTypeId :
-			return functor( static_cast<V2dVectorData *>( data ) );
+			return functor( static_cast<V2dVectorData *>( data ), std::forward<Args>( args )... );
 		case V3iVectorDataTypeId :
-			return functor( static_cast<V3iVectorData *>( data ) );
+			return functor( static_cast<V3iVectorData *>( data ), std::forward<Args>( args )... );
 		case V3fVectorDataTypeId :
-			return functor( static_cast<V3fVectorData *>( data ) );
+			return functor( static_cast<V3fVectorData *>( data ), std::forward<Args>( args )... );
 		case V3dVectorDataTypeId :
-			return functor( static_cast<V3dVectorData *>( data ) );
+			return functor( static_cast<V3dVectorData *>( data ), std::forward<Args>( args )... );
 		case Box3fVectorDataTypeId :
-			return functor( static_cast<Box3fVectorData *>( data ) );
+			return functor( static_cast<Box3fVectorData *>( data ), std::forward<Args>( args )... );
 		case Box3dVectorDataTypeId :
-			return functor( static_cast<Box3dVectorData *>( data ) );
+			return functor( static_cast<Box3dVectorData *>( data ), std::forward<Args>( args )... );
 		case M33fVectorDataTypeId :
-			return functor( static_cast<M33fVectorData *>( data ) );
+			return functor( static_cast<M33fVectorData *>( data ), std::forward<Args>( args )... );
 		case M33dVectorDataTypeId :
-			return functor( static_cast<M33dVectorData *>( data ) );
+			return functor( static_cast<M33dVectorData *>( data ), std::forward<Args>( args )... );
 		case M44fVectorDataTypeId :
-			return functor( static_cast<M44fVectorData *>( data ) );
+			return functor( static_cast<M44fVectorData *>( data ), std::forward<Args>( args )... );
 		case M44dVectorDataTypeId :
-			return functor( static_cast<M44dVectorData *>( data ) );
+			return functor( static_cast<M44dVectorData *>( data ), std::forward<Args>( args )... );
 		case QuatfVectorDataTypeId :
-			return functor( static_cast<QuatfVectorData *>( data ) );
+			return functor( static_cast<QuatfVectorData *>( data ), std::forward<Args>( args )... );
 		case QuatdVectorDataTypeId :
-			return functor( static_cast<QuatdVectorData *>( data ) );
+			return functor( static_cast<QuatdVectorData *>( data ), std::forward<Args>( args )... );
 		case Color3fVectorDataTypeId :
-			return functor( static_cast<Color3fVectorData *>( data ) );
+			return functor( static_cast<Color3fVectorData *>( data ), std::forward<Args>( args )... );
 		case Color4fVectorDataTypeId :
-			return functor( static_cast<Color4fVectorData *>( data ) );
+			return functor( static_cast<Color4fVectorData *>( data ), std::forward<Args>( args )... );
 		default :
 			throw InvalidArgumentException( boost::str ( boost::format( "Data has unknown type '%1%' / '%2%' " ) % typeId % data->typeName() ) );
 	}
 }
 
-template<class F>
-typename std::result_of<F( const Data * )>::type dispatch( const Data *data, F &&functor )
+template<class F, typename... Args>
+typename std::result_of<F( const Data *, Args&&... )>::type dispatch( const Data *data, F &&functor, Args&&... args )
 {
 	IECore::TypeId typeId = data->typeId();
 
 	switch( typeId )
 	{
 		case BoolDataTypeId :
-			return functor( static_cast<const BoolData *>( data ) );
+			return functor( static_cast<const BoolData *>( data ), std::forward<args>( args )... );
 		case FloatDataTypeId :
-			return functor( static_cast<const FloatData *>( data ) );
+			return functor( static_cast<const FloatData *>( data ), std::forward<args>( args )... );
 		case DoubleDataTypeId :
-			return functor( static_cast<const DoubleData *>( data ) );
+			return functor( static_cast<const DoubleData *>( data ), std::forward<args>( args )... );
 		case IntDataTypeId :
-			return functor( static_cast<const IntData *>( data ) );
+			return functor( static_cast<const IntData *>( data ), std::forward<args>( args )... );
 		case UIntDataTypeId :
-			return functor( static_cast<const UIntData *>( data ) );
+			return functor( static_cast<const UIntData *>( data ), std::forward<args>( args )... );
 		case CharDataTypeId :
-			return functor( static_cast<const CharData *>( data ) );
+			return functor( static_cast<const CharData *>( data ), std::forward<args>( args )... );
 		case UCharDataTypeId :
-			return functor( static_cast<const UCharData *>( data ) );
+			return functor( static_cast<const UCharData *>( data ), std::forward<args>( args )... );
 		case ShortDataTypeId :
-			return functor( static_cast<const ShortData *>( data ) );
+			return functor( static_cast<const ShortData *>( data ), std::forward<args>( args )... );
 		case UShortDataTypeId :
-			return functor( static_cast<const UShortData *>( data ) );
+			return functor( static_cast<const UShortData *>( data ), std::forward<args>( args )... );
 		case Int64DataTypeId :
-			return functor( static_cast<const Int64Data *>( data ) );
+			return functor( static_cast<const Int64Data *>( data ), std::forward<args>( args )... );
 		case UInt64DataTypeId :
-			return functor( static_cast<const UInt64Data *>( data ) );
+			return functor( static_cast<const UInt64Data *>( data ), std::forward<args>( args )... );
 		case StringDataTypeId :
-			return functor( static_cast<const StringData *>( data ) );
+			return functor( static_cast<const StringData *>( data ), std::forward<args>( args )... );
 		case InternedStringDataTypeId :
-			return functor( static_cast<const InternedStringData *>( data ) );
+			return functor( static_cast<const InternedStringData *>( data ), std::forward<args>( args )... );
 		case HalfDataTypeId :
-			return functor( static_cast<const HalfData *>( data ) );
+			return functor( static_cast<const HalfData *>( data ), std::forward<args>( args )... );
 		case V2iDataTypeId :
-			return functor( static_cast<const V2iData *>( data ) );
+			return functor( static_cast<const V2iData *>( data ), std::forward<args>( args )... );
 		case V3iDataTypeId :
-			return functor( static_cast<const V3iData *>( data ) );
+			return functor( static_cast<const V3iData *>( data ), std::forward<args>( args )... );
 		case V2fDataTypeId :
-			return functor( static_cast<const V2fData *>( data ) );
+			return functor( static_cast<const V2fData *>( data ), std::forward<args>( args )... );
 		case V3fDataTypeId :
-			return functor( static_cast<const V3fData *>( data ) );
+			return functor( static_cast<const V3fData *>( data ), std::forward<args>( args )... );
 		case V2dDataTypeId :
-			return functor( static_cast<const V2dData *>( data ) );
+			return functor( static_cast<const V2dData *>( data ), std::forward<args>( args )... );
 		case V3dDataTypeId :
-			return functor( static_cast<const V3dData *>( data ) );
+			return functor( static_cast<const V3dData *>( data ), std::forward<args>( args )... );
 		case Color3fDataTypeId :
-			return functor( static_cast<const Color3fData *>( data ) );
+			return functor( static_cast<const Color3fData *>( data ), std::forward<args>( args )... );
 		case Color4fDataTypeId :
-			return functor( static_cast<const Color4fData *>( data ) );
+			return functor( static_cast<const Color4fData *>( data ), std::forward<args>( args )... );
 		case Box2iDataTypeId :
-			return functor( static_cast<const Box2iData *>( data ) );
+			return functor( static_cast<const Box2iData *>( data ), std::forward<args>( args )... );
 		case Box2fDataTypeId :
-			return functor( static_cast<const Box2fData *>( data ) );
+			return functor( static_cast<const Box2fData *>( data ), std::forward<args>( args )... );
 		case Box3fDataTypeId :
-			return functor( static_cast<const Box3fData *>( data ) );
+			return functor( static_cast<const Box3fData *>( data ), std::forward<args>( args )... );
 		case Box2dDataTypeId :
-			return functor( static_cast<const Box2dData *>( data ) );
+			return functor( static_cast<const Box2dData *>( data ), std::forward<args>( args )... );
 		case Box3dDataTypeId :
-			return functor( static_cast<const Box3dData *>( data ) );
+			return functor( static_cast<const Box3dData *>( data ), std::forward<args>( args )... );
 		case M33fDataTypeId :
-			return functor( static_cast<const M33fData *>( data ) );
+			return functor( static_cast<const M33fData *>( data ), std::forward<args>( args )... );
 		case M33dDataTypeId :
-			return functor( static_cast<const M33dData *>( data ) );
+			return functor( static_cast<const M33dData *>( data ), std::forward<args>( args )... );
 		case M44fDataTypeId :
-			return functor( static_cast<const M44fData *>( data ) );
+			return functor( static_cast<const M44fData *>( data ), std::forward<args>( args )... );
 		case M44dDataTypeId :
-			return functor( static_cast<const M44dData *>( data ) );
+			return functor( static_cast<const M44dData *>( data ), std::forward<args>( args )... );
 		case TransformationMatrixfDataTypeId :
-			return functor( static_cast<const TransformationMatrixfData *>( data ) );
+			return functor( static_cast<const TransformationMatrixfData *>( data ), std::forward<args>( args )... );
 		case TransformationMatrixdDataTypeId :
-			return functor( static_cast<const TransformationMatrixdData *>( data ) );
+			return functor( static_cast<const TransformationMatrixdData *>( data ), std::forward<args>( args )... );
 		case QuatfDataTypeId :
-			return functor( static_cast<const QuatfData *>( data ) );
+			return functor( static_cast<const QuatfData *>( data ), std::forward<args>( args )... );
 		case QuatdDataTypeId :
-			return functor( static_cast<const QuatdData *>( data ) );
+			return functor( static_cast<const QuatdData *>( data ), std::forward<args>( args )... );
 		case SplineffDataTypeId :
-			return functor( static_cast<const SplineffData *>( data ) );
+			return functor( static_cast<const SplineffData *>( data ), std::forward<args>( args )... );
 		case SplineddDataTypeId :
-			return functor( static_cast<const SplineddData *>( data ) );
+			return functor( static_cast<const SplineddData *>( data ), std::forward<args>( args )... );
 		case SplinefColor3fDataTypeId :
-			return functor( static_cast<const SplinefColor3fData *>( data ) );
+			return functor( static_cast<const SplinefColor3fData *>( data ), std::forward<args>( args )... );
 		case SplinefColor4fDataTypeId :
-			return functor( static_cast<const SplinefColor4fData *>( data ) );
+			return functor( static_cast<const SplinefColor4fData *>( data ), std::forward<args>( args )... );
 		case DateTimeDataTypeId :
-			return functor( static_cast<const DateTimeData *>( data ) );
+			return functor( static_cast<const DateTimeData *>( data ), std::forward<args>( args )... );
 		case BoolVectorDataTypeId :
-			return functor( static_cast<const BoolVectorData *>( data ) );
+			return functor( static_cast<const BoolVectorData *>( data ), std::forward<args>( args )... );
 		case FloatVectorDataTypeId :
-			return functor( static_cast<const FloatVectorData *>( data ) );
+			return functor( static_cast<const FloatVectorData *>( data ), std::forward<args>( args )... );
 		case DoubleVectorDataTypeId :
-			return functor( static_cast<const DoubleVectorData *>( data ) );
+			return functor( static_cast<const DoubleVectorData *>( data ), std::forward<args>( args )... );
 		case HalfVectorDataTypeId :
-			return functor( static_cast<const HalfVectorData *>( data ) );
+			return functor( static_cast<const HalfVectorData *>( data ), std::forward<args>( args )... );
 		case IntVectorDataTypeId :
-			return functor( static_cast<const IntVectorData *>( data ) );
+			return functor( static_cast<const IntVectorData *>( data ), std::forward<args>( args )... );
 		case UIntVectorDataTypeId :
-			return functor( static_cast<const UIntVectorData *>( data ) );
+			return functor( static_cast<const UIntVectorData *>( data ), std::forward<args>( args )... );
 		case CharVectorDataTypeId :
-			return functor( static_cast<const CharVectorData *>( data ) );
+			return functor( static_cast<const CharVectorData *>( data ), std::forward<args>( args )... );
 		case UCharVectorDataTypeId :
-			return functor( static_cast<const UCharVectorData *>( data ) );
+			return functor( static_cast<const UCharVectorData *>( data ), std::forward<args>( args )... );
 		case ShortVectorDataTypeId :
-			return functor( static_cast<const ShortVectorData *>( data ) );
+			return functor( static_cast<const ShortVectorData *>( data ), std::forward<args>( args )... );
 		case UShortVectorDataTypeId :
-			return functor( static_cast<const UShortVectorData *>( data ) );
+			return functor( static_cast<const UShortVectorData *>( data ), std::forward<args>( args )... );
 		case Int64VectorDataTypeId :
-			return functor( static_cast<const Int64VectorData *>( data ) );
+			return functor( static_cast<const Int64VectorData *>( data ), std::forward<args>( args )... );
 		case UInt64VectorDataTypeId :
-			return functor( static_cast<const UInt64VectorData *>( data ) );
+			return functor( static_cast<const UInt64VectorData *>( data ), std::forward<args>( args )... );
 		case StringVectorDataTypeId :
-			return functor( static_cast<const StringVectorData *>( data ) );
+			return functor( static_cast<const StringVectorData *>( data ), std::forward<args>( args )... );
 		case InternedStringVectorDataTypeId :
-			return functor( static_cast<const InternedStringVectorData *>( data ) );
+			return functor( static_cast<const InternedStringVectorData *>( data ), std::forward<args>( args )... );
 		case V2iVectorDataTypeId :
-			return functor( static_cast<const V2iVectorData *>( data ) );
+			return functor( static_cast<const V2iVectorData *>( data ), std::forward<args>( args )... );
 		case V2fVectorDataTypeId :
-			return functor( static_cast<const V2fVectorData *>( data ) );
+			return functor( static_cast<const V2fVectorData *>( data ), std::forward<args>( args )... );
 		case V2dVectorDataTypeId :
-			return functor( static_cast<const V2dVectorData *>( data ) );
+			return functor( static_cast<const V2dVectorData *>( data ), std::forward<args>( args )... );
 		case V3iVectorDataTypeId :
-			return functor( static_cast<const V3iVectorData *>( data ) );
+			return functor( static_cast<const V3iVectorData *>( data ), std::forward<args>( args )... );
 		case V3fVectorDataTypeId :
-			return functor( static_cast<const V3fVectorData *>( data ) );
+			return functor( static_cast<const V3fVectorData *>( data ), std::forward<args>( args )... );
 		case V3dVectorDataTypeId :
-			return functor( static_cast<const V3dVectorData *>( data ) );
+			return functor( static_cast<const V3dVectorData *>( data ), std::forward<args>( args )... );
 		case Box3fVectorDataTypeId :
-			return functor( static_cast<const Box3fVectorData *>( data ) );
+			return functor( static_cast<const Box3fVectorData *>( data ), std::forward<args>( args )... );
 		case Box3dVectorDataTypeId :
-			return functor( static_cast<const Box3dVectorData *>( data ) );
+			return functor( static_cast<const Box3dVectorData *>( data ), std::forward<args>( args )... );
 		case M33fVectorDataTypeId :
-			return functor( static_cast<const M33fVectorData *>( data ) );
+			return functor( static_cast<const M33fVectorData *>( data ), std::forward<args>( args )... );
 		case M33dVectorDataTypeId :
-			return functor( static_cast<const M33dVectorData *>( data ) );
+			return functor( static_cast<const M33dVectorData *>( data ), std::forward<args>( args )... );
 		case M44fVectorDataTypeId :
-			return functor( static_cast<const M44fVectorData *>( data ) );
+			return functor( static_cast<const M44fVectorData *>( data ), std::forward<args>( args )... );
 		case M44dVectorDataTypeId :
-			return functor( static_cast<const M44dVectorData *>( data ) );
+			return functor( static_cast<const M44dVectorData *>( data ), std::forward<args>( args )... );
 		case QuatfVectorDataTypeId :
-			return functor( static_cast<const QuatfVectorData *>( data ) );
+			return functor( static_cast<const QuatfVectorData *>( data ), std::forward<args>( args )... );
 		case QuatdVectorDataTypeId :
-			return functor( static_cast<const QuatdVectorData *>( data ) );
+			return functor( static_cast<const QuatdVectorData *>( data ), std::forward<args>( args )... );
 		case Color3fVectorDataTypeId :
-			return functor( static_cast<const Color3fVectorData *>( data ) );
+			return functor( static_cast<const Color3fVectorData *>( data ), std::forward<args>( args )... );
 		case Color4fVectorDataTypeId :
-			return functor( static_cast<const Color4fVectorData *>( data ) );
+			return functor( static_cast<const Color4fVectorData *>( data ), std::forward<args>( args )... );
 		default :
 			throw InvalidArgumentException( boost::str ( boost::format( "Data has unknown type '%1%' / '%2%' " ) % typeId % data->typeName() ) );
 	}

--- a/src/IECoreScene/MeshAlgoReorder.cpp
+++ b/src/IECoreScene/MeshAlgoReorder.cpp
@@ -66,14 +66,13 @@ typedef std::map< Edge, FaceList > EdgeToConnectedFacesMap;
 
 struct ReorderFn
 {
-		std::string m_name;
 
 		ReorderFn( const std::vector<int> &remapping ) : m_remapping( remapping )
 		{
 		}
 
 		template<typename T>
-		DataPtr operator()( const TypedData<std::vector<T> > *d )
+		DataPtr operator()( const TypedData<std::vector<T> > *d, const std::string &name )
 		{
 			const auto &inputs = d->readable();
 
@@ -89,9 +88,9 @@ struct ReorderFn
 			return data;
 		}
 
-		DataPtr operator()( Data *d )
+		DataPtr operator()( Data *d, const std::string &name )
 		{
-			string e = boost::str( boost::format( "MeshAlgo::reorderVertices : \"%s\" has unsupported data type \"%s\"." ) % m_name % d->typeName() );
+			string e = boost::str( boost::format( "MeshAlgo::reorderVertices : \"%s\" has unsupported data type \"%s\"." ) % name % d->typeName() );
 			throw InvalidArgumentException( e );
 		}
 
@@ -465,46 +464,37 @@ void MeshAlgo::reorderVertices( MeshPrimitive *mesh, int id0, int id1, int id2 )
 		if( it->second.interpolation == PrimitiveVariable::FaceVarying )
 		{
 			assert( it->second.data );
-
-			faceVaryingFn.m_name = it->first;
-
 			if( it->second.indices )
 			{
-				it->second.indices = runTimeCast<IntVectorData>( faceVaryingFn( it->second.indices.get() ) );
+				it->second.indices = runTimeCast<IntVectorData>( faceVaryingFn( it->second.indices.get(), it->first ) );
 			}
 			else
 			{
-				it->second.data = dispatch( it->second.data.get(), faceVaryingFn );
+				it->second.data = dispatch( it->second.data.get(), faceVaryingFn, it->first );
 			}
 		}
 		else if( it->second.interpolation == PrimitiveVariable::Vertex || it->second.interpolation == PrimitiveVariable::Varying )
 		{
 			assert( it->second.data );
-
-			vertexFn.m_name = it->first;
-
 			if( it->second.indices )
 			{
-				it->second.indices = runTimeCast<IntVectorData>( vertexFn( it->second.indices.get() ) );
+				it->second.indices = runTimeCast<IntVectorData>( vertexFn( it->second.indices.get(), it->first ) );
 			}
 			else
 			{
-				it->second.data = dispatch( it->second.data.get(), vertexFn );
+				it->second.data = dispatch( it->second.data.get(), vertexFn, it->first );
 			}
 		}
 		else if( it->second.interpolation == PrimitiveVariable::Uniform )
 		{
 			assert( it->second.data );
-
-			uniformFn.m_name = it->first;
-
 			if( it->second.indices )
 			{
-				it->second.indices = runTimeCast<IntVectorData>( uniformFn( it->second.indices.get() ) );
+				it->second.indices = runTimeCast<IntVectorData>( uniformFn( it->second.indices.get(), it->first ) );
 			}
 			else
 			{
-				it->second.data = dispatch( it->second.data.get(), uniformFn );
+				it->second.data = dispatch( it->second.data.get(), uniformFn, it->first );
 			}
 		}
 	}


### PR DESCRIPTION
It's common for the functor used with `DataAlgo::dispatch()` to need access to other values in addition to the data itself, and so far we've provided these additional values as member variables on the functor. For many use cases this is logical, acting a little like lambda captures (we need to wait for C++17 until we can use real lambdas effectively with `dispatch()`. But other times it has proved to be awkward, particularly when reusing the same functor with a series of primitive variables. In these cases we've had to manually poke new values into the functor prior to each dispatch. With this small change, we can now pass such arguments directly to the functor via the `dispatch()` call itself, simplifying the calling code a little, and preparing us better for the advent of C++17. Which I imagine will reach our little backwater sometime in the 2020s...