### PR TITLE
IECoreArnold : write face varying indices for indexed Vertex varying UVs

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
@@ -131,11 +131,23 @@ void convertUVSet( const std::string &uvSet, const PrimitiveVariable &uvVariable
 	AtArray *indicesArray = nullptr;
 	if( uvVariable.indices )
 	{
-		const vector<int> &indices = uvVariable.indices->readable();
-		indicesArray = AiArrayAllocate( indices.size(), 1, AI_TYPE_UINT );
-		for( size_t i = 0, e = indices.size(); i < e; ++i )
+		if( uvVariable.interpolation == PrimitiveVariable::FaceVarying )
 		{
-			AiArraySetUInt( indicesArray, i, indices[i] );
+			const vector<int> &indices = uvVariable.indices->readable();
+			indicesArray = AiArrayAllocate( indices.size(), 1, AI_TYPE_UINT );
+			for( size_t i = 0, e = indices.size(); i < e; ++i )
+			{
+				AiArraySetUInt( indicesArray, i, indices[i] );
+			}
+		}
+		else // Varying or Vertex - we need to expands the indices to face varying
+		{
+			const vector<int> &indices = uvVariable.indices->readable();
+			indicesArray = AiArrayAllocate( vertexIds.size(), 1, AI_TYPE_UINT );
+			for( size_t i = 0, e = vertexIds.size(); i < e; ++i )
+			{
+				AiArraySetUInt( indicesArray, i, indices[vertexIds[i]] );
+			}
 		}
 	}
 	else if( uvVariable.interpolation == PrimitiveVariable::FaceVarying )


### PR DESCRIPTION
It seems like our houdini exporter is keen to generate indexed UVs even if they're vertex interpolated.
 
### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
