### PR TITLE
Houdini scene cache reader group from filtered out tags

### DIFF
--- a/src/IECoreHoudini/SOP_SceneCacheSource.cpp
+++ b/src/IECoreHoudini/SOP_SceneCacheSource.cpp
@@ -655,26 +655,23 @@ bool SOP_SceneCacheSource::convertObject( const IECore::Object *object, const st
 			for ( SceneInterface::NameList::const_iterator it=tags.begin(); it != tags.end(); ++it )
 			{
 				UT_String tag( *it );
-				if ( tag.multiMatch( params.tagFilter ) )
+				// skip this tag because it's used behind the scenes
+				if ( tag.multiMatch( convertTagFilter ) )
 				{
-					// skip this tag because it's used behind the scenes
-					if ( tag.multiMatch( convertTagFilter ) )
-					{
-						continue;
-					}
-
-					// replace this special character found in SCC tags that will prevent the group from being created
-					tag.substitute(":", "_");
-
-					tag.prepend("ieTag_");
-
-					GA_PrimitiveGroup *group = gdp->findPrimitiveGroup(tag);
-					if ( !group )
-					{
-						group = gdp->newPrimitiveGroup(tag);
-					}
-					group->addRange(newPrims);
+					continue;
 				}
+
+				// replace this special character found in SCC tags that will prevent the group from being created
+				tag.substitute(":", "_");
+
+				tag.prepend("ieTag_");
+
+				GA_PrimitiveGroup *group = gdp->findPrimitiveGroup(tag);
+				if ( !group )
+				{
+					group = gdp->newPrimitiveGroup(tag);
+				}
+				group->addRange(newPrims);
 			}
 		}
 

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -1494,7 +1494,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		xform.parm( "push" ).pressButton()
 
 		srcs = [ c for c in xform.allSubChildren() if c.type().nameWithCategory() == "Sop/ieSceneCacheSource" ]
-		self.assertEqual( set( [ pg.name() for src in srcs for pg in src.geometry().primGroups() ] ), { "ieTag_b" } )
+		self.assertEqual( set( [ pg.name() for src in srcs for pg in src.geometry().primGroups() ] ), { "ieTag_a", "ieTag_b", "ieTag_c" } )
 
 		# check that all groups present when Hierarchy is set to parenting
 		xform.parm( "collapse" ).pressButton()
@@ -1541,7 +1541,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		xform.parm( "push" ).pressButton()
 
 		srcs = [ c for c in xform.allSubChildren() if c.type().nameWithCategory() == "Sop/ieSceneCacheSource" ]
-		self.assertEqual( set( [ pg.name() for src in srcs for pg in src.geometry().primGroups() ] ), {  "ieTag_b" } )
+		self.assertEqual( set( [ pg.name() for src in srcs for pg in src.geometry().primGroups() ] ), {  "ieTag_a", "ieTag_b", "ieTag_c" } )
 
 
 	def writeAttributeSCC( self ) :


### PR DESCRIPTION
When creating groups from tags we don't want the tagFilter parm to be used.
That's because we want to have tags that are subsets of the tag filter we use
to be converted to groups.

- IECoreHoudini:SOP_SceneCacheSource: Don't use `tagFilter` when converting `tags` to `groups` (#18).

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
