### PR TITLE
ie config : don't load the IE maya menu when in a batch session

### DIFF
--- a/config/ie/ieMayaSetup.py
+++ b/config/ie/ieMayaSetup.py
@@ -1,4 +1,7 @@
-import IECore
-import IECoreMaya
+import maya.cmds
 
-IECoreMaya.Menus.createMenu( "IE", IECore.MenuDefinition(), "MayaWindow" )
+# create the 'IE' menu when the UI is available
+if hasattr( maya.cmds, "about" ) and not maya.cmds.about( batch=True, q=True ):
+	import IECore
+	import IECoreMaya
+	IECoreMaya.Menus.createMenu( "IE", IECore.MenuDefinition(), "MayaWindow" )


### PR DESCRIPTION
ie config : Fix to not load the IE maya menu when in a batch session

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
