### PR TITLE
PrimitiveVariable::IndexedView : Allow assignment

### DIFF
--- a/include/IECoreScene/PrimitiveVariable.h
+++ b/include/IECoreScene/PrimitiveVariable.h
@@ -137,12 +137,12 @@ class PrimitiveVariable::IndexedView
 
 		typename std::vector<T>::const_reference operator[]( size_t i ) const
 		{
-			return m_data[index(i)];
+			return (*m_data)[index(i)];
 		}
 
 		size_t size() const
 		{
-			return m_indices ? m_indices->size() : m_data.size();
+			return m_indices ? m_indices->size() : m_data->size();
 		}
 
 		size_t index( size_t i ) const
@@ -152,7 +152,7 @@ class PrimitiveVariable::IndexedView
 
 		const std::vector<T> &data() const
 		{
-			return m_data;
+			return *m_data;
 		}
 
 		const std::vector<int> *indices() const
@@ -162,9 +162,9 @@ class PrimitiveVariable::IndexedView
 
 	private :
 
-		static const std::vector<T> &data( const PrimitiveVariable &variable );
+		static const std::vector<T> *data( const PrimitiveVariable &variable );
 
-		const std::vector<T> &m_data;
+		const std::vector<T> *m_data;
 		const std::vector<int> *m_indices;
 
 };

--- a/include/IECoreScene/PrimitiveVariable.inl
+++ b/include/IECoreScene/PrimitiveVariable.inl
@@ -52,17 +52,17 @@ PrimitiveVariable::IndexedView<T>::IndexedView( const PrimitiveVariable &variabl
 
 template<typename T>
 PrimitiveVariable::IndexedView<T>::IndexedView( const std::vector<T> &data, const std::vector<int> *indices)
-	: 	m_data( data ), m_indices( indices )
+	: 	m_data( &data ), m_indices( indices )
 {
 }
 
 template<typename T>
-const std::vector<T> &PrimitiveVariable::IndexedView<T>::data( const PrimitiveVariable &variable )
+const std::vector<T> *PrimitiveVariable::IndexedView<T>::data( const PrimitiveVariable &variable )
 {
 	typedef IECore::TypedData<std::vector<T>> DataType;
 	if( const DataType *d = IECore::runTimeCast<const DataType>( variable.data.get() ) )
 	{
-		return d->readable();
+		return &d->readable();
 	}
 	throw IECore::Exception(
 		std::string( "PrimitiveVariable does not contain " ) + DataType::staticTypeName()
@@ -159,7 +159,7 @@ typename PrimitiveVariable::IndexedView<T>::Iterator PrimitiveVariable::IndexedV
 {
 	return Iterator(
 		m_indices ? m_indices->data() : nullptr,
-		m_data.begin()
+		m_data->begin()
 	);
 }
 
@@ -168,7 +168,7 @@ typename PrimitiveVariable::IndexedView<T>::Iterator PrimitiveVariable::IndexedV
 {
 	return Iterator(
 		m_indices ? m_indices->data() + m_indices->size() : nullptr,
-		m_indices ? m_data.begin() : m_data.end()
+		m_indices ? m_data->begin() : m_data->end()
 	);
 }
 


### PR DESCRIPTION
The default assignment operator could not be used because the `m_data` reference type prevented it, as GCC explains :

```
include/IECoreScene/PrimitiveVariable.h:118:26: error: non-static reference member 'const std::vector<Imath_2_2::Vec2<float> >& IECoreScene::PrimitiveVariable::IndexedView<Imath_2_2::Vec2<float> >::m_data', can't use default assignment operator
```

Storing `m_data` via pointer solves the problem.
