### PR TITLE
OpenImageIOAlgo : Fix DataView copy constructor and copy assignment

### DIFF
--- a/include/IECoreImage/OpenImageIOAlgo.h
+++ b/include/IECoreImage/OpenImageIOAlgo.h
@@ -75,9 +75,12 @@ struct IECOREIMAGE_API DataView
 {
 
 	DataView();
+	DataView( const DataView &other );
 	/// If the data is StringData, `createUStrings` creates an
 	/// `OIIO::ustring` and refers to the storage from that instead.
 	DataView( const IECore::Data *data, bool createUStrings = false );
+
+	DataView &operator=( const DataView &rhs );
 
 	OIIO::TypeDesc type;
 	const void *data;

--- a/src/IECoreImage/OpenImageIOAlgo.cpp
+++ b/src/IECoreImage/OpenImageIOAlgo.cpp
@@ -205,6 +205,27 @@ DataView::DataView()
 {
 }
 
+DataView::DataView( const DataView &other )
+	:	type( other.type ), data( other.data ), m_charPointers( other.m_charPointers )
+{
+	if( m_charPointers.size() )
+	{
+		data = &m_charPointers[0];
+	}
+}
+
+DataView &DataView::operator=( const DataView &rhs )
+{
+	type = rhs.type;
+	data = rhs.data;
+	m_charPointers = rhs.m_charPointers;
+	if( m_charPointers.size() )
+	{
+		data = &m_charPointers[0];
+	}
+	return *this;
+}
+
 DataView::DataView( const IECore::Data *d, bool createUStrings )
 	:	data( nullptr )
 {


### PR DESCRIPTION
When viewing StringData or StringVectorData, we populate `m_charPointers` to provide data in the layout required by OIIO. When copying, we need to ensure that the copy points to the data owned by its own `m_charPointers`, and not the source's. This bug was detected by Asan when running the GafferOSL tests.

