### PR TITLE
IECoreScene : Verify we can interpolate Data arrays.

### DIFF
--- a/test/IECoreScene/ObjectInterpolationTest.py
+++ b/test/IECoreScene/ObjectInterpolationTest.py
@@ -94,5 +94,45 @@ class ObjectInterpolationTest( unittest.TestCase ) :
 		m3 = IECore.linearObjectInterpolation( m1, m2, 0.5 )
 		self.assertEqual( m3.blindData()["a"], IECore.FloatData( 10 ) )
 
+	def testPrimVarsWithDifferingDataArraysAreSkipped( self ):
+
+		m1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		m2 = m1.copy()
+
+		m1["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1, 2, 1, 2] ), IECore.IntVectorData( [ 0, 1, 2, 3 ] ) )
+		m2["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1, 2 ] ), IECore.IntVectorData( [ 0, 1, 0, 1 ] ) )
+
+		m3 = IECore.linearObjectInterpolation( m1, m2, 0.5 )
+
+		self.assertTrue( "v" in m3 )
+
+		self.assertEqual( m3["v"], m1["v"])
+
+	def testPrimVarsWithDifferentIndicesAreSkipped( self ):
+
+		m1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		m2 = m1.copy()
+
+		m1["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1, 2, 3, 4] ), IECore.IntVectorData( [ 0, 1, 2, 3 ] ) )
+		m2["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 4, 3, 2, 1] ), IECore.IntVectorData( [ 3, 2, 1, 0 ] ) )
+
+		m3 = IECore.linearObjectInterpolation( m1, m2, 0.5 )
+
+		self.assertTrue( "v" in m3 )
+		self.assertEqual( m3["v"], m1["v"])
+
+	def testPrimVarInterpolationChangeSkipped( self ):
+
+		m1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		m2 = m1.copy()
+
+		m1["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1, 2, 3, 4] ), IECore.IntVectorData( [ 0, 1, 2, 3 ] ) )
+		m2["v"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 4, 3, 2, 1] ) )
+
+		m3 = IECore.linearObjectInterpolation( m1, m2, 0.5 )
+
+		self.assertTrue( "v" in m3 )
+		self.assertEqual( m3["v"], m1["v"])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
With indexed primitive variables it's possible to have differing data array lengths or ordering even though the primvar interpolation is valid and unchanging.  We now emit error messages if we encounter this situation & return null from the interpolation 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
