### PR TITLE
Houdini exporter performance improvements

### DIFF
--- a/include/IECoreHoudini/DetailSplitter.h
+++ b/include/IECoreHoudini/DetailSplitter.h
@@ -41,6 +41,7 @@
 #include "IECore/RefCounted.h"
 
 #include "GU/GU_DetailHandle.h"
+#include "OBJ/OBJ_Node.h"
 
 #include <map>
 #include <string>
@@ -68,6 +69,8 @@ class DetailSplitter : public IECore::RefCounted
 		/// @param key The name of a primitive string attribute on the GU_Detail.
 		DetailSplitter( const GU_DetailHandle &handle, const std::string &key = "name", bool useHoudiniSegment = true );
 
+		///
+		DetailSplitter( OBJ_Node *objNode, double time, const std::string &key = "name", bool useHoudiniSegment = true );
 		virtual ~DetailSplitter();
 
 		/// Creates and returns a handle to a new GU_Detail which contains only
@@ -88,8 +91,11 @@ class DetailSplitter : public IECore::RefCounted
 		// Returns the child names for a given path
 		Names getNames(const std::vector<IECore::InternedString>& path);
 
-
 		bool hasPath( const IECoreScene::SceneInterface::Path& path, bool isExplicit = true );
+
+		bool hasPaths();
+
+		bool update( OBJ_Node *objNode, double time ) ;
 	private :
 
 		bool validate();
@@ -97,15 +103,20 @@ class DetailSplitter : public IECore::RefCounted
 
 		typedef std::map<std::string, GU_DetailHandle> Cache;
 
+		double m_time;
+		OBJ_Node* m_objNode;
+
 		int m_lastMetaCount;
 		const std::string m_key;
-		const GU_DetailHandle m_handle;
+		OP_Context m_context;
+		GU_DetailHandle m_handle;
 		Cache m_cache;
 		IECore::PathMatcherDataPtr m_pathMatcher;
 
 		std::unordered_map<std::string, IECore::ObjectPtr> m_segmentMap;
 		std::vector<std::string> m_names;
 		bool m_useHoudiniSegment;
+
 };
 
 IE_CORE_DECLAREPTR( DetailSplitter );

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -467,30 +467,33 @@ bool LiveScene::hasTag( const Name &name, int filter ) const
 	{
 		// check tags based on primitive groups
 		OBJ_Node *contentNode = retrieveNode( true )->castToOBJNode();
-		if ( contentNode && contentNode->getObjectType() == OBJ_GEOMETRY && m_splitter )
+		if ( contentNode && contentNode->getObjectType() == OBJ_GEOMETRY )
 		{
 			std::string pathStr;
 			SceneInterface::Path path;
 			relativeContentPath( path );
 			pathToString( path, pathStr );
 
-			if( auto splitObject = runTimeCast<Primitive>( m_splitter->splitObject( pathStr ) ) )
+			if ( m_splitter )
 			{
-				const auto &readableBlindData = splitObject->blindData()->readable();
-				auto tagsIt = readableBlindData.find( IECore::InternedString( "tags" ) );
-				if( tagsIt == readableBlindData.end() )
+				if( auto splitObject = runTimeCast<Primitive>( m_splitter->splitObject( pathStr ) ) )
 				{
-					return false;
-				}
-				const IECore::InternedStringVectorData *tagsVector = runTimeCast<const IECore::InternedStringVectorData>( tagsIt->second.get() );
+					const auto &readableBlindData = splitObject->blindData()->readable();
+					auto tagsIt = readableBlindData.find( IECore::InternedString( "tags" ) );
+					if( tagsIt == readableBlindData.end() )
+					{
+						return false;
+					}
+					const IECore::InternedStringVectorData *tagsVector = runTimeCast<const IECore::InternedStringVectorData>( tagsIt->second.get() );
 
-				if( !tagsVector )
-				{
-					return false;
-				}
-				const auto &readableTagsVector = tagsVector->readable();
+					if( !tagsVector )
+					{
+						return false;
+					}
+					const auto &readableTagsVector = tagsVector->readable();
 
-				return std::find( readableTagsVector.begin(), readableTagsVector.end(), name ) != readableTagsVector.end();
+					return std::find( readableTagsVector.begin(), readableTagsVector.end(), name ) != readableTagsVector.end();
+				}
 			}
 
 			GU_DetailHandle newHandle = contentHandle();

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -813,11 +813,14 @@ void LiveScene::childNames( NameList &childNames ) const
 
 	IECoreScene::SceneInterface::Path parentPath ( m_path.begin() + m_contentIndex, m_path.end());
 
-	DetailSplitter::Names names  = m_splitter->getNames( m_contentIndex  ? parentPath : IECoreScene::SceneInterface::rootPath );
-
-	for (const auto &c : names)
+	if ( m_splitter )
 	{
-		childNames.push_back( c );
+		DetailSplitter::Names names = m_splitter->getNames( m_contentIndex ? parentPath : IECoreScene::SceneInterface::rootPath );
+
+		for( const auto &c : names )
+		{
+			childNames.push_back( c );
+		}
 	}
 
 }

--- a/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
+++ b/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
@@ -405,7 +405,18 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::doWrite( const SceneInterface *liveScene, 
 	liveScene->readTags( tags );
 	outScene->writeTags( tags );
 
-	if ( liveScene->hasObject() )
+	bool hasObject = false;
+
+	try
+	{
+		hasObject = liveScene->hasObject();
+	}
+	catch( const IECore::Exception &e )
+	{
+		addError( ROP_MESSAGE, e.what() );
+	}
+
+	if( hasObject )
 	{
 		try
 		{

--- a/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
+++ b/src/IECoreHoudini/ROP_SceneCacheWriter.cpp
@@ -338,6 +338,11 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::endRender()
 
 ROP_RENDER_CODE ROP_SceneCacheWriter::doWrite( const SceneInterface *liveScene, SceneInterface *outScene, double time, UT_Interrupt *progress )
 {
+	SceneInterface::Path p;
+	std::string strPath;
+	liveScene->path( p );
+	SceneInterface::pathToString( p, strPath );
+
 	progress->setLongOpText( ( "Writing " + liveScene->name().string() ).c_str() );
 	if ( progress->opInterrupt() )
 	{
@@ -404,7 +409,12 @@ ROP_RENDER_CODE ROP_SceneCacheWriter::doWrite( const SceneInterface *liveScene, 
 	{
 		try
 		{
-			outScene->writeObject( liveScene->readObject( time ).get(), time );
+			auto srcObject = liveScene->readObject( time );
+			if ( !srcObject )
+			{
+				addError( ROP_MESSAGE, boost::str( boost::format("unable to convert '%1%'") % strPath).c_str() );
+			}
+			outScene->writeObject( srcObject.get(), time );
 		}
 		catch ( IECore::Exception &e )
 		{

--- a/test/IECoreHoudini/LiveSceneTest.py
+++ b/test/IECoreHoudini/LiveSceneTest.py
@@ -1056,8 +1056,9 @@ class LiveSceneTest( IECoreHoudini.TestCase ) :
 
 		# forcing a cook error
 		hou.parm('/obj/box1/actualBox/sizex').setExpression( "fake" )
+
 		self.assertEqual( box1.hasObject(), False )
-		self.assertEqual( box1.readObject( 0 ), None )
+		self.assertEqual(box1.readObject( 0 ) , None )
 		self.assertEqual( box1.childNames(), [] )
 		self.assertRaises( RuntimeError, box1.child, "gap" )
 		self.assertEqual( box1.child( "gap", IECoreScene.SceneInterface.MissingBehaviour.NullIfMissing ), None )

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -2319,8 +2319,9 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 
 		rop.parm( "execute" ).pressButton()
 
-		# Skips over 3 cortex objects.
-		self.assertEqual( len( rop.errors() ) , 0 )
+		# unable to convert the 3 cortex objects.
+		# "Error converting SOP: '/obj/ieSceneCacheGeometry1' to scc. Potentially unsupported prim types found: [ CortexObject ]"
+		self.assertEqual( len( rop.errors() ) , 1 )
 
 	def testRopFlattenedWithErrors( self ) :
 

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -2319,8 +2319,8 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 
 		rop.parm( "execute" ).pressButton()
 
-		# unable to write a cache of 3 cortex objects without a name attribute
-		self.assertEqual( len( rop.errors() ) , 1 )
+		# Skips over 3 cortex objects.
+		self.assertEqual( len( rop.errors() ) , 0 )
 
 	def testRopFlattenedWithErrors( self ) :
 


### PR DESCRIPTION
Only recreate a single DetailSplitter on frame change, before it would recreate a splitter per LiveScene location. 

- Improve error reporting if SOP isn't convertible - LiveScene::hasObject raises an exception and if raised from a SceneCacheWriter it's displayed to the user a a ROP error.
