### PR TITLE
ImageReader : Hardcode PNG color conversion as sRGB->Linear

### DIFF
--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -290,8 +290,26 @@ class ImageReader::Implementation
 						TypeDesc::TypeString, &fileFormat
 					);
 
-					std::string linearColorSpace = OpenImageIOAlgo::colorSpace( "", *spec );
-					std::string currentColorSpace = OpenImageIOAlgo::colorSpace( fileFormat, *spec );
+					std::string linearColorSpace;
+					std::string currentColorSpace;
+					if( strcmp( fileFormat, "png" ) == 0 )
+					{
+						// The most common use for loading PNGs via Cortex is for icons in Gaffer.
+						// If we were to use the OCIO config to guess the colorspaces as below, we
+						// would get it spectacularly wrong. For instance, with an ACES config the
+						// resulting icons are so washed out as to be illegible. Instead, we hardcode
+						// the rudimentary colour spaces much more likely to be associated with a PNG.
+						// These are supported by OIIO regardless of what OCIO config is in use.
+						/// \todo Should this apply to other formats too? Can we somehow fix
+						/// `OpenImageIOAlgo::colorSpace` instead?
+						linearColorSpace = "linear";
+						currentColorSpace = "sRGB";
+					}
+					else
+					{
+						linearColorSpace = OpenImageIOAlgo::colorSpace( "", *spec );
+						currentColorSpace = OpenImageIOAlgo::colorSpace( fileFormat, *spec );
+					}
 					ColorAlgo::transformChannel( data.get(), currentColorSpace, linearColorSpace );
 				}
 


### PR DESCRIPTION
Otherwise we end up applying fancy OCIO configs like ACES, when it is extremely unlikely that a bog standard PNG is encoded that way. I'm not sure that this is completely _right_, but it certainly does _work_, at least for Gaffer's purposes. I'm opening this PR in the hopes of either getting it merged, or provoking someone more knowledgable into providing an equivalent but more rigorous fix.

Here's a before and after :

![pngcolorspace](https://user-images.githubusercontent.com/1133871/51918881-3e811380-23da-11e9-9eed-bd32b2865b32.png)
