### PR TITLE
Polymesh tangent

### DIFF
--- a/src/IECoreScene/MeshMergeOp.cpp
+++ b/src/IECoreScene/MeshMergeOp.cpp
@@ -238,14 +238,14 @@ struct MeshMergeOp::PrependPrimVars
 			{
 				typedef typename T::ValueType::value_type ValueType;
 				ValueType defaultValue = DefaultValue<ValueType>()();
-				size_t size = m_mesh->variableSize( m_primVar.interpolation ) - data->readable().size();
 
+				typename T::Ptr expandedData = runTimeCast<T>( m_primVar.expandedData() );
+				size_t size = m_mesh->variableSize( m_primVar.interpolation ) - expandedData->readable().size();
 				data2 = new T();
 				data2->writable().insert( data2->writable().end(), size, defaultValue );
 
 				/// The first mesh dictates whether the PrimitiveVariable should
 				/// be indexed. If the second mesh has indices, we must expand them.
-				typename T::Ptr expandedData = runTimeCast<T>( m_primVar.expandedData() );
 				data2->writable().insert( data2->writable().end(), expandedData->readable().begin(), expandedData->readable().end() );
 			}
 

--- a/test/IECoreScene/MeshMergeOpTest.py
+++ b/test/IECoreScene/MeshMergeOpTest.py
@@ -33,18 +33,24 @@
 ##########################################################################
 
 import unittest
-import imath
+
 import IECore
 import IECoreScene
+import imath
+
 import math
 
 class MeshMergeOpTest( unittest.TestCase ) :
 
+	def verifyPrimvars( self, primitive ):
+		for v in primitive.keys():
+			self.failUnless( primitive.isPrimitiveVariableValid(primitive[v]), "invalid primvar {0}".format( v ) )
+
 	def verifyMerge( self, mesh1, mesh2, merged ) :
 
-		self.failUnless( mesh1.arePrimitiveVariablesValid() )
-		self.failUnless( mesh2.arePrimitiveVariablesValid() )
-		self.failUnless( merged.arePrimitiveVariablesValid() )
+		self.verifyPrimvars( mesh1 )
+		self.verifyPrimvars( mesh2 )
+		self.verifyPrimvars( merged )
 
 		for v in IECoreScene.PrimitiveVariable.Interpolation.values :
 			i = IECoreScene.PrimitiveVariable.Interpolation( v )


### PR DESCRIPTION
Support both *Vertex* and *FaceVarying* UVs in the tangent calculation. We preserve the indexing of the UVs in the tangents. Generating indexed tangents exposed a bug in the MeshMeshOp.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
