### PR TITLE
MeshAlgo : connectedVertices

### DIFF
--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -91,6 +91,12 @@ IECORESCENE_API std::vector<MeshPrimitivePtr> segment( const MeshPrimitive *mesh
 /// tolerance parameter is used to define a floating point epsilon for these checks.
 IECORESCENE_API MeshPrimitivePtr triangulate( const MeshPrimitive *mesh, float tolerance = 1e-6f, bool throwExceptions = false);
 
+
+/// Generate a list of connected vertices per vertex
+/// The first vector contains a flat list of all the indices of the connected neighbor vertices.
+///	The second one holds an offset index for every vertex. Note that the offset indices vector skips the first offset index (since it's 0)
+IECORESCENE_API	std::pair<IECore::IntVectorDataPtr, IECore::IntVectorDataPtr> connectedVertices( const IECoreScene::MeshPrimitive *mesh );
+
 } // namespace MeshAlgo
 
 } // namespace IECoreScene

--- a/src/IECoreScene/MeshAlgoConnectedVertices.cpp
+++ b/src/IECoreScene/MeshAlgoConnectedVertices.cpp
@@ -1,0 +1,87 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreScene/MeshAlgo.h"
+
+using namespace std;
+using namespace IECore;
+using namespace IECoreScene;
+
+pair<IntVectorDataPtr, IntVectorDataPtr> MeshAlgo::connectedVertices( const MeshPrimitive *mesh )
+{
+	size_t numVertices = mesh->variableData< V3fVectorData >( "P", PrimitiveVariable::Vertex )->readable().size();
+	const vector<int> &numVerticesPerFace = mesh->verticesPerFace()->readable();
+	const vector<int> &vertexIds = mesh->vertexIds()->readable();
+
+	vector< set<int> > neighbors( numVertices );
+
+	int currentVertOffset = 0;
+	for ( auto &vertsPerFace : numVerticesPerFace )
+	{
+		for ( int i = 0; i < vertsPerFace; ++i)
+		{
+			const int &faceVert = vertexIds[ currentVertOffset + i ];
+			const int &faceVertNext = vertexIds[ currentVertOffset + ( i + 1 ) % vertsPerFace ];
+			neighbors[ faceVert ].insert( faceVertNext );
+			neighbors[ faceVertNext ].insert( faceVert );
+		}
+		currentVertOffset += vertsPerFace;
+	}
+
+	int neighborCount = 0;
+	for ( auto &n : neighbors )
+	{
+		neighborCount += n.size();
+	}
+
+	IntVectorDataPtr offsets = new IntVectorData();
+	IntVectorDataPtr neighborList = new IntVectorData();
+	vector<int> &offsetsW = offsets->writable();
+	vector<int> &neighborListW = neighborList->writable();
+
+	neighborListW.resize( neighborCount, -1 );
+	offsetsW.resize( neighbors.size(), -1 );
+
+	int ix = 0;
+	for ( size_t i = 0; i < neighbors.size(); ++i )
+	{
+		for ( auto &n : neighbors[ i ] )
+		{
+			neighborListW[ ix++ ] = n;
+		}
+		offsetsW[ i ] = ix;
+	}
+
+	return pair<IntVectorDataPtr, IntVectorDataPtr>( neighborList, offsets );
+}

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -105,6 +105,7 @@ void bindMeshAlgo()
 	scope meshAlgoScope( meshAlgoModule );
 
 	StdPairToTupleConverter<PrimitiveVariable, PrimitiveVariable>();
+	StdPairToTupleConverter<IECore::IntVectorDataPtr, IECore::IntVectorDataPtr>();
 
 	def( "calculateTangents", &MeshAlgo::calculateTangents, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv", arg_( "orthoTangents" ) = true, arg_( "position" ) = "P" ) );
 	def( "calculateFaceArea", &MeshAlgo::calculateFaceArea, ( arg_( "mesh" ), arg_( "position" ) = "P" ) );
@@ -117,6 +118,7 @@ void bindMeshAlgo()
 	def( "distributePoints", &MeshAlgo::distributePoints, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "position" ) = "P" ) );
 	def( "segment", &::segment, segmentOverLoads() );
 	def( "triangulate", &MeshAlgo::triangulate, (arg_("mesh"), arg_("tolerance") =1e-6f, arg_("throwExceptions") = false) );
+	def( "connectedVertices", &MeshAlgo::connectedVertices );
 }
 
 } // namespace IECoreSceneModule

--- a/test/IECoreScene/MeshAlgoConnectedVerticesTest.py
+++ b/test/IECoreScene/MeshAlgoConnectedVerticesTest.py
@@ -1,6 +1,6 @@
 ##########################################################################
 #
-#  Copyright (c) 2017, Image Engine Design Inc. All rights reserved.
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are
@@ -33,18 +33,52 @@
 ##########################################################################
 
 import unittest
+import imath
+import IECore
+import IECoreScene
 
-from MeshAlgoDeleteFacesTest import MeshAlgoDeleteFacesTest
-from MeshAlgoDistortionsTest import MeshAlgoDistortionsTest
-from MeshAlgoDistributePointsTest import MeshAlgoDistributePointsTest
-from MeshAlgoFaceAreaTest import MeshAlgoFaceAreaTest
-from MeshAlgoResampleTest import MeshAlgoResampleTest
-from MeshAlgoTangentsTest import MeshAlgoTangentsTest
-from MeshAlgoWindingTest import MeshAlgoWindingTest
-from MeshAlgoSegmentTest import MeshAlgoSegmentTest
-from MeshAlgoReorderTest import MeshAlgoReorderTest
-from MeshAlgoTriangulateTest import MeshAlgoTriangulateTest
-from MeshAlgoConnectedVerticesTest import MeshAlgoConnectedVerticesTest
+class MeshAlgoConnectedVerticesTest( unittest.TestCase ) :
+
+	def testConnectedVertices( self ) :
+
+		v = imath.V3f
+
+		# p
+		#  3_ _2 _5
+		#  |   |\ |
+		#  |_ _|_\|
+		#  0   1  4
+
+		p = IECore.V3fVectorData(
+			[
+				v( 0, 0, 0 ),
+				v( 2, 0, 0 ),
+				v( 2, 2, 0 ),
+				v( 0, 2, 0 ),
+				v( 3, 0, 0 ),
+				v( 3, 2, 0 ),
+			]
+		)
+
+		m = IECoreScene.MeshPrimitive( IECore.IntVectorData( [ 4, 3, 3 ] ), IECore.IntVectorData( [ 0, 1, 2, 3, 1, 4, 2, 4, 5, 2 ] ), "linear", p )
+
+		neighborList, offsets = IECoreScene.MeshAlgo.connectedVertices( m )
+		neighbors = [ [] for i in offsets ]
+		offsets.insert( 0,0 )
+
+		for i in range( len( offsets ) - 1 ):
+			neighbors[ i ] = set( neighborList[ offsets[ i ] : offsets[ i + 1 ] ] )
+
+		result = [
+			set([1, 3]),
+			set([0, 2, 4]),
+			set([1, 3, 4, 5]),
+			set([0, 2]),
+			set([1, 2, 5]),
+			set([2, 4])]
+
+		self.assertEqual( neighbors, result)
+
 
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()


### PR DESCRIPTION
This adds a MeshAlgo to get all connected vertices of a mesh.  


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
