### PR TITLE
VP2 Fixes

### DIFF
--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -168,6 +168,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		Instances m_instances;
 
 		bool m_drawRootBounds;
+		bool m_drawChildBounds;
 		MPlug m_shaderOutPlug;
 		bool m_instancedRendering;
 		IECoreScene::ConstSceneInterfacePtr m_sceneInterface;

--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -123,20 +123,21 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		struct Instance
 		{
-			Instance( Imath::M44d transformation, bool selected, bool componentMode, MDagPath path )
-				: transformation( transformation ), selected( selected ), componentMode( componentMode ), path( path )
+			Instance( Imath::M44d transformation, bool selected, bool componentMode, MDagPath path, bool visible )
+				: transformation( transformation ), selected( selected ), componentMode( componentMode ), path( path ), visible( visible )
 			{
 			}
 
 			bool operator==( const Instance &rhs ) const
 			{
-				return transformation == rhs.transformation && selected == rhs.selected && path == rhs.path && componentMode == rhs.componentMode;
+				return transformation == rhs.transformation && selected == rhs.selected && path == rhs.path && componentMode == rhs.componentMode && visible == rhs.visible;
 			}
 
 			Imath::M44d transformation;
 			bool selected;
 			bool componentMode;
 			MDagPath path;
+			bool visible;
 		};
 
 		using Instances = std::vector<Instance>;

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1587,7 +1587,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			else
 			{
 				auto result = m_renderItemsToEnable.insert( renderItem );
-				if( !result.second ) // we hadn't removed the instance transforms on this renderItem yet
+				if( result.second ) // we hadn't removed the instance transforms on this renderItem yet
 				{
 					removeAllInstances( *renderItem );
 				}

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1477,7 +1477,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			MString itemName( instanceName.c_str() );
 			MRenderItem *renderItem = acquireRenderItem( container, IECore::NullObject::defaultNullObject(), itemName, RenderStyle::BoundingBox, isNew );
 
-			MShaderInstance *shader = m_allShaders->getShader( RenderStyle::BoundingBox, instance.componentMode, /* isComponentSelected = */ false );
+			MShaderInstance *shader = m_allShaders->getShader( RenderStyle::BoundingBox, instance.componentMode, instance.selected );
 			renderItem->setShader( shader );
 
 			if( isNew )
@@ -1488,8 +1488,15 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			}
 			else
 			{
-				m_renderItemsToEnable.insert( renderItem );
+				auto result = m_renderItemsToEnable.insert( renderItem );
+				if( result.second ) // we hadn't removed the instance transforms on this renderItem yet
+				{
+					removeAllInstances( *renderItem );
+				}
 			}
+
+			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( accumulatedMatrix * instance.transformation );
+			addInstanceTransform( *renderItem, instanceMatrix );
 		}
 	}
 


### PR DESCRIPTION
Two things that Murray found and that were quick to fix.

- The misinterpreted return value of `std::map::insert` caused slowdowns, and trails when transforming scene shapes.
- Hiding scene shapes didn't have the desired effect. Now it does.