### PR TITLE
Support for Houdini 17

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1737,7 +1737,17 @@ vdbPythonScripts = glob.glob( "python/IECoreVDB/*.py" )
 
 if doConfigure :
 
-	c = Configure( vdbEnv )
+	# Since we only build shared libraries and not exectuables,
+	# we only need to check that shared libs will link correctly.
+	# This is necessary when building against a VDB that links to
+	# extra optional dependencies not required by Cortex (eg a VDB
+	# lib that ships with a DCC). This approach succeeds because
+	# building a shared library doesn't require resolving the
+	# unresolved symbols of the libraries that it links to.
+	vdbCheckEnv = vdbEnv.Clone()
+	vdbCheckEnv.Append( CXXFLAGS = [ "-fPIC" ] )
+	vdbCheckEnv.Append( LINKFLAGS = [ "-shared" ] )
+	c = Configure( vdbCheckEnv )
 
 	haveVDB = False
 	if c.CheckLibWithHeader( vdbEnv.subst( "openvdb" + env["VDB_LIB_SUFFIX"] ), "openvdb/openvdb.h", "CXX" ) :
@@ -2830,7 +2840,17 @@ usdPythonModuleEnv.Append( **usdEnvAppends )
 
 if doConfigure :
 
-	c = Configure( usdEnv )
+	# Since we only build shared libraries and not exectuables,
+	# we only need to check that shared libs will link correctly.
+	# This is necessary when building against a USD that links to
+	# extra optional dependencies not required by Cortex (eg a USD
+	# lib that ships with a DCC). This approach succeeds because
+	# building a shared library doesn't require resolving the
+	# unresolved symbols of the libraries that it links to.
+	usdCheckEnv = usdEnv.Clone()
+	usdCheckEnv.Append( CXXFLAGS = [ "-fPIC" ] )
+	usdCheckEnv.Append( LINKFLAGS = [ "-shared" ] )
+	c = Configure( usdCheckEnv )
 
 	haveUSD = False
 	if c.CheckLibWithHeader( usdLibs[0], "pxr/usd/usd/api.h", "CXX" ) :

--- a/SConstruct
+++ b/SConstruct
@@ -510,6 +510,13 @@ o.Add(
 	"/usr/local/include",
 )
 
+o.Add(
+	"VDB_LIB_SUFFIX",
+	"The suffix appended to the names of the OpenVDB libraries. You can modify this "
+	"to link against libraries installed with non-default names",
+	"",
+)
+
 # appleseed options
 
 o.Add(
@@ -1697,7 +1704,7 @@ vdbEnvAppends = {
 	"LIBPATH" : [
 		"$VDB_LIB_PATH",
 	],
-	"LIBS" : ["openvdb"]
+	"LIBS" : ["openvdb$VDB_LIB_SUFFIX"]
 }
 
 vdbEnv.Append( **vdbEnvAppends )
@@ -1716,7 +1723,7 @@ if doConfigure :
 	c = Configure( vdbEnv )
 
 	haveVDB = False
-	if c.CheckLibWithHeader( "openvdb", "openvdb/openvdb.h", "CXX" ) :
+	if c.CheckLibWithHeader( vdbEnv.subst( "openvdb" + env["VDB_LIB_SUFFIX"] ), "openvdb/openvdb.h", "CXX" ) :
 		haveVDB = True
 	else :
 		sys.stderr.write( "WARNING : no OpenVDB library found, not building IECoreVDB - check VDB_INCLUDE_PATH, VDB_LIB_PATH and config.log.\n" )

--- a/SConstruct
+++ b/SConstruct
@@ -458,6 +458,14 @@ o.Add(
 )
 
 o.Add(
+	"USD_LIB_PREFIX",
+	"The prefix to prepend to the names of the USD libraries. You can modify this "
+	"to link against libraries installed with non-default names. "
+	"Should match the USD build option PXR_LIB_PREFIX",
+	""
+)
+
+o.Add(
 	BoolVariable(
 		"WITH_USD_MONOLITHIC",
 		"Determines if we link to the individual usd libs or a monolithic lib"
@@ -2795,6 +2803,9 @@ else :
 		"kind",
 		"work"
 	]
+
+if usdEnv["USD_LIB_PREFIX"] :
+	usdLibs = [ usdEnv["USD_LIB_PREFIX"] + x for x in usdLibs ]
 
 usdEnvAppends = {
 	"CXXFLAGS" : [

--- a/config/ie/options
+++ b/config/ie/options
@@ -330,8 +330,25 @@ if targetApp=="houdini" :
 	houdiniVersion = targetAppVersion
 
 	houdiniReg = IEEnv.registry["apps"]["houdini"][houdiniVersion][platform]
-	BOOST_INCLUDE_PATH = "/software/tools/include/" + platform + "/boost/" + boostVersion
 	HOUDINI_ROOT = houdiniReg['location']
+
+	# we use out normal boost includes (and libs) because Houdini has mangled their
+	# boost install with an "h" prefix on the includes, libs, and even macros like HBOOST_VERSION.
+	BOOST_INCLUDE_PATH = "/software/tools/include/" + platform + "/boost/" + boostVersion
+
+	# houdini 17 ships its own USD so we link against that
+	if distutils.version.LooseVersion(houdiniVersion) >= distutils.version.LooseVersion("17.0") :
+		TBB_INCLUDE_PATH = "$HOUDINI_INCLUDE_PATH"
+		TBB_LIB_PATH = "$HOUDINI_LIB_PATH"
+		OPENEXR_LIB_SUFFIX = ""
+		GLEW_LIB_SUFFIX = ""
+		ALEMBIC_LIB_SUFFIX = "_sidefx"
+		VDB_LIB_SUFFIX = "_sesi"
+		USD_INCLUDE_PATH = "$HOUDINI_INCLUDE_PATH"
+		USD_LIB_PATH = "$HOUDINI_LIB_PATH"
+		USD_LIB_PREFIX = "libpxr_"
+		WITH_USD_MONOLITHIC = True
+
 	HOUDINI_CXX_FLAGS = " ".join( CXXFLAGS + houdiniReg['compilerFlags'] )
 	INSTALL_HOUDINILIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 	INSTALL_HOUDINIPLUGIN_NAME = os.path.join( appPrefix, "plugins", "$IECORE_NAME" )

--- a/config/ie/options
+++ b/config/ie/options
@@ -299,7 +299,7 @@ if targetApp=="houdini" :
 	houdiniReg = IEEnv.registry["apps"]["houdini"][houdiniVersion][platform]
 	BOOST_INCLUDE_PATH = "/software/tools/include/" + platform + "/boost/" + boostVersion
 	HOUDINI_ROOT = houdiniReg['location']
-	HOUDINI_CXX_FLAGS = " ".join( CXXFLAGS ) + ' -DVERSION=\"'+houdiniVersion+'\" -DDLLEXPORT=  -D_GNU_SOURCE -DLINUX -DAMD64 -m64 -fPIC -DSIZEOF_VOID_P=8 -DSESI_LITTLE_ENDIAN -DENABLE_THREADS -DUSE_PTHREADS -D_REENTRANT -D_FILE_OFFSET_BITS=64 -DGCC4 -DGCC3 -Wno-deprecated -Wno-reorder'
+	HOUDINI_CXX_FLAGS = " ".join( CXXFLAGS + houdiniReg['compilerFlags'] )
 	INSTALL_HOUDINILIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 	INSTALL_HOUDINIPLUGIN_NAME = os.path.join( appPrefix, "plugins", "$IECORE_NAME" )
 	INSTALL_HOUDINIOTL_DIR = os.path.join( appPrefix, "otls" )

--- a/config/ie/options
+++ b/config/ie/options
@@ -264,6 +264,39 @@ except :
 # ask for opengl support
 WITH_GL=1
 
+# find alembic:
+ALEMBIC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "Alembic", alembicVersion )
+ALEMBIC_LIB_SUFFIX = "-" + alembicVersion
+
+VDB_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "OpenVDB", vdbVersion )
+VDB_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
+
+BLOSC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "blosc", bloscVersion )
+BLOSC_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
+BLOSC_LIB_SUFFIX = "-" + bloscVersion
+
+# find USD:
+
+USD_INCLUDE_PATH = None
+USD_LIB_PATH = None
+
+if usdVersion :
+
+	usdReg = IEEnv.registry["apps"]["usd"][usdVersion][platform]
+
+	if usdReg :
+		if targetApp :
+			USD_INCLUDE_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "include" )
+			USD_LIB_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "lib" )
+		else:
+			USD_INCLUDE_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "include" )
+			USD_LIB_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "lib" )
+
+
+# find hdf5:
+HDF5_INCLUDE_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "include" )
+HDF5_LIB_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "lib" )
+
 # find maya if we're building for maya
 if targetApp=="maya" :
 
@@ -322,39 +355,6 @@ if targetApp=="houdini" :
 		WITH_GL = 1
 	else:
 		WITH_GL = False
-
-# find alembic:
-ALEMBIC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "Alembic", alembicVersion )
-ALEMBIC_LIB_SUFFIX = "-" + alembicVersion
-
-VDB_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "OpenVDB", vdbVersion )
-VDB_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
-
-BLOSC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "blosc", bloscVersion )
-BLOSC_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
-BLOSC_LIB_SUFFIX = "-" + bloscVersion
-
-# find USD:
-
-USD_INCLUDE_PATH = None
-USD_LIB_PATH = None
-
-if usdVersion :
-
-	usdReg = IEEnv.registry["apps"]["usd"][usdVersion][platform]
-
-	if usdReg :
-		if targetApp :
-			USD_INCLUDE_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "include" )
-			USD_LIB_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "lib" )
-		else:
-			USD_INCLUDE_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "include" )
-			USD_LIB_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "lib" )
-
-
-# find hdf5:
-HDF5_INCLUDE_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "include" )
-HDF5_LIB_PATH = os.path.join( "/software/apps/hdf5", hdf5Version, platform, compiler, compilerVersion, "lib" )
 
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )

--- a/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
@@ -42,6 +42,12 @@
 #include "UT/UT_Version.h"
 #include "UT/UT_WorkArgs.h"
 
+#if UT_MAJOR_VERSION_INT >= 17
+
+#include "UT/UT_StdUtil.h"
+
+#endif
+
 #include "IECore/CompoundObject.h"
 #include "IECore/CompoundParameter.h"
 #include "IECoreScene/private/PrimitiveVariableAlgos.h"
@@ -183,7 +189,16 @@ void FromHoudiniGeometryConverter::remapAttributes( const GU_Detail *geo, Attrib
 		std::vector<std::string> tokens;
 		UT_String remapString( remapStrings( i ) );
 		remapString.tokenize( workArgs, ":" );
+
+#if UT_MAJOR_VERSION_INT < 17
+
 		workArgs.toStringVector( tokens );
+
+#else
+
+		UTargsToStringVector( workArgs, tokens );
+
+#endif
 
 		// not enough elements!
 		if ( tokens.size() < 4 )
@@ -196,7 +211,16 @@ void FromHoudiniGeometryConverter::remapAttributes( const GU_Detail *geo, Attrib
 		std::vector<std::string> dataTokens;
 		UT_String dataString( tokens[3] );
 		dataString.tokenize( dataWorkArgs, "_" );
+
+#if UT_MAJOR_VERSION_INT < 17
+
 		dataWorkArgs.toStringVector( dataTokens );
+
+#else
+
+		UTargsToStringVector( dataWorkArgs, dataTokens );
+
+#endif
 
 		if ( dataTokens.size() == 2 ) // we need both class & type!
 		{

--- a/src/IECoreHoudini/GEO_CobIOTranslator.cpp
+++ b/src/IECoreHoudini/GEO_CobIOTranslator.cpp
@@ -32,6 +32,8 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "UT/UT_Version.h"
+
 #include "IECore/CompoundParameter.h"
 #include "IECore/Reader.h"
 #include "IECore/TypeIds.h"
@@ -88,7 +90,17 @@ GA_Detail::IOStatus GEO_CobIOTranslator::fileLoad( GEO_Detail *geo, UT_IStream &
 	ConstObjectPtr object = 0;
 	try
 	{
+
+#if UT_MAJOR_VERSION_INT < 17
+
 		ReaderPtr reader = Reader::create( is.getLabel() );
+
+#else
+
+		ReaderPtr reader = Reader::create( is.getLabel().toStdString() );
+
+#endif
+
 		if ( !reader )
 		{
 			return false;

--- a/src/IECoreHoudini/GEO_CortexPrimitive.cpp
+++ b/src/IECoreHoudini/GEO_CortexPrimitive.cpp
@@ -45,6 +45,7 @@
 #include "UT/UT_JSONParser.h"
 #include "UT/UT_JSONWriter.h"
 #include "UT/UT_MemoryCounter.h"
+#include "UT/UT_StringHolder.h"
 #ifdef IECOREHOUDINI_WITH_GL
 #include "DM/DM_RenderTable.h"
 #include "IECoreHoudini/GUI_CortexPrimitiveHook.h"
@@ -748,6 +749,14 @@ void GEO_CortexPrimitive::infoText( const GU_Detail *geo, OP_Context &context, O
 	parms.append( "\n" );
 }
 
+namespace
+{
+
+static UT_StringHolder vertex_sh = "vertex";
+static UT_StringHolder cortex_sh = "cortex";
+
+} // namespace
+
 class GEO_CortexPrimitive::geo_CortexPrimitiveJSON : public GA_PrimitiveJSON
 {
 	public :
@@ -782,6 +791,9 @@ class GEO_CortexPrimitive::geo_CortexPrimitiveJSON : public GA_PrimitiveJSON
 			return geo_TBJ_ENTRIES;
 		}
 
+
+#if UT_MAJOR_VERSION_INT < 17
+
 		virtual const char *getKeyword( int i ) const
 		{
 			switch ( i )
@@ -802,6 +814,31 @@ class GEO_CortexPrimitive::geo_CortexPrimitiveJSON : public GA_PrimitiveJSON
 
 			return 0;
 		}
+
+#else
+
+		virtual const UT_StringHolder &getKeyword( int i ) const
+		{
+			switch ( i )
+			{
+				case geo_TBJ_VERTEX :
+				{
+					return vertex_sh;
+				}
+				case geo_TBJ_CORTEX :
+				{
+					return cortex_sh;
+				}
+				case geo_TBJ_ENTRIES :
+				{
+					break;
+				}
+			}
+
+			return UT_StringHolder::theEmptyString;
+		}
+
+#endif
 
 		virtual bool shouldSaveField( const GA_Primitive *prim, int i, const GA_SaveMap &sm ) const
 		{

--- a/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
@@ -33,6 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "UT/UT_PtrArray.h"
+#include "UT/UT_Version.h"
 
 #include "IECoreHoudini/OBJ_SceneCacheGeometry.h"
 #include "IECoreHoudini/SOP_SceneCacheSource.h"
@@ -80,7 +81,18 @@ bool OBJ_SceneCacheGeometry::runCreateScript()
 
 	// add the standard mantra geometry parms
 	UT_String script( "opproperty -f -F Render " + path.toStdString() + " mantra default_geometry" );
+
+#if UT_MAJOR_VERSION_INT < 17
+
 	executeHscriptScript( script, 0 );
+
+#else
+
+	OP_Context context;
+	executeHscriptScript( script, context );
+
+#endif
+
 
 	return OBJ_Geometry::runCreateScript();
 }

--- a/src/IECoreHoudini/ToHoudiniStringAttribConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniStringAttribConverter.cpp
@@ -32,6 +32,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "UT/UT_Version.h"
+
+#if UT_MAJOR_VERSION_INT >= 17
+
+#include "UT/UT_StdUtil.h"
+
+#endif
+
 #include "IECore/MessageHandler.h"
 
 #include "IECoreHoudini/ToHoudiniStringAttribConverter.h"
@@ -98,7 +106,16 @@ GA_RWAttributeRef ToHoudiniStringVectorAttribConverter::doConversion( const IECo
 	const GA_AIFSharedStringTuple *tuple = attr->getAIFSharedStringTuple();
 
 	UT_StringArray strings;
+
+#if UT_MAJOR_VERSION_INT < 17
+
 	strings.fromStdVectorOfStrings( stringVectorData->readable() );
+
+#else
+
+	UTarrayFromStdVectorOfStrings( strings, stringVectorData->readable() );
+
+#endif
 
 	const std::vector<int> &indices = ((const IECore::IntVectorData *)m_indicesParameter->getValidatedValue())->readable();
 	if ( indices.empty() || !strings.entries() )

--- a/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
+++ b/src/IECoreHoudini/bindings/IECoreHoudiniModule.cpp
@@ -40,6 +40,10 @@
 
 #include "UT/UT_Version.h"
 
+// must be included before RE_Visual to avoid a compilation
+// error todo with QT_NO_EMIT in QtCore/qobjectdefs.h
+#include "RE/RE_Render.h"
+
 #if UT_MAJOR_VERSION_INT >= 16
 
 #include "RE/RE_Visual.h"
@@ -55,7 +59,6 @@
 #include "SOP/SOP_Node.h"
 #include "HOM/HOM_Node.h"
 #include "HOM/HOM_Geometry.h"
-#include "RE/RE_Render.h"
 #include "RE/RE_Window.h"
 #include "RE/RE_Server.h"
 

--- a/src/IECoreHoudini/plugin/Plugin.cpp
+++ b/src/IECoreHoudini/plugin/Plugin.cpp
@@ -84,7 +84,7 @@ typedef GU_CortexPrimitive CortexPrimitive;
 /// Tell Houdini that this plugin should be loaded with RTLD_GLOBAL
 extern "C"
 {
-	DLLEXPORT void HoudiniDSOInit( UT_DSOInfo &dsoinfo )
+	SYS_VISIBILITY_EXPORT void HoudiniDSOInit( UT_DSOInfo &dsoinfo )
 	{
 		dsoinfo.loadGlobal = true;
 	}


### PR DESCRIPTION
The code changes are fairly trivial, just adjustments for small HDK updates, but I had to add several new SConstruct options. The new options are:

- VDB_LIB_SUFFIX
  - We probably should have had this all along, since we have it for most other dependencies.
- WITH_USD_MONOLITHIC
  - USD can be built as a collection of small libs or as one big lib. Houdini is shipping one big lib currently.
- USD_LIB_PREFIX
  - USD allows a custom lib prefix to eliminate the normal "lib", and their example use indicates you might use it to create "pxrusd_ms.so" instead of "libusd_ms.so" (ie swapping "lib" for "pxr"), but Houdini has set that option to "libpxr_" thus creating "libpxr_usd_ms.so". Fortunately SCons appears to link appropriately using "-llibpxr_usd_ms", so we can match the option. It is our first *_LIB_PREFIX option.

All unit tests are passing in both H16.5 and H17.0, and initial interactive use seems stable as well.