### PR TITLE
Cortex changes to allow for multiple VDB visualisations

### DIFF
--- a/include/IECoreGL/TypeIds.h
+++ b/include/IECoreGL/TypeIds.h
@@ -123,6 +123,8 @@ enum TypeId
 	PrimitiveSelectableTypeId = 105080,
 	ToGLStateConverterTypeId = 105081,
 	ToGLSphereConverterTypeId = 105082,
+	VolumeTypeStateComponentTypeId = 105083,
+	VolumeGridStateComponentTypeId = 105084,
 	LastCoreGLTypeId = 105999,
 };
 

--- a/include/IECoreGL/TypeIds.h
+++ b/include/IECoreGL/TypeIds.h
@@ -125,6 +125,8 @@ enum TypeId
 	ToGLSphereConverterTypeId = 105082,
 	VolumeTypeStateComponentTypeId = 105083,
 	VolumeGridStateComponentTypeId = 105084,
+    VolumeScalarRampStateComponentTypeId = 105085,
+    VolumeColorRampStateComponentTypeId = 105086,
 	LastCoreGLTypeId = 105999,
 };
 

--- a/include/IECoreGL/TypedStateComponent.h
+++ b/include/IECoreGL/TypedStateComponent.h
@@ -38,6 +38,7 @@
 
 #include "IECoreGL/Export.h"
 #include "IECoreGL/StateComponent.h"
+#include "IECore/Spline.h"
 
 #include "IECore/Export.h"
 
@@ -142,6 +143,11 @@ typedef TypedStateComponent<Imath::Color4f, PointColorStateComponentTypeId> Poin
 typedef TypedStateComponent<int, VolumeTypeStateComponentTypeId> VolumeTypeStateComponent;
 /// How to render a VDBRenderable
 typedef TypedStateComponent<std::string, VolumeGridStateComponentTypeId> VolumeGridStateComponent;
+/// Ramp for scalar volume parameters
+typedef TypedStateComponent<IECore::Splineff, VolumeScalarRampStateComponentTypeId> VolumeScalarRampStateComponent;
+/// Ramp for color volume parameters
+typedef TypedStateComponent<IECore::SplinefColor3f, VolumeColorRampStateComponentTypeId> VolumeColorRampStateComponent;
+
 
 enum GLPointsUsage
 {
@@ -254,6 +260,8 @@ IE_CORE_DECLAREPTR( OutlineColorStateComponent );
 IE_CORE_DECLAREPTR( PointColorStateComponent );
 IE_CORE_DECLAREPTR( VolumeTypeStateComponent );
 IE_CORE_DECLAREPTR( VolumeGridStateComponent );
+IE_CORE_DECLAREPTR( VolumeScalarRampStateComponent );
+IE_CORE_DECLAREPTR( VolumeColorRampStateComponent );
 IE_CORE_DECLAREPTR( DoubleSidedStateComponent );
 IE_CORE_DECLAREPTR( LineSmoothingStateComponent );
 IE_CORE_DECLAREPTR( PointSmoothingStateComponent );

--- a/include/IECoreGL/TypedStateComponent.h
+++ b/include/IECoreGL/TypedStateComponent.h
@@ -138,6 +138,10 @@ typedef TypedStateComponent<Imath::Color4f, WireframeColorStateComponentTypeId> 
 typedef TypedStateComponent<Imath::Color4f, OutlineColorStateComponentTypeId> OutlineColorStateComponent;
 /// Specifies the color to draw points in
 typedef TypedStateComponent<Imath::Color4f, PointColorStateComponentTypeId> PointColorStateComponent;
+/// How to render a VDBRenderable
+typedef TypedStateComponent<int, VolumeTypeStateComponentTypeId> VolumeTypeStateComponent;
+/// How to render a VDBRenderable
+typedef TypedStateComponent<std::string, VolumeGridStateComponentTypeId> VolumeGridStateComponent;
 
 enum GLPointsUsage
 {
@@ -248,6 +252,8 @@ IE_CORE_DECLAREPTR( BoundColorStateComponent );
 IE_CORE_DECLAREPTR( WireframeColorStateComponent );
 IE_CORE_DECLAREPTR( OutlineColorStateComponent );
 IE_CORE_DECLAREPTR( PointColorStateComponent );
+IE_CORE_DECLAREPTR( VolumeTypeStateComponent );
+IE_CORE_DECLAREPTR( VolumeGridStateComponent );
 IE_CORE_DECLAREPTR( DoubleSidedStateComponent );
 IE_CORE_DECLAREPTR( LineSmoothingStateComponent );
 IE_CORE_DECLAREPTR( PointSmoothingStateComponent );

--- a/src/IECoreGL/ToGLStateConverter.cpp
+++ b/src/IECoreGL/ToGLStateConverter.cpp
@@ -172,6 +172,8 @@ const AttributeToStateMap &attributeToStateMap()
 		m["gl:smoothing:lines"] = attributeToTypedState<LineSmoothingStateComponent>;
 		m["gl:smoothing:polygons"] = attributeToTypedState<PolygonSmoothingStateComponent>;
 		m["gl:surface"] = attributeToShaderState;
+		m["gl:volume:style"] = attributeToTypedState<VolumeTypeStateComponent>;
+		m["gl:volume:grid"] = attributeToTypedState<VolumeGridStateComponent>;
 	}
 	return m;
 }

--- a/src/IECoreGL/ToGLStateConverter.cpp
+++ b/src/IECoreGL/ToGLStateConverter.cpp
@@ -174,6 +174,8 @@ const AttributeToStateMap &attributeToStateMap()
 		m["gl:surface"] = attributeToShaderState;
 		m["gl:volume:style"] = attributeToTypedState<VolumeTypeStateComponent>;
 		m["gl:volume:grid"] = attributeToTypedState<VolumeGridStateComponent>;
+		m["gl:volume:scalarRamp"] = attributeToTypedState<VolumeScalarRampStateComponent>;
+		m["gl:volume:colorRamp"] = attributeToTypedState<VolumeColorRampStateComponent>;
 	}
 	return m;
 }

--- a/src/IECoreGL/TypedStateComponent.cpp
+++ b/src/IECoreGL/TypedStateComponent.cpp
@@ -276,5 +276,7 @@ IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( CullingBoxStateComponent,
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( ProceduralThreadingStateComponent, ProceduralThreadingStateComponentTypeId, bool, true );
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( CameraVisibilityStateComponent, CameraVisibilityStateComponentTypeId, bool, true );
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( AutomaticInstancingStateComponent, AutomaticInstancingStateComponentTypeId, bool, true );
+IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeTypeStateComponent, VolumeTypeStateComponentTypeId, int, 0);
+IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeGridStateComponent, VolumeGridStateComponentTypeId, std::string, "density");
 
 } // namespace IECoreGL

--- a/src/IECoreGL/TypedStateComponent.cpp
+++ b/src/IECoreGL/TypedStateComponent.cpp
@@ -278,5 +278,7 @@ IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( CameraVisibilityStateComp
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( AutomaticInstancingStateComponent, AutomaticInstancingStateComponentTypeId, bool, true );
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeTypeStateComponent, VolumeTypeStateComponentTypeId, int, 0);
 IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeGridStateComponent, VolumeGridStateComponentTypeId, std::string, "density");
+IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeScalarRampStateComponent, VolumeScalarRampStateComponentTypeId, IECore::Splineff, IECore::Splineff() );
+IECOREGL_TYPEDSTATECOMPONENT_SPECIALISEANDINSTANTIATE( VolumeColorRampStateComponent, VolumeColorRampStateComponentTypeId, IECore::SplinefColor3f, IECore::SplinefColor3f() );
 
 } // namespace IECoreGL


### PR DESCRIPTION
Provides a way to specify pass data to GL on how to visualise VDBs  along with the grid to visualise. 

- Added a ramp state state converter also. 

@johnhaddon I'm sure you mentioned on at least a couple of occasions there is a better way to support passing  data from attributes to IECore::GL than this but I can't find any mention of it, so apologies for asking again.  

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
