### PR TITLE
Canceller binding : Derive Cancelled class from RunTimeError

### DIFF
--- a/src/IECorePython/CancellerBinding.cpp
+++ b/src/IECorePython/CancellerBinding.cpp
@@ -48,7 +48,6 @@ namespace IECorePython
 
 void bindCanceller()
 {
-	class_<Cancelled>( "Cancelled");
 
 	class_<Canceller, boost::noncopyable>( "Canceller" )
 		.def( "cancel", &Canceller::cancel )
@@ -58,13 +57,17 @@ void bindCanceller()
 
 	register_ptr_to_python<std::shared_ptr<Canceller>>();
 
+	PyObject *cancelledClass = PyErr_NewException( (char *)"IECore.Cancelled", PyExc_RuntimeError, nullptr );
+
 	register_exception_translator<Cancelled>(
-		[]( const Cancelled &e ) {
-			object o( e );
-			Py_INCREF( o.ptr() );
-			PyErr_SetObject( (PyObject *)o.ptr()->ob_type, o.ptr() );
+		[cancelledClass]( const Cancelled &e ) {
+			PyObject *value = PyObject_CallFunction( cancelledClass, nullptr );
+			PyErr_SetObject( cancelledClass, value );
 		}
 	);
+
+	scope().attr( "Cancelled" ) = object( borrowed( cancelledClass ) );
+
 }
 
 } // namespace IECorePython

--- a/test/IECore/CancellerTest.py
+++ b/test/IECore/CancellerTest.py
@@ -51,5 +51,27 @@ class CancellerTest( unittest.TestCase ) :
 		with self.assertRaises( IECore.Cancelled ) :
 			IECore.Canceller.check( c )
 
+	def testFinally( self ) :
+
+		def f() :
+
+			c = IECore.Canceller()
+			c.cancel()
+
+			didFinally = False
+			try :
+				IECore.Canceller.check( c )
+			finally :
+				didFinally = True
+
+			self.assertEqual( didFinally, True )
+
+		self.assertRaises( IECore.Cancelled, f )
+
+	def testCancelledClass( self ) :
+
+		self.assertIsInstance( IECore.Cancelled(), RuntimeError )
+		self.assertEqual( IECore.Cancelled.__module__, "IECore" )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
It turns out that Python has problems with exceptions that don't derive from the python `Exception` class. The symptom was a `"SystemError: 'finally' pops bad exception"` error in `testFinally()`. There's a bit more information in [this thread](https://mail.python.org/pipermail/cplusplus-sig/2012-June/016649.html).
