### PR TITLE
Remove GIL release in createDummy

### DIFF
--- a/src/IECoreHoudini/bindings/FromHoudiniGeometryConverterBinding.cpp
+++ b/src/IECoreHoudini/bindings/FromHoudiniGeometryConverterBinding.cpp
@@ -79,8 +79,6 @@ static FromHoudiniGeometryConverterPtr createFromGeo( HOM_Geometry *homGeo, IECo
 
 static FromHoudiniGeometryConverterPtr createDummy( object ids )
 {
-	IECorePython::ScopedGILRelease scopedGILRelease;
-
 	extract<IECore::TypeId> ex( ids );
 	if( ex.check() )
 	{


### PR DESCRIPTION
This wasn't necessary and causes segfaults when building for H17 (gcc 6.3.1, boost 1.61, c++14)