### PR TITLE
Query an IndexedView from a Primitive

### DIFF
--- a/include/IECoreScene/Primitive.h
+++ b/include/IECoreScene/Primitive.h
@@ -39,6 +39,10 @@
 #include "IECoreScene/PrimitiveVariable.h"
 #include "IECoreScene/VisibleRenderable.h"
 
+#include "IECore/MessageHandler.h"
+
+#include "boost/optional.hpp"
+
 namespace IECoreScene
 {
 
@@ -62,6 +66,17 @@ class IECORESCENE_API Primitive : public VisibleRenderable
 
 		/// Variables a stored as a public map for easy manipulation.
 		PrimitiveVariableMap variables;
+
+		/// To obtain an IndexedView onto a particular primitive variable.
+		/// An IndexedView allows access to both indexed & non indexed primitive variables using a common API.
+		/// If the required interpolation & datatype do not match then an empty optional is returned unless throwIfInvalid is true.
+		/// The returned IndexedView lifetime must be bound by the primitive variable data it is viewing.
+		template<typename T>
+		boost::optional<PrimitiveVariable::IndexedView<typename T::ValueType::value_type>> variableIndexedView(
+			const std::string &name,
+			PrimitiveVariable::Interpolation requiredInterpolation = PrimitiveVariable::Invalid,
+			bool throwIfInvalid = false
+		) const;
 
 		/// Use variableData() to find a named variable and cast to the requested data type.
 		/// If requiredInterpolation is specified and does not match the interpolation of the

--- a/include/IECoreScene/Primitive.inl
+++ b/include/IECoreScene/Primitive.inl
@@ -38,6 +38,67 @@
 namespace IECoreScene
 {
 
+template<typename T> boost::optional<PrimitiveVariable::IndexedView < typename T::ValueType::value_type> >
+Primitive::variableIndexedView( const std::string &name, PrimitiveVariable::Interpolation requiredInterpolation, bool throwIfInvalid ) const
+{
+	PrimitiveVariableMap::const_iterator it = variables.find( name );
+	if( it == variables.end() )
+	{
+		if( throwIfInvalid )
+		{
+			throw IECore::InvalidArgumentException( boost::str( boost::format( "Primitive::variableIndexedView - No primvar named '%1%' found" ) % name ) );
+		}
+		else
+		{
+			return boost::none;
+		}
+	}
+
+	if( requiredInterpolation != PrimitiveVariable::Invalid && it->second.interpolation != requiredInterpolation )
+	{
+		if( throwIfInvalid )
+		{
+			throw IECore::InvalidArgumentException(
+				boost::str(
+					boost::format(
+						"Primitive::variableIndexedView - PrimVar '%1%' interpolation (%2%) doesn't match requiredInterpolation (%3%)"
+					) % name % it->second.interpolation % requiredInterpolation
+				)
+			);
+		}
+		else
+		{
+			return boost::none;
+		}
+	}
+
+	const T *data = IECore::runTimeCast<const T>( it->second.data.get() );
+	if( data )
+	{
+		return PrimitiveVariable::IndexedView<typename T::ValueType::value_type>(
+			data->readable(),
+			it->second.indices ? &it->second.indices->readable() : nullptr
+		);
+	}
+	else if( throwIfInvalid )
+	{
+		throw IECore::InvalidArgumentException(
+			boost::str(
+				boost::format( "Primitive::variableIndexedView - Unable to created indexed view for '%1%' PrimVar, requested type: '%2%', actual type: '%3%'" ) %
+					name %
+					T::baseTypeName() %
+					it->second.data->typeName()
+			)
+		);
+	}
+	else
+	{
+		return boost::none;
+	}
+
+	return boost::none; // gcc 4.8.1 incorrectly warns about a missing return here.
+}
+
 template<typename T>
 T *Primitive::variableData( const std::string &name, PrimitiveVariable::Interpolation requiredInterpolation )
 {

--- a/include/IECoreScene/Primitive.inl
+++ b/include/IECoreScene/Primitive.inl
@@ -113,7 +113,13 @@ T *Primitive::variableData( const std::string &name, PrimitiveVariable::Interpol
 	}
 	if( it->second.indices )
 	{
-		throw IECore::Exception( "Primitive::variableData() can only be used for non-indexed variables. Use Primitive::expandedVariableData() or access Primitive::variables directly." );
+		throw IECore::Exception(
+			boost::str(
+				boost::format(
+					"Primitive::variableData() can only be used for non-indexed variables. Use Primitive::expandedVariableData() or access Primitive::variables directly. Primitive variable name: '%1%'"
+				) % name
+			)
+		);
 	}
 
 	return IECore::runTimeCast<T>( it->second.data.get() );
@@ -133,7 +139,13 @@ const T *Primitive::variableData( const std::string &name, PrimitiveVariable::In
 	}
 	if( it->second.indices )
 	{
-		throw IECore::Exception( "Primitive::variableData() can only be used for non-indexed variables. Use Primitive::expandedVariableData() or access Primitive::variables directly." );
+		throw IECore::Exception(
+			boost::str(
+				boost::format(
+					"Primitive::variableData() can only be used for non-indexed variables. Use Primitive::expandedVariableData() or access Primitive::variables directly. Primitive variable name: '%1%'"
+				) % name
+			)
+		);
 	}
 
 	return IECore::runTimeCast<const T>( it->second.data.get() );

--- a/test/IECoreScene/PrimitiveTest.py
+++ b/test/IECoreScene/PrimitiveTest.py
@@ -162,5 +162,9 @@ class PrimitiveTest( unittest.TestCase ) :
 		self.assert_( m.isPrimitiveVariableValid( IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatVectorData( [ 1, 2, 3 ] ), IECore.IntVectorData( [ 0 ] ) ) ) )
 		self.assert_( m.isPrimitiveVariableValid( IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatVectorData( [ 1, 2, 3 ] ), IECore.IntVectorData( [ 0, 1, 2 ] ) ) ) )
 
+	def testVariableIndexedView( self ) :
+
+		IECoreScene.testVariableIndexedView()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I'm not sure about the testing on this one

* C++ test bound via PrimiveBinding.cpp
* Create bindings for IndexedView & the new function on the Primitive class.

I'm a little unhappy about the unique_ptr return & installing an exception handler on each call, but can't think of anything better. 

This API is motivated by being able to use *Primitive::variableIndexedView* as a direct replacement for *Primitive::variableData*.