### PR TITLE
IECoreVDB : prevent VDB read in memory calculation.

### DIFF
--- a/src/IECoreVDB/VDBObject.cpp
+++ b/src/IECoreVDB/VDBObject.cpp
@@ -370,7 +370,7 @@ void VDBObject::memoryUsage( IECore::Object::MemoryAccumulator &acc ) const
 
 	for( const auto it : m_grids )
 	{
-		acc.accumulate( it.second.grid().get(), it.second.grid()->memUsage() );
+		acc.accumulate( it.second.metadata().get(), it.second.metadata()->memUsage() );
 	}
 }
 

--- a/test/IECoreVDB/VDBObjectTest.py
+++ b/test/IECoreVDB/VDBObjectTest.py
@@ -112,7 +112,7 @@ class VDBObjectTest( VDBTestCase ) :
 		sourcePath = os.path.join( self.dataDir, "smoke.vdb" )
 		vdbObject = IECoreVDB.VDBObject( sourcePath )
 
-		self.assertTrue(788000 <= vdbObject.memoryUsage() <= 788200)
+		self.assertTrue( 1000 <= vdbObject.memoryUsage() <= 1500, "actual memory usage: {0}".format( vdbObject.memoryUsage() ) )
 
 		d = vdbObject.findGrid("density")
 
@@ -121,7 +121,7 @@ class VDBObjectTest( VDBTestCase ) :
 
 		d.mapAll( incValue )
 
-		self.assertTrue(7022000 <= vdbObject.memoryUsage() <= 7022300)
+		self.assertTrue(7022000 <= vdbObject.memoryUsage() <= 7022300, "actual memory usage: {0}".format( vdbObject.memoryUsage() ))
 
 	def testCanRemoveGrid( self ) :
 		sourcePath = os.path.join( self.dataDir, "smoke.vdb" )


### PR DESCRIPTION
Generates memory estimate without loading grid.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
