### PR TITLE
PrimitiveVariable::IndexedView : Add default constructor

### DIFF
--- a/include/IECoreScene/PrimitiveVariable.h
+++ b/include/IECoreScene/PrimitiveVariable.h
@@ -120,6 +120,9 @@ class PrimitiveVariable::IndexedView
 
 	public :
 
+		/// Uninitialised.
+		IndexedView();
+
 		/// Throws if the PrimitiveVariable doesn't contain
 		/// `TypedData<vector<T>>`.
 		///

--- a/include/IECoreScene/PrimitiveVariable.inl
+++ b/include/IECoreScene/PrimitiveVariable.inl
@@ -45,6 +45,12 @@ namespace IECoreScene
 {
 
 template<typename T>
+PrimitiveVariable::IndexedView<T>::IndexedView()
+	:	m_data( nullptr ), m_indices( nullptr )
+{
+}
+
+template<typename T>
 PrimitiveVariable::IndexedView<T>::IndexedView( const PrimitiveVariable &variable )
 	:	m_data( data( variable ) ), m_indices( variable.indices ? &variable.indices->readable() : nullptr )
 {


### PR DESCRIPTION
This is useful when initialisation must be deferred for some reason, typically because it is done inside a conditional.

