### PR TITLE
PathMatcher : Remove ignored qualifier on `exactMatch()`

### DIFF
--- a/include/IECore/PathMatcher.h
+++ b/include/IECore/PathMatcher.h
@@ -268,7 +268,7 @@ class PathMatcher::RawIterator : public boost::iterator_facade<RawIterator, cons
 		/// yield an exact match. If this returns false, then this
 		/// path exists in the matcher only as the ancestor of descendant
 		/// paths for which exactMatch() will be true.
-		const bool exactMatch() const;
+		bool exactMatch() const;
 
 	private :
 

--- a/include/IECore/PathMatcher.inl
+++ b/include/IECore/PathMatcher.inl
@@ -69,7 +69,7 @@ inline void PathMatcher::RawIterator::prune()
 	m_pruned = true;
 }
 
-inline const bool PathMatcher::RawIterator::exactMatch() const
+inline bool PathMatcher::RawIterator::exactMatch() const
 {
 	if( const Node *n = node() )
 	{


### PR DESCRIPTION
I'm not sure why this was a const bool return type, but I think just returning bool means the same thing, and it allows us to compile with both -Werror and -Wignored-qualifiers, the later of which comes from the Houdini 17 cxx flags.

Breaking Change :
 - PathMatcher : Changed return type of a public method.