### PR TITLE
IECoreHoudini : ToHoudiniConverter - support uniform UVs

### DIFF
--- a/src/IECoreHoudini/ToHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniGeometryConverter.cpp
@@ -241,11 +241,29 @@ void ToHoudiniGeometryConverter::transferAttribValues(
 				uvw.emplace_back( uvIndexedView[i][0], uvIndexedView[i][1], 0 );
 			}
 
-			GA_Range range = vertRange;
-			if ( it.second.interpolation == pointInterpolation )
+			GA_Range range;
+			if( it.second.interpolation == pointInterpolation )
 			{
 				range = points;
 			}
+			else if( it.second.interpolation == primitiveInterpolation )
+			{
+				range = prims;
+			}
+			else if( it.second.interpolation == vertexInterpolation )
+			{
+				range = vertRange;
+			}
+			else
+			{
+				IECore::msg(
+					IECore::MessageHandler::Warning,
+					"ToHoudiniGeometryConverter",
+					"UV PrimitiveVariable '" + it.first + "' has invalid interpolation. Ignoring."
+				);
+				continue;
+			}
+			
 
 			V3fVectorData::Ptr uvwData = new V3fVectorData( uvw );
 			uvwData->setInterpretation( GeometricData::UV );

--- a/test/IECoreHoudini/ToHoudiniCurvesConverter.py
+++ b/test/IECoreHoudini/ToHoudiniCurvesConverter.py
@@ -997,8 +997,11 @@ class TestToHoudiniCurvesConverter( IECoreHoudini.TestCase ) :
 			imath.V3f( 0, 0, 0 ), imath.V3f( 1, 0, 0 )
 		], IECore.GeometricData.Interpretation.Point )
 
+		uvs = IECore.V2fVectorData( [imath.V2f( 0, 0 ), imath.V2f( 0, 1 ), imath.V2f( 1, 0 )], IECore.GeometricData.Interpretation.UV )
+
 		curves = IECoreScene.CurvesPrimitive( vertsPerCurve, IECore.CubicBasisf.linear(), False )
 		curves["P"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, positions )
+		curves["testUV"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, uvs )
 
 		sop = self.emptySop()
 
@@ -1007,11 +1010,14 @@ class TestToHoudiniCurvesConverter( IECoreHoudini.TestCase ) :
 
 		actualVertices = []
 		actualTopology = []
+		actualUVs = []
 		geo = sop.geometry()
 		self.assertEqual( 3, len( geo.prims() ) )
 		for prim in geo.prims() :
 			self.assertTrue( isinstance( prim, hou.Polygon ) )
 			self.assertFalse( prim.isClosed() )
+			uv = prim.attribValue( "testUV" )
+			actualUVs.append( imath.V2f( uv[0], uv[1] ))
 
 			actualTopology.append( len( prim.vertices() ) )
 			for vertex in prim.vertices() :
@@ -1020,6 +1026,7 @@ class TestToHoudiniCurvesConverter( IECoreHoudini.TestCase ) :
 
 		self.assertEqual( IECore.V3fVectorData( actualVertices, IECore.GeometricData.Interpretation.Point ), positions )
 		self.assertEqual( IECore.IntVectorData( actualTopology ), vertsPerCurve )
+		self.assertEqual( IECore.V2fVectorData( actualUVs, IECore.GeometricData.Interpretation.UV ), uvs )
 
 	def tearDown( self ) :
 


### PR DESCRIPTION
Before this change when loading .scc caches back into houdini which have uniform interpolated UVs they get incorrectly set as **primitive**.

 [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x]  I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
