### PR TITLE
StringAlgo : Add path matching functions

### DIFF
--- a/include/IECore/StringAlgo.h
+++ b/include/IECore/StringAlgo.h
@@ -36,8 +36,10 @@
 #define IECORE_STRINGALGO_H
 
 #include "IECore/Export.h"
+#include "IECore/InternedString.h"
 
 #include <string>
+#include <vector>
 
 namespace IECore
 {
@@ -75,6 +77,20 @@ inline bool matchMultiple( const char *s, const char *patterns );
 /// have special meaning to the match() function.
 inline bool hasWildcards( const MatchPattern &pattern );
 inline bool hasWildcards( const char *pattern );
+
+/// A type that holds a pattern that can be matched against a path
+/// of names. Matching for each path component is performed using the
+/// `match()` function above. An additional "..." token allows any sequence
+/// of path components to be matched. This gives the same matching behaviour
+/// as the `PathMatcher` class.
+typedef std::vector<InternedString> MatchPatternPath;
+
+/// Returns true if `path` matches `patternPath`, and false otherwise.
+IECORE_API bool match( const std::vector<InternedString> &path, const MatchPatternPath &patternPath );
+
+/// Tokenizes string into a MatchPatternPath, splitting on `separator`. Equivalent to
+/// `tokenize()`, but with special handling for the "..." match token when separator is '.'.
+IECORE_API MatchPatternPath matchPatternPath( const std::string &patternPath, char separator = '/' );
 
 /// Returns the numeric suffix from the end of s, if one exists, and -1 if
 /// one doesn't. If stem is specified then it will be filled with the contents

--- a/src/IECorePython/StringAlgoBinding.cpp
+++ b/src/IECorePython/StringAlgoBinding.cpp
@@ -40,7 +40,34 @@
 
 #include "IECore/StringAlgo.h"
 
+#include "boost/python/suite/indexing/container_utils.hpp"
+
 using namespace boost::python;
+using namespace IECore;
+
+namespace
+{
+
+bool matchPath( object path, object patternPath )
+{
+	std::vector<InternedString> p, pp;
+	boost::python::container_utils::extend_container( p, path );
+	boost::python::container_utils::extend_container( pp, patternPath );
+	return StringAlgo::match( p, pp );
+}
+
+list matchPatternPath( const std::string &path, char separator )
+{
+	StringAlgo::MatchPatternPath p = StringAlgo::matchPatternPath( path, separator );
+	list result;
+	for( const auto &x : p )
+	{
+		result.append( x.c_str() );
+	}
+	return result;
+}
+
+} // namespace
 
 void IECorePython::bindStringAlgo()
 {
@@ -48,7 +75,9 @@ void IECorePython::bindStringAlgo()
 	scope().attr( "StringAlgo" ) = module;
 	scope moduleScope( module );
 
+	def( "match", &matchPath );
 	def( "match", (bool (*)( const char *, const char * ))&IECore::StringAlgo::match );
 	def( "matchMultiple", (bool (*)( const char *, const char * ))&IECore::StringAlgo::matchMultiple );
 	def( "hasWildcards", (bool (*)( const char * ))&IECore::StringAlgo::hasWildcards );
+	def( "matchPatternPath", &matchPatternPath, ( arg( "patternPath" ), arg( "separator" ) = '/' ) );
 }

--- a/test/IECore/StringAlgoTest.py
+++ b/test/IECore/StringAlgoTest.py
@@ -151,5 +151,21 @@ class StringAlgoTest( unittest.TestCase ) :
 			else :
 				self.assertFalse( IECore.StringAlgo.hasWildcards( p ), "{0} doesn't have wildcards".format( p ) )
 
+	def testMatchPaths( self ) :
+
+		self.assertTrue( IECore.StringAlgo.match( [ "a", "b", "c" ], [ "a", "b", "c" ] ) )
+		self.assertTrue( IECore.StringAlgo.match( [ "a", "b", "c" ], [ "a", "b", "*" ] ) )
+		self.assertTrue( IECore.StringAlgo.match( [ "a", "b", "c" ], [ "*", "*", "*" ] ) )
+
+		self.assertFalse( IECore.StringAlgo.match( [ "a", "b", "c" ], [ "a", "b", "d" ] ) )
+		self.assertFalse( IECore.StringAlgo.match( [ "a", "b", "c" ], [ "*" ] ) )
+
+	def testMatchPatternPath( self ) :
+
+		self.assertEqual( IECore.StringAlgo.matchPatternPath( "/a/.../b*/d" ), [ "a", "...", "b*", "d" ] )
+		self.assertEqual( IECore.StringAlgo.matchPatternPath( "" ), [] )
+		self.assertEqual( IECore.StringAlgo.matchPatternPath( "a.b.c", separator = "." ), [ "a", "b", "c" ] )
+		self.assertEqual( IECore.StringAlgo.matchPatternPath( "a...b", separator = "." ), [ "a", "...", "b" ] )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This provides equivalent matching to `IECore::PathMatcher`, for use when constructing a `PathMatcher` would be overkill (typically when you only want to match against one path).
