### PR TITLE
IECoreAlembic : Warn if attempting to write an attribute on the root

### DIFF
--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
@@ -1541,7 +1541,7 @@ class AlembicScene::AlembicWriter : public AlembicIO
 		{
 			if( !haveXform() )
 			{
-				throw IECore::Exception(
+				IECore::msg(IECore::MessageHandler::Level::Warning, __func__,
 					boost::str(
 						boost::format( "Cannot write attribute ( attribute name: '%1%', attribute type: '%2%', time: %3% ) at root. " ) %
 							name.string() %
@@ -1549,6 +1549,7 @@ class AlembicScene::AlembicWriter : public AlembicIO
 							time
 					)
 				);
+				return;
 			}
 
 			if( const IECore::BoolData *data = runTimeCast<const IECore::BoolData>( attribute ) )

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -680,6 +680,8 @@ class AlembicSceneTest( unittest.TestCase ) :
 		b = a.createChild( "b" )
 		c = b.createChild( "c" )
 
+		a.writeAttribute( "testNoExceptionOnRoot", IECore.FloatData( 10.0 ), 0.0)
+
 		b.writeAttribute( "testFloat", IECore.FloatData( 2.1 ), 0.0 )
 		b.writeAttribute( "testInt", IECore.IntData( 3 ), 0.0 )
 		b.writeAttribute( "testColor", IECore.Color3fData( imath.Color3f( 1.0, 2.0, 3.0 ) ), 0.0 )
@@ -689,6 +691,8 @@ class AlembicSceneTest( unittest.TestCase ) :
 		del c, b, a
 
 		a = IECoreAlembic.AlembicScene( "/tmp/test_keep.abc", IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( a.attributeNames(), [] )
 
 		self.assertTrue( a.hasChild( "b" ) )
 		b = a.child( "b" )
@@ -724,11 +728,6 @@ class AlembicSceneTest( unittest.TestCase ) :
 
 		self.assertFalse( c.hasAttribute( "DontExist" ) )
 		self.assertEqual( c.attributeNames(), [] )
-
-	def testWriteAttributeOnRootRaisesException( self ) :
-
-		a = IECoreAlembic.AlembicScene( "/tmp/test.abc", IECore.IndexedIO.OpenMode.Write )
-		self.assertRaises( RuntimeError, a.writeAttribute, "badnews", IECore.FloatData( 3.1415 ), 0.0 )
 
 	def testWriteAnimatedAttributes( self ) :
 


### PR DESCRIPTION
Gaffer was attempting to write globals to the root, which was raising an exception and terminating the scene writer. 