### PR TITLE
Endpoint multiplicity

### DIFF
--- a/include/IECore/CubicBasis.h
+++ b/include/IECore/CubicBasis.h
@@ -44,6 +44,15 @@ IECORE_POP_DEFAULT_VISIBILITY
 namespace IECore
 {
 
+enum class StandardCubicBasis
+{
+		Unknown,
+		Linear,
+		Bezier,
+		BSpline,
+		CatmullRom
+};
+
 /// Provides a basis matrix class for use in constructing cubic curves.
 /// \ingroup mathGroup
 template<typename T>
@@ -59,6 +68,8 @@ class IECORE_EXPORT CubicBasis
 		unsigned step;
 
 		CubicBasis( const MatrixType &m, unsigned s );
+
+		CubicBasis( StandardCubicBasis standardBasis );
 
 		template<class S>
 		inline void coefficients( S t, S &c0, S &c1, S &c2, S &c3 ) const;
@@ -132,6 +143,7 @@ class IECORE_EXPORT CubicBasis
 		static const CubicBasis &bSpline();
 		static const CubicBasis &catmullRom();
 
+		StandardCubicBasis standardBasis() const;
 };
 
 typedef CubicBasis<float> CubicBasisf;

--- a/include/IECore/CubicBasis.inl
+++ b/include/IECore/CubicBasis.inl
@@ -36,6 +36,7 @@
 #define IECORE_CUBICBASIS_INL
 
 #include "IECore/CubicBasis.h"
+#include "IECore/Exception.h"
 
 namespace IECore
 {
@@ -44,6 +45,28 @@ template<typename T>
 CubicBasis<T>::CubicBasis( const MatrixType &m, unsigned s )
 	:	matrix( m ), step( s )
 {
+}
+
+template<typename T>
+CubicBasis<T>::CubicBasis( StandardCubicBasis standardBasis )
+{
+	switch( standardBasis )
+	{
+	case StandardCubicBasis::Linear:
+		*this = CubicBasis<T>::linear();
+		break;
+	case StandardCubicBasis::Bezier:
+		*this = CubicBasis<T>::bezier();
+		break;
+	case StandardCubicBasis::BSpline:
+		*this = CubicBasis<T>::bSpline();
+		break;
+	case StandardCubicBasis::CatmullRom:
+		*this = CubicBasis<T>::catmullRom();
+		break;
+	case StandardCubicBasis::Unknown:
+		throw IECore::Exception( "CubicBasis::CubicBasis - Invalid basis");
+	}
 }
 
 template<typename T>
@@ -328,6 +351,30 @@ const CubicBasis<T> &CubicBasis<T>::catmullRom()
 	);
 	return m;
 }
+
+template<typename T>
+StandardCubicBasis CubicBasis<T>::standardBasis() const
+{
+	if( *this == CubicBasis<T>::linear() )
+	{
+		return StandardCubicBasis::Linear;
+	}
+	else if( *this == CubicBasis<T>::bezier() )
+	{
+		return StandardCubicBasis::Bezier;
+	}
+	else if( *this == CubicBasis<T>::bSpline() )
+	{
+		return StandardCubicBasis::BSpline;
+	}
+	else if( *this == CubicBasis<T>::catmullRom() )
+	{
+		return StandardCubicBasis::CatmullRom;
+	}
+
+	return StandardCubicBasis::Unknown;
+}
+
 
 } // namespace IECore
 

--- a/include/IECoreHoudini/FromHoudiniCurvesConverter.h
+++ b/include/IECoreHoudini/FromHoudiniCurvesConverter.h
@@ -82,7 +82,7 @@ class FromHoudiniCurvesConverter : public IECoreHoudini::FromHoudiniGeometryConv
 
 		static bool compatiblePrimitive( GA_PrimitiveTypeId type )
 		{
-			if ( ( type == GEO_PRIMNURBCURVE ) || ( type == GEO_PRIMBEZCURVE ) )
+			if ( ( type == GEO_PRIMNURBCURVE ) || ( type == GEO_PRIMBEZCURVE ) || (type == GEO_PRIMPOLY ))
 			{
 				return true;
 			}

--- a/include/IECoreHoudini/FromHoudiniGeometryConverter.h
+++ b/include/IECoreHoudini/FromHoudiniGeometryConverter.h
@@ -191,6 +191,7 @@ class FromHoudiniGeometryConverter : public FromHoudiniConverter
 		IECore::DataPtr extractStringVectorData( const GA_Attribute *attr, const GA_Range &range, IECore::IntVectorDataPtr &indexData ) const;
 		IECore::DataPtr extractStringData( const GU_Detail *geo, const GA_Attribute *attr ) const;
 
+		bool static hasOnlyOpenPolygons( const GU_Detail *geo );
 	private :
 
 		void constructCommon();

--- a/include/IECoreScene/CurvesAlgo.h
+++ b/include/IECoreScene/CurvesAlgo.h
@@ -60,6 +60,9 @@ IECORESCENE_API CurvesPrimitivePtr deleteCurves( const CurvesPrimitive *curvesPr
 /// completely segmententing the curves based on the unique values in a primitive variable.
 IECORESCENE_API std::vector<CurvesPrimitivePtr> segment( const CurvesPrimitive *curves, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues = nullptr );
 
+/// Update the number of replicated end points based on the basis.
+IECORESCENE_API CurvesPrimitivePtr updateEndpointMultiplicity( const CurvesPrimitive *curves, const IECore::CubicBasisf& cubicBasis );
+
 } // namespace CurveAlgo
 
 } // namespace IECoreScene

--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -73,6 +73,11 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniPolygonsConverter::canCo
 		}
 	}
 
+	if ( hasOnlyOpenPolygons( geo ) )
+	{
+		return Suitable;
+	}
+
 	// is there a single named shape?
 	GA_ROAttributeRef attrRef = geo->findPrimitiveAttribute( "name" );
 	if ( attrRef.isValid() && attrRef.isString() )

--- a/src/IECoreHoudini/SOP_SceneCacheSource.cpp
+++ b/src/IECoreHoudini/SOP_SceneCacheSource.cpp
@@ -541,7 +541,7 @@ ConstObjectPtr SOP_SceneCacheSource::transformObject( const IECore::Object *obje
 
 bool SOP_SceneCacheSource::convertObject( const IECore::Object *object, const std::string &name, const SceneInterface *scene, Parameters &params )
 {
-	ToHoudiniGeometryConverterPtr converter = 0;
+	ToHoudiniGeometryConverterPtr converter = nullptr;
 	if ( params.geometryType == Cortex )
 	{
 		converter = new ToHoudiniCortexObjectConverter( object );

--- a/src/IECorePython/CubicBasisBinding.cpp
+++ b/src/IECorePython/CubicBasisBinding.cpp
@@ -94,6 +94,7 @@ void bindCubicBasis( const char *name )
 	typedef typename T::BaseType BaseType;
 
 	class_<T>( name, init<const typename T::MatrixType, unsigned>() )
+		.def( init< IECore::StandardCubicBasis >() )
 		.def_readwrite( "matrix", &T::matrix )
 		.def_readwrite( "step", &T::step )
 		.def( "coefficients", &coefficients<T> )
@@ -120,12 +121,23 @@ void bindCubicBasis( const char *name )
 		.def( "bezier", &T::bezier, return_value_policy<copy_const_reference>() ).staticmethod( "bezier" )
 		.def( "bSpline", &T::bSpline, return_value_policy<copy_const_reference>() ).staticmethod( "bSpline" )
 		.def( "catmullRom", &T::catmullRom, return_value_policy<copy_const_reference>() ).staticmethod( "catmullRom" )
+		.def( "standardBasis", &T::standardBasis )
 		.def( "__repr__", &repr<T> )
 	;
 }
 
 void bindCubicBasis()
 {
+
+	enum_< IECore::StandardCubicBasis > ("StandardCubicBasis")
+		.value("Unknown", IECore::StandardCubicBasis::Unknown)
+		.value("Linear", IECore::StandardCubicBasis::Linear )
+		.value("Bezier", IECore::StandardCubicBasis::Bezier )
+		.value("BSpline", IECore::StandardCubicBasis::BSpline )
+		.value("CatmullRom", IECore::StandardCubicBasis::CatmullRom )
+		.export_values()
+		;
+
 	bindCubicBasis<CubicBasisf>( "CubicBasisf" );
 	bindCubicBasis<CubicBasisd>( "CubicBasisd" );
 }

--- a/src/IECoreScene/CurvesAlgoUpdateEndpointMultiplicity.cpp
+++ b/src/IECoreScene/CurvesAlgoUpdateEndpointMultiplicity.cpp
@@ -1,0 +1,214 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreScene/CurvesAlgo.h"
+
+#include "IECore/DataAlgo.h"
+
+#include "tbb/concurrent_unordered_map.h"
+#include "tbb/task_group.h"
+
+#include "boost/format.hpp"
+
+using namespace IECore;
+using namespace IECoreScene;
+using namespace Imath;
+
+namespace
+{
+
+
+// replicate the first and last values an additional two times at the begining and end of the vector.
+template<typename T>
+void expand( const std::vector<T> &in, std::vector<T> &out, const std::vector<int> &vertsPerCurve )
+{
+	out.reserve( in.size() + vertsPerCurve.size() * 4 );
+
+	size_t index = 0;
+	for( size_t i = 0; i < vertsPerCurve.size(); i++ )
+	{
+		size_t curveNumVerts = (size_t) vertsPerCurve[i];
+
+		for( size_t j = 0; j < curveNumVerts; j++, index++ )
+		{
+			out.push_back( in[index] );
+
+			if( j == 0 || j == ( curveNumVerts - 1 ) )
+			{
+				out.push_back( in[index] );
+				out.push_back( in[index] );
+			}
+		}
+	}
+}
+
+// remove the replicated first and last values reversing the 'expand' function above
+template<typename T>
+void compress( const std::vector<T> &in, std::vector<T> &out, const std::vector<int> &vertsPerCurve )
+{
+	out.reserve( in.size() - vertsPerCurve.size() * 4 );
+
+	size_t index = 0;
+	for( size_t i = 0; i < vertsPerCurve.size(); i++ )
+	{
+		size_t curveNumVerts = (size_t) vertsPerCurve[i];
+		for( size_t j = 0; j < curveNumVerts; j++, index++ )
+		{
+			if( j == 0 || j == 1 || j == ( curveNumVerts - 1 ) || j == ( curveNumVerts - 2 ) )
+			{
+				continue;
+			}
+			out.push_back( in[index] );
+		}
+	}
+}
+
+struct DuplicateEndPoints
+{
+	DuplicateEndPoints( bool expand ) : m_expand( expand )
+	{
+	}
+
+	// template template parameter 'S' to capture if the input type is either TypedData or GeometricTypedData
+	template<typename T, template<typename> class S >
+	IECore::DataPtr operator()(
+		const S<std::vector<T>> *data, const std::vector<int> &vertsPerCurve
+	) const
+	{
+		const std::vector<T> &in = data->readable();
+		typename S<std::vector<T>>::Ptr newOut = new S<std::vector<T>>();
+		if( m_expand )
+		{
+			expand( in, newOut->writable(), vertsPerCurve );
+		}
+		else
+		{
+			compress( in, newOut->writable(), vertsPerCurve );
+		}
+
+		setGeometricInterpretation( newOut.get(), getGeometricInterpretation( data ) );
+
+		return newOut;
+	}
+
+	IECore::DataPtr operator()( const Data *data, const std::vector<int> & ) const
+	{
+		throw IECore::Exception( "DuplicateEndPoints : Unsupported Data type" );
+	}
+
+	bool m_expand;
+
+};
+
+} // namespace
+
+CurvesPrimitivePtr IECoreScene::CurvesAlgo::updateEndpointMultiplicity( const IECoreScene::CurvesPrimitive *curves, const IECore::CubicBasisf &cubicBasis )
+{
+	CurvesPrimitivePtr newCurves = new IECoreScene::CurvesPrimitive();
+
+	bool expand;
+	if( ( cubicBasis == IECore::CubicBasisf::catmullRom() || cubicBasis == IECore::CubicBasisf::bezier() || cubicBasis == IECore::CubicBasisf::bSpline() ) &&
+		curves->basis() == IECore::CubicBasisf::linear() )
+	{
+		expand = true;
+	}
+	else if( (
+		curves->basis() == IECore::CubicBasisf::catmullRom() ||
+			curves->basis() == IECore::CubicBasisf::bezier() ||
+			curves->basis() == IECore::CubicBasisf::bSpline()
+	) && cubicBasis == IECore::CubicBasisf::linear() )
+	{
+		expand = false;
+	}
+	else
+	{
+		return curves->copy();
+	}
+
+	DuplicateEndPoints endPointDuplicator( expand );
+
+	// enqueue a task for each primitive variable and another for the topology update
+	// note we have to write the new primvars to tbb concurrent_unordered map before updating the primitives primvars in serial
+	// todo : we should be able to thread the expand and compress functions but this would require a parallel reduce to calculate
+	// offsets.
+	tbb::task_group taskGroup;
+	tbb::concurrent_unordered_map<std::string, IECoreScene::PrimitiveVariable> newPrimVars;
+	for( const auto it : curves->variables )
+	{
+		// only duplicate vertex interpolated end points
+		if( it.second.interpolation == IECoreScene::PrimitiveVariable::Vertex )
+		{
+			auto f = [it, &endPointDuplicator, curves, &newPrimVars]()
+			{
+				if( it.second.indices )
+				{
+					auto newIndices = IECore::runTimeCast<IECore::IntVectorData>( IECore::dispatch( it.second.indices.get(), endPointDuplicator, curves->verticesPerCurve()->readable() ) );
+					newPrimVars[it.first] = IECoreScene::PrimitiveVariable( it.second.interpolation, it.second.data, newIndices );
+				}
+				else
+				{
+					auto newVertexData = IECore::dispatch( it.second.data.get(), endPointDuplicator, curves->verticesPerCurve()->readable() );
+					newPrimVars[it.first] = IECoreScene::PrimitiveVariable( it.second.interpolation, newVertexData );
+				}
+			};
+
+			taskGroup.run( f );
+		}
+		else
+		{
+			newCurves->variables[it.first] = it.second;
+		}
+	}
+
+	auto newTopology = curves->verticesPerCurve()->copy();
+	auto updateTopology = [&newTopology, expand]()
+	{
+		for( auto &i : newTopology->writable() )
+		{
+			i += expand ? 4 : -4;
+		}
+	};
+
+	taskGroup.run( updateTopology );
+	taskGroup.wait();
+
+	for (auto i : newPrimVars)
+	{
+		newCurves->variables[i.first] = i.second;
+	}
+
+	newCurves->setTopology( newTopology, cubicBasis, curves->periodic() );
+
+	return newCurves;
+}

--- a/src/IECoreScene/bindings/CurvesAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/CurvesAlgoBinding.cpp
@@ -77,6 +77,7 @@ void bindCurvesAlgo()
 	def( "resamplePrimitiveVariable", &CurvesAlgo::resamplePrimitiveVariable );
 	def( "deleteCurves", &CurvesAlgo::deleteCurves, arg_( "invert" ) = false );
 	def( "segment", ::segment, segmentOverLoads());
+	def( "updateEndpointMultiplicity", &CurvesAlgo::updateEndpointMultiplicity );
 }
 
 } // namespace IECoreSceneModule

--- a/test/IECore/CubicBasisTest.py
+++ b/test/IECore/CubicBasisTest.py
@@ -188,6 +188,43 @@ class CubicTest( unittest.TestCase ) :
 
 			self.assertAlmostEqual( a, b.integral( t0, t1, p0, p1, p2, p3 ), 6 )
 
+	def testReadEnum( self ):
+
+		b = IECore.CubicBasisf.linear()
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.Linear )
+
+		b = IECore.CubicBasisf.bezier()
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.Bezier )
+
+		b = IECore.CubicBasisf.bSpline()
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.BSpline )
+
+		b = IECore.CubicBasisf.catmullRom()
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.CatmullRom )
+
+		b = IECore.CubicBasisf(imath.M44f(), 0)
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.Unknown )
+
+	def testConstructFromEnum( self ):
+
+		b = IECore.CubicBasisf ( IECore.StandardCubicBasis.Linear )
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.Linear )
+		self.assertEqual( b, IECore.CubicBasisf.linear() )
+
+		b = IECore.CubicBasisf ( IECore.StandardCubicBasis.Bezier )
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.Bezier )
+		self.assertEqual( b, IECore.CubicBasisf.bezier() )
+
+		b = IECore.CubicBasisf ( IECore.StandardCubicBasis.BSpline )
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.BSpline )
+		self.assertEqual( b, IECore.CubicBasisf.bSpline() )
+
+		b = IECore.CubicBasisf ( IECore.StandardCubicBasis.CatmullRom )
+		self.assertEqual( b.standardBasis(), IECore.StandardCubicBasis.CatmullRom )
+		self.assertEqual( b, IECore.CubicBasisf.catmullRom() )
+
+		with self.assertRaises( Exception ) as cm:
+			b = IECore.CubicBasisf ( IECore.StandardCubicBasis.Unknown )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Enable linear curves to be converted into bSpline other cubic spline basis. This should save memory for cases were we have many curves with only a few verts each.

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] I have updated the documentation, if applicable.
- [x]  My code follows the Cortex project's prevailing coding style and conventions.
