### PR TITLE
Travis tests

### DIFF
--- a/test/IECore/IndexedIO.py
+++ b/test/IECore/IndexedIO.py
@@ -102,7 +102,7 @@ class TestMemoryIndexedIO(unittest.TestCase):
 		self.assertEqual( txt, IECore.Object.load( f2, "obj1" ) )
 		self.assertEqual( txt, IECore.Object.load( f2, "obj2" ) )
 
-	@unittest.skipIf( IECore.isDebug(), "Skip performance testing in debug builds" )
+	@unittest.skipUnless( os.environ.get("CORTEX_PERFORMANCE_TEST", False), "'CORTEX_PERFORMANCE_TEST' env var not set" )
 	def testRmStress(self) :
 		"""Test MemoryIndexedIO rm (stress test)"""
 
@@ -329,7 +329,7 @@ class TestFileIndexedIO(unittest.TestCase):
 		self.assertEqual( len(e), 0 )
 		f.remove("sub2")
 
-	@unittest.skipIf( IECore.isDebug(), "Skip performance testing in debug builds" )
+	@unittest.skipUnless( os.environ.get("CORTEX_PERFORMANCE_TEST", False), "'CORTEX_PERFORMANCE_TEST' env var not set" )
 	def testRmStress(self) :
 		"""Test FileIndexedIO rm (stress test)"""
 

--- a/test/IECore/VectorData.py
+++ b/test/IECore/VectorData.py
@@ -35,6 +35,7 @@
 """Unit test for VectorData binding"""
 
 import math
+import os
 import unittest
 import imath
 
@@ -1209,6 +1210,7 @@ class TestVectorDataToString( unittest.TestCase ) :
 
 class TestVectorDataHashOptimisation( unittest.TestCase ) :
 
+	@unittest.skipIf( os.environ.get("TRAVIS", False), "'TRAVIS' env var defined - skipping unreliable test" )
 	def test( self ) :
 
 		d = IECore.IntVectorData( 100 * 1024 * 1024 )


### PR DESCRIPTION
I end up restarting jobs numerous times to make it go green before merging.  How about we effectively disable the following three tests until we can make them more reliable or faster?

70% of test time is taken in these two tests (220s -> 70s) 
Only run *testRmStress* tests if *IE_PERFORMANCE_TEST* environment variable has been defined. 

Skip the *TestVectorDataHashOptimisation* test on travis as it often fails. 
