### PR TITLE
BUILD_TYPE option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,13 +92,13 @@ matrix:
     include:
         - os: linux
           compiler: gcc
-          env: COMPILER_VERSION=4.8 CXXSTD=c++11 DEBUG=0 IECORE_STREAMINDEXEDIO_COMPRESSION="lz4 9 1 1"
+          env: COMPILER_VERSION=4.8 CXXSTD=c++11 BUILD_TYPE=RELEASE IECORE_STREAMINDEXEDIO_COMPRESSION="lz4 9 1 1"
         - os: linux
           compiler: gcc
-          env: COMPILER_VERSION=4.8 CXXSTD=c++11 DEBUG=0 IECORE_STREAMINDEXEDIO_COMPRESSION="lz4 0 1 1"
+          env: COMPILER_VERSION=4.8 CXXSTD=c++11 BUILD_TYPE=RELEASE IECORE_STREAMINDEXEDIO_COMPRESSION="lz4 0 1 1"
         - os: linux
           compiler: gcc
-          env: COMPILER_VERSION=4.8 CXXSTD=c++11 DEBUG=1
+          env: COMPILER_VERSION=4.8 CXXSTD=c++11 BUILD_TYPE=DEBUG
         - os: linux
           compiler: gcc
-          env: COMPILER_VERSION=6 CXXSTD=c++14 DEBUG=0
+          env: COMPILER_VERSION=6 CXXSTD=c++14 BUILD_TYPE=RELEASE

--- a/SConstruct
+++ b/SConstruct
@@ -1078,7 +1078,7 @@ if env["BUILD_TYPE"] == "DEBUG" :
 elif env["BUILD_TYPE"] == "RELEASE" :
 	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3"] )
 elif env["BUILD_TYPE"] == "RELWITHDEBINFO" :
-	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3", "-g"] )
+	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3", "-g", "-fno-omit-frame-pointer"] )
 
 # autoconf-like checks for stuff.
 # this part of scons doesn't seem so well thought out.

--- a/SConstruct
+++ b/SConstruct
@@ -101,11 +101,12 @@ o.Add(
 )
 
 o.Add(
-	BoolVariable( "DEBUG", "Make a debug build", False )
-)
-
-o.Add(
-	BoolVariable( "DEBUGINFO", "Make debug info for release builds", False )
+	EnumVariable(
+		"BUILD_TYPE",
+		"Optimisation and debug symbol configuration",
+		"RELEASE",
+		allowed_values = ('RELEASE', 'DEBUG', 'RELWITHDEBINFO')
+	)
 )
 
 o.Add(
@@ -1072,13 +1073,12 @@ if env["WARNINGS_AS_ERRORS"] :
 		SHLINKFLAGS = [ "-Wl,-fatal_warnings" ],
 	)
 
-if env["DEBUG"] :
-	env.Append( CXXFLAGS = [ "-g", "-O0" ] )
-else :
-	cxxFlags = [ "-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O2" ]
-	if env["DEBUGINFO"] :
-		cxxFlags.append( "-g" )
-	env.Append( CXXFLAGS = cxxFlags )
+if env["BUILD_TYPE"] == "DEBUG" :
+	env.Append( CXXFLAGS = ["-g", "-O0"] )
+elif env["BUILD_TYPE"] == "RELEASE" :
+	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3"] )
+elif env["BUILD_TYPE"] == "RELWITHDEBINFO" :
+	env.Append( CXXFLAGS = ["-DNDEBUG", "-DBOOST_DISABLE_ASSERTS", "-O3", "-g"] )
 
 # autoconf-like checks for stuff.
 # this part of scons doesn't seem so well thought out.

--- a/config/ie/options
+++ b/config/ie/options
@@ -144,26 +144,7 @@ boostVersionSuffix = "-mt-" + boostVersion.replace( ".", "_" )
 while boostVersionSuffix.endswith( "_0" ) :
 	boostVersionSuffix = boostVersionSuffix[:-2]
 
-debug = getOption( "DEBUG", False )
 CXXFLAGS = [ "-pipe", "-Wall", "-pthread" ]
-
-if debug :
-
-	CXXFLAGS += [ "-g" ]
-
-	withAsserts = True
-
-else :
-
-	withAsserts = False
-
-withAsserts = getOption( "WITH_ASSERTS", withAsserts )
-if not withAsserts :
-	CXXFLAGS += [ "-DNDEBUG", "-DBOOST_DISABLE_ASSERTS" ]
-
-if not debug :
-
-	CXXFLAGS += [ "-O2" ]
 
 LINKFLAGS = []
 


### PR DESCRIPTION
Simplify build options and also match gaffer

BUILD_TYPE  can be set to DEBUG, RELEASE or RELWITHDEBINFO

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
