### PR TITLE
IECoreHoudini : Remove StringVector binding.

### DIFF
--- a/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
+++ b/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
@@ -145,11 +145,6 @@ BOOST_PYTHON_MODULE(_IECoreHoudini)
 	// setup our global python context
 	CoreHoudini::initPython();
 
-	// register a converter for a vector of strings
-	typedef std::vector<std::string> StringVector;
-    class_<StringVector>("StringVector")
-    	.def(boost::python::vector_indexing_suite<StringVector>());
-
 	// bind our IECoreHoudini classes & types
 	bindTypeId();
 	bindFnParameterisedHolder();


### PR DESCRIPTION
This seems to be a legacy from the origins of IECoreHoudini at DrD. As far as I'm aware it isn't used anymore, and its causing issues with other Houdini plugins.