### PR TITLE
IECoreGL : convert glVisualiser attributes to State userAttributes.

### DIFF
--- a/include/IECoreGL/State.h
+++ b/include/IECoreGL/State.h
@@ -75,6 +75,7 @@ class IECOREGL_API State : public Bindable
 
 				State &m_currentState;
 				std::vector<StateComponentPtr> m_savedComponents;
+				std::map<IECore::InternedString, IECore::DataPtr> m_savedUserAttributes;
 
 		};
 

--- a/src/IECoreGL/State.cpp
+++ b/src/IECoreGL/State.cpp
@@ -215,6 +215,20 @@ void State::ScopedBinding::init( const State &s, bool bind )
 			cIt->second = it->second;
 		}
 	}
+
+	auto &writableUserAttributes = m_currentState.userAttributes()->writable();
+
+	for( auto userAttributeIt : s.userAttributes()->readable() )
+	{
+		auto it = writableUserAttributes.find( userAttributeIt.first );
+		if ( it != writableUserAttributes.end() )
+		{
+			m_savedUserAttributes[it->first] = it->second;
+		}
+
+		writableUserAttributes[userAttributeIt.first] = userAttributeIt.second;
+	}
+
 }
 
 State::ScopedBinding::~ScopedBinding()
@@ -223,6 +237,11 @@ State::ScopedBinding::~ScopedBinding()
 	{
 		(*it)->bind();
 		m_currentState.add( *it );
+	}
+
+	for ( auto it : m_savedUserAttributes )
+	{
+		m_currentState.userAttributes()->writable()[it.first] = it.second;
 	}
 }
 

--- a/src/IECoreGL/ToGLStateConverter.cpp
+++ b/src/IECoreGL/ToGLStateConverter.cpp
@@ -48,6 +48,7 @@
 #include "IECore/CompoundObject.h"
 #include "IECore/ObjectVector.h"
 #include "IECore/SimpleTypedData.h"
+#include "IECore/StringAlgo.h"
 
 using namespace IECore;
 using namespace IECoreGL;
@@ -176,6 +177,8 @@ const AttributeToStateMap &attributeToStateMap()
 	return m;
 }
 
+IECore::InternedString g_glVisualiser("glVisualiser");
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -209,6 +212,18 @@ IECore::RunTimeTypedPtr ToGLStateConverter::doConversion( IECore::ConstObjectPtr
 	const StatePtr result = new State( false );
 	for( CompoundObject::ObjectMap::const_iterator it = co->members().begin(), eIt = co->members().end(); it != eIt; ++it )
 	{
+		StringAlgo::MatchPatternPath p = StringAlgo::matchPatternPath( it->first.string(), ':' );
+
+		if ( p.size() > 0 && p[0] == g_glVisualiser )
+		{
+			if ( Data *value = IECore::runTimeCast<Data>( it->second.get() ) )
+			{
+				result->userAttributes()->writable()[it->first] = value;
+			}
+
+			continue;
+		}
+
 		AttributeToStateMap::const_iterator mIt = m.find( it->first );
 		if( mIt != m.end() )
 		{

--- a/test/IECoreGL/State.py
+++ b/test/IECoreGL/State.py
@@ -72,19 +72,32 @@ class TestState( unittest.TestCase ) :
 
 		state1 = IECoreGL.State( True )
 		state1.add( IECoreGL.NameStateComponent( "billy" ) )
+		state1.userAttributes()["test"] = IECore.IntData( 1 )
+
 		state2 = IECoreGL.State( False )
 		state2.add( IECoreGL.NameStateComponent( "bob" ) )
+		state2.userAttributes()["test"] = IECore.IntData( 2 )
 
 		self.assertEqual( state1.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "billy" )
 		self.assertEqual( state2.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "bob" )
+
+		self.assertEqual( state1.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 1 ) } ) )
+		self.assertEqual( state2.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 2 ) } ) )
 
 		with IECoreGL.State.ScopedBinding( state2, state1 ) :
 
 			self.assertEqual( state1.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "bob" )
 			self.assertEqual( state2.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "bob" )
 
+			self.assertEqual( state1.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 2 ) } ) )
+			self.assertEqual( state2.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 2 ) } ) )
+
 		self.assertEqual( state1.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "billy" )
 		self.assertEqual( state2.get( IECoreGL.NameStateComponent.staticTypeId() ).name(), "bob" )
+
+		self.assertEqual( state1.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 1 ) } ) )
+		self.assertEqual( state2.userAttributes(), IECore.CompoundData( { "test" : IECore.IntData( 2 ) } ) )
+
 
 	def testOverrides( self ) :
 


### PR DESCRIPTION
Second attempt to copy a few attributes  so they're available in GL rendering.