### PR TITLE
Build updates for gcc 6

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -524,7 +524,7 @@ o.Add(
 o.Add(
 	"VDB_LIB_PATH",
 	"The path to the OpenVDB lib directory.",
-	"/usr/local/include",
+	"/usr/local/lib",
 )
 
 o.Add(
@@ -532,6 +532,12 @@ o.Add(
 	"The suffix appended to the names of the OpenVDB libraries. You can modify this "
 	"to link against libraries installed with non-default names",
 	"",
+)
+
+o.Add(
+	"VDB_PYTHON_PATH",
+	"The path to the OpenVDB lib directory for the python bindings.",
+	"/usr/local/lib",
 )
 
 # appleseed options
@@ -1803,7 +1809,7 @@ if doConfigure :
 		# testing
 		vdbTestEnv = testEnv.Clone()
 
-		vdbTestEnv["ENV"]["PYTHONPATH"] = vdbTestEnv["ENV"]["PYTHONPATH"] + ":" + vdbTestEnv["VDB_LIB_PATH"]
+		vdbTestEnv["ENV"]["PYTHONPATH"] = vdbTestEnv["ENV"]["PYTHONPATH"] + ":" + vdbTestEnv["VDB_PYTHON_PATH"]
 
 		vdbTest = vdbTestEnv.Command( "test/IECoreVDB/results.txt", vdbPythonModule, pythonExecutable + " $TEST_VDB_SCRIPT" )
 		NoCache( vdbTest )

--- a/config/ie/buildAll
+++ b/config/ie/buildAll
@@ -70,26 +70,32 @@ if IEEnv.platform() in ( "cent7.x86_64", ) :
 			for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
 				build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "ARNOLD_VERSION=UNDEFINED", "APPLESEED_VERSION=UNDEFINED", "DL_VERSION="+dlVersion ] )
 
+	appleseedCompilerMap = { x : [] for x in IEEnv.activeVersions(IEEnv.registry["compilers"]["gcc"]) }
 	for appleseedVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] ):
 		if not IEEnv.Registry.validateVariation( ["CORTEX_VERSION=10", "APPLESEED_VERSION={0}".format( appleseedVersion ) ] ) :
 			continue
 
-		for compilerVersion in IEEnv.activeVersions(IEEnv.registry["compilers"]["gcc"]): 
-			for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
-				build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "ARNOLD_VERSION=UNDEFINED", "APPLESEED_VERSION="+appleseedVersion, "DL_VERSION=UNDEFINED" ] )
-
-
-	appleseedVersion = IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] )[-1]
+		compilerVersion = IEEnv.registry["apps"]["appleseed"][appleseedVersion][IEEnv.platform()]["compilerVersion"]
+		appleseedCompilerMap[compilerVersion].append( appleseedVersion )
+		
+		for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
+			build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "ARNOLD_VERSION=UNDEFINED", "APPLESEED_VERSION="+appleseedVersion, "DL_VERSION=UNDEFINED" ] )
 
 	for aiVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["arnold"] ):
 
 		for mayaVersion in IEEnv.activeAppVersions( "maya" ) :
+			compilerVersion = IEEnv.registry["apps"]["maya"][mayaVersion][IEEnv.platform()]["compilerVersion"]
+			appleseedVersion = appleseedCompilerMap.get( compilerVersion, IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] ) )[-1]
 			build( [ "APP=maya", "APP_VERSION="+mayaVersion, "ARNOLD_VERSION=" + aiVersion, "APPLESEED_VERSION={0}".format(appleseedVersion)] )
 
 		for nukeVersion in IEEnv.activeAppVersions( "nuke" ) :
+			compilerVersion = IEEnv.registry["apps"]["nuke"][nukeVersion][IEEnv.platform()]["compilerVersion"]
+			appleseedVersion = appleseedCompilerMap.get( compilerVersion, IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] ) )[-1]
 			build( [ "APP=nuke", "APP_VERSION="+nukeVersion, "ARNOLD_VERSION=" + aiVersion, "APPLESEED_VERSION={0}".format(appleseedVersion) ] )
 
 		for houdiniVersion in IEEnv.activeAppVersions( "houdini" ) :
+			compilerVersion = IEEnv.registry["apps"]["houdini"][houdiniVersion][IEEnv.platform()]["compilerVersion"]
+			appleseedVersion = appleseedCompilerMap.get( compilerVersion, IEEnv.activeVersions( IEEnv.registry["apps"]["appleseed"] ) )[-1]
 			build( [ "APP=houdini", "APP_VERSION="+houdiniVersion, "ARNOLD_VERSION=" + aiVersion, "APPLESEED_VERSION={0}".format(appleseedVersion) ] )
 
 	for rvVersion in IEEnv.activeAppVersions( "rv" ) :

--- a/config/ie/options
+++ b/config/ie/options
@@ -268,11 +268,13 @@ except :
 WITH_GL=1
 
 # find alembic:
-ALEMBIC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "Alembic", alembicVersion )
+ALEMBIC_INCLUDE_PATH = os.path.join( "/software", "apps", "Alembic", alembicVersion, platform, compiler, compilerVersion, "include" )
+ALEMBIC_LIB_PATH = os.path.join( "/software", "apps", "Alembic", alembicVersion, platform, compiler, compilerVersion, "lib" )
 ALEMBIC_LIB_SUFFIX = "-" + alembicVersion
 
-VDB_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "OpenVDB", vdbVersion )
-VDB_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
+VDB_INCLUDE_PATH = os.path.join( "/software", "apps", "OpenVDB", vdbVersion, platform, compiler, compilerVersion, "include" )
+VDB_LIB_PATH = os.path.join( "/software", "apps", "OpenVDB", vdbVersion, platform, compiler, compilerVersion, "lib" )
+VDB_PYTHON_PATH = os.path.join( "/software", "apps", "OpenVDB", vdbVersion, platform, compiler, compilerVersion, "python", "lib", "python"+pythonVersion )
 
 BLOSC_INCLUDE_PATH = os.path.join( "/software/tools/include/", platform, "blosc", bloscVersion )
 BLOSC_LIB_PATH = os.path.join("/software/tools/lib", platform, compiler, compilerVersion )
@@ -292,8 +294,8 @@ if usdVersion :
 			USD_INCLUDE_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "include" )
 			USD_LIB_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "lib" )
 		else:
-			USD_INCLUDE_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "include" )
-			USD_LIB_PATH = os.path.join( usdReg["location"], "cortex", "$IECORE_MAJOR_VERSION", "lib" )
+			USD_INCLUDE_PATH = os.path.join( usdReg["location"], compiler, compilerVersion, "cortex", "$IECORE_MAJOR_VERSION", "include" )
+			USD_LIB_PATH = os.path.join( usdReg["location"], compiler, compilerVersion, "cortex", "$IECORE_MAJOR_VERSION", "lib" )
 
 
 # find hdf5:

--- a/config/ie/options
+++ b/config/ie/options
@@ -170,6 +170,7 @@ LINKFLAGS = []
 # set the dependency paths
 TBB_INCLUDE_PATH = os.path.join( "/software/apps/tbb", tbbVersion, platform, compiler, compilerVersion, "include" )
 TBB_LIB_PATH = os.path.join( "/software/apps/tbb", tbbVersion, platform, compiler, compilerVersion, "lib" )
+TBB_LIB_SUFFIX = "-" + tbbVersion
 BOOST_INCLUDE_PATH = os.path.join( "/software/tools/include", platform, "boost", boostVersion )
 BOOST_LIB_PATH = os.path.join( "/software", "tools", "lib", platform, compiler, compilerVersion )
 OPENEXR_INCLUDE_PATH = "/software/tools/include/" + platform + "/OpenEXR/" + openEXRVersion
@@ -345,6 +346,7 @@ if targetApp=="houdini" :
 	if distutils.version.LooseVersion(houdiniVersion) >= distutils.version.LooseVersion("17.0") :
 		TBB_INCLUDE_PATH = "$HOUDINI_INCLUDE_PATH"
 		TBB_LIB_PATH = "$HOUDINI_LIB_PATH"
+		TBB_LIB_SUFFIX = ""
 		OPENEXR_LIB_SUFFIX = ""
 		GLEW_LIB_SUFFIX = ""
 		ALEMBIC_LIB_SUFFIX = "_sidefx"

--- a/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
@@ -986,6 +986,8 @@ bool FromHoudiniGeometryConverter::hasOnlyOpenPolygons( const GU_Detail *geo )
 
 		return true;
 	}
+
+	return false;
 }
 
 const IECore::InternedString &FromHoudiniGeometryConverter::groupPrimVarPrefix()

--- a/test/IECoreImage/ImageReaderTest.py
+++ b/test/IECoreImage/ImageReaderTest.py
@@ -212,7 +212,7 @@ class ImageReaderTest( unittest.TestCase ) :
 	def testIncompleteImage( self ) :
 
 		r = IECoreImage.ImageReader( "test/IECoreImage/data/exr/incomplete.exr" )
-		self.assertRaisesRegexp( Exception, "Scan line 29 is missing", r.read )
+		self.assertRaisesRegexp( Exception, "Error reading pixel data from image file", r.read )
 
 	def testHeaderToBlindData( self ) :
 


### PR DESCRIPTION
These changes are necessary to build Cortex with gcc 6.3.1 at IE, using some older dependencies.