### PR TITLE
SceneInterface : make extensions case insensitive

### DIFF
--- a/src/IECoreScene/SceneInterface.cpp
+++ b/src/IECoreScene/SceneInterface.cpp
@@ -36,6 +36,7 @@
 
 #include "boost/filesystem/convenience.hpp"
 #include "boost/tokenizer.hpp"
+#include "boost/algorithm/string.hpp"
 
 using namespace IECore;
 using namespace IECoreScene;
@@ -58,23 +59,24 @@ SceneInterface::CreatorMap &SceneInterface::fileCreators()
 
 void SceneInterface::registerCreator( const std::string &extension, IndexedIO::OpenMode modes, CreatorFn f )
 {
+	const std::string extension_lower = boost::algorithm::to_lower_copy( extension );
 	CreatorMap &createFns = fileCreators();
 
 	if ( modes & IndexedIO::Read )
 	{
-		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension, IndexedIO::Read );
+		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension_lower, IndexedIO::Read );
 		assert( createFns.find(key) == createFns.end() );
 		createFns.insert( CreatorMap::value_type(key, f) );
 	}
 	if ( modes & IndexedIO::Write )
 	{
-		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension, IndexedIO::Write );
+		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension_lower, IndexedIO::Write );
 		assert( createFns.find(key) == createFns.end() );
 		createFns.insert( CreatorMap::value_type(key, f) );
 	}
 	if ( modes & IndexedIO::Append )
 	{
-		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension, IndexedIO::Append );
+		std::pair< std::string, IndexedIO::OpenModeFlags > key( extension_lower, IndexedIO::Append );
 		assert( createFns.find(key) == createFns.end() );
 		createFns.insert( CreatorMap::value_type(key, f) );
 	}
@@ -103,6 +105,7 @@ SceneInterfacePtr SceneInterface::create( const std::string &path, IndexedIO::Op
 	SceneInterfacePtr result = nullptr;
 
 	std::string extension = boost::filesystem::extension(path);
+	boost::algorithm::to_lower( extension );
 	IndexedIO::OpenModeFlags openMode = IndexedIO::OpenModeFlags( mode & (IndexedIO::Read|IndexedIO::Write|IndexedIO::Append) );
 	std::pair< std::string, IndexedIO::OpenModeFlags > key( extension, openMode );
 

--- a/test/IECoreScene/SceneInterfaceTest.py
+++ b/test/IECoreScene/SceneInterfaceTest.py
@@ -44,6 +44,7 @@ import IECoreScene
 class SceneInterfaceTest( unittest.TestCase ) :
 
 	__testFile = "/tmp/test.scc"
+	__testFileUpper = "/tmp/test.SCC"
 
 	def writeSCC( self ) :
 
@@ -64,15 +65,23 @@ class SceneInterfaceTest( unittest.TestCase ) :
 
 		instance1 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
 		instance2 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance1_upper = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFileUpper )
 
 		self.assertTrue( instance1.isSame( instance2 ) )
+		self.assertTrue( instance1.isSame( instance1_upper ) )
 
 		instance3 = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFile, IECore.IndexedIO.OpenMode.Read )
 		instance4 = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFile, IECore.IndexedIO.OpenMode.Read )
+		instance3_upper = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFileUpper, IECore.IndexedIO.OpenMode.Read )
 
 		self.assertFalse( instance3.isSame( instance4 ) )
 		self.assertFalse( instance3.isSame( instance1 ) )
 		self.assertFalse( instance3.isSame( instance2 ) )
+
+		self.assertFalse( instance3.isSame( instance3_upper ) )
+		self.assertFalse( instance3_upper.isSame( instance1 ) )
+		self.assertFalse( instance3_upper.isSame( instance2 ) )
+		self.assertFalse( instance3_upper.isSame( instance1_upper ) )
 
 	def testErase( self ) :
 


### PR DESCRIPTION
Allows loading of scene files with upper case extensions. Based on discussion at https://github.com/GafferHQ/gaffer/issues/2906

### Checklist ###
 I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
