### PR TITLE
Mesh algo tangents

### DIFF
--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -47,8 +47,16 @@ namespace IECoreScene
 namespace MeshAlgo
 {
 
-/// Calculate the surface tangent vectors of a mesh primitive.
+/// TODO: remove this compatibility function:
 IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangents( const MeshPrimitive *mesh, const std::string &uvSet = "uv", bool orthoTangents = true, const std::string &position = "P" );
+/// Calculate the surface tangent vectors of a mesh primitive based on UV information
+IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangentsFromUV( const MeshPrimitive *mesh, const std::string &uvSet = "uv", const std::string &position = "P", bool orthoTangents = true, bool leftHanded = false );
+/// Calculate the surface tangent vectors of a mesh primitive based on the first neighbor edge
+IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangentsFromFirstEdge( const MeshPrimitive *mesh, const std::string &position = "P", const std::string &normal = "N", bool orthoTangents = true, bool leftHanded = false );
+/// Calculate the surface tangent vectors of a mesh primitive based on the primitives centroid
+IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangentsFromPrimitiveCentroid( const MeshPrimitive *mesh, const std::string &position = "P", const std::string &normal = "N", bool orthoTangents = true, bool leftHanded = false );
+/// Calculate the surface tangent vectors of a mesh primitive based on the first two adjacent edges
+IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangentsFromTwoEdges( const MeshPrimitive *mesh, const std::string &position = "P", const std::string &normal = "N", bool orthoTangents = true, bool leftHanded = false );
 
 /// Calculate the face area of a mesh primitive.
 IECORESCENE_API PrimitiveVariable calculateFaceArea( const MeshPrimitive *mesh, const std::string &position = "P" );

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -108,6 +108,10 @@ void bindMeshAlgo()
 	StdPairToTupleConverter<IECore::IntVectorDataPtr, IECore::IntVectorDataPtr>();
 
 	def( "calculateTangents", &MeshAlgo::calculateTangents, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv", arg_( "orthoTangents" ) = true, arg_( "position" ) = "P" ) );
+	def( "calculateTangentsFromUV", &MeshAlgo::calculateTangentsFromUV, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv",  arg_( "position" ) = "P", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );
+	def( "calculateTangentsFromFirstEdge", &MeshAlgo::calculateTangentsFromFirstEdge, ( arg_( "mesh" ), arg_( "position" ) = "P", arg_( "normal" ) = "N", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );
+	def( "calculateTangentsFromTwoEdges", &MeshAlgo::calculateTangentsFromTwoEdges, ( arg_( "mesh" ), arg_( "position" ) = "P", arg_( "normal" ) = "N", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );
+	def( "calculateTangentsFromPrimitiveCentroid", &MeshAlgo::calculateTangentsFromPrimitiveCentroid, ( arg_( "mesh" ), arg_( "position" ) = "P", arg_( "normal" ) = "N", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );
 	def( "calculateFaceArea", &MeshAlgo::calculateFaceArea, ( arg_( "mesh" ), arg_( "position" ) = "P" ) );
 	def( "calculateFaceTextureArea", &MeshAlgo::calculateFaceTextureArea, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv", arg_( "position" ) = "P" ) );
 	def( "calculateDistortion", &MeshAlgo::calculateDistortion, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv", arg_( "referencePosition" ) = "Pref", arg_( "position" ) = "P" ) );

--- a/test/IECoreScene/MeshAlgoTangentsTest.py
+++ b/test/IECoreScene/MeshAlgoTangentsTest.py
@@ -225,6 +225,127 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 		self.assertArrayEqual( IECore.V3fVectorData( [u0, u1, u0, u2, u2] ), uTangent.data )
 		self.assertArrayEqual( IECore.V3fVectorData( [v0, v1, v0, v2, v2] ), vTangent.data )
 
+	def testComputeTangentsFromFirstEdge( self ):
+
+		verticesPerFace = IECore.IntVectorData( [3, 3] )
+		vertexIds = IECore.IntVectorData( [0, 1, 2, 2, 1, 3] )
+		interpolation = "linear"
+		positions = IECore.V3fVectorData(
+			[imath.V3f( -1.0, 0.0, 0.0 ), imath.V3f( 0.0, 1.0, 0.0 ), imath.V3f( 0.0, 0.0, 1.0 ), imath.V3f( 1.0, 0.0, 0.0 )] )
+
+		mesh = IECoreScene.MeshPrimitive( verticesPerFace, vertexIds, interpolation, positions )
+		normals = IECore.V3fVectorData( [ imath.V3f( -1, 1, 1 ).normalize(), imath.V3f( 0, 1, 1 ).normalize(),imath.V3f( 0, 1, 1 ).normalize(), imath.V3f( 1, 1, 1 ).normalize() ], IECore.GeometricData.Interpretation.Normal)
+		mesh['N'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, normals )
+
+		vecFirstEdge = IECore.V3fVectorData( [ imath.V3f( 1, 1, 0 ).normalize(), imath.V3f( -1, -1, 0 ).normalize(),imath.V3f( -1, 0, -1).normalize(), imath.V3f( -1, 1, 0 ).normalize() ], IECore.GeometricData.Interpretation.Normal )
+
+		# non orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromFirstEdge( mesh, orthoTangents=False, leftHanded=False )
+		tRes = vecFirstEdge
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromFirstEdge( mesh, orthoTangents=True, leftHanded=False )
+		tRes = vecFirstEdge
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [vt.cross(n).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromFirstEdge( mesh, orthoTangents=True, leftHanded=True )
+		tRes = vecFirstEdge
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [n.cross(vt).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+	def testComputeTangentsFromTwoEdges( self ):
+
+		verticesPerFace = IECore.IntVectorData( [3, 3] )
+		vertexIds = IECore.IntVectorData( [0, 1, 2, 2, 1, 3] )
+		interpolation = "linear"
+		p = IECore.V3fVectorData(
+			[imath.V3f( -1.0, 0.0, 0.0 ), imath.V3f( 0.0, 1.0, 0.0 ), imath.V3f( 0.0, 0.0, 1.0 ), imath.V3f( 1.0, 0.0, 0.0 )] )
+
+		mesh = IECoreScene.MeshPrimitive( verticesPerFace, vertexIds, interpolation, p )
+		normals = IECore.V3fVectorData( [ imath.V3f( -1, 1, 1 ).normalize(), imath.V3f( 0, 1, 1 ).normalize(),imath.V3f( 0, 1, 1 ).normalize(), imath.V3f( 1, 1, 1 ).normalize() ], IECore.GeometricData.Interpretation.Normal)
+		mesh['N'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, normals )
+
+		vecBetweenTwoEdges = IECore.V3fVectorData( [x.normalized() for x in [ (p[1]+p[2])*0.5-p[0], (p[0]+p[2])*0.5-p[1], (p[0]+p[1])*0.5-p[2], (p[1]+p[2])*0.5-p[3] ] ], IECore.GeometricData.Interpretation.Normal )
+
+		# non orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromTwoEdges( mesh, orthoTangents=False, leftHanded=False )
+		tRes =  vecBetweenTwoEdges
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromTwoEdges( mesh, orthoTangents=True, leftHanded=False )
+		tRes =  vecBetweenTwoEdges
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [vt.cross(n).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromTwoEdges( mesh, orthoTangents=True, leftHanded=True )
+		tRes =  vecBetweenTwoEdges
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [n.cross(vt).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+	def testComputeTangentsFromPrimitiveCentroid( self ):
+
+		verticesPerFace = IECore.IntVectorData( [3, 3] )
+		vertexIds = IECore.IntVectorData( [0, 1, 2, 2, 1, 3] )
+		interpolation = "linear"
+		p = IECore.V3fVectorData(
+			[imath.V3f( -1.0, 0.0, 0.0 ), imath.V3f( 0.0, 1.0, 0.0 ), imath.V3f( 0.0, 0.0, 1.0 ), imath.V3f( 1.0, 0.0, 0.0 )] )
+
+		mesh = IECoreScene.MeshPrimitive( verticesPerFace, vertexIds, interpolation, p )
+		normals = IECore.V3fVectorData( [ imath.V3f( -1, 1, 1 ).normalize(), imath.V3f( 0, 1, 1 ).normalize(),imath.V3f( 0, 1, 1 ).normalize(), imath.V3f( 1, 1, 1 ).normalize() ], IECore.GeometricData.Interpretation.Normal)
+		mesh['N'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, normals )
+
+		vecToCentroid = IECore.V3fVectorData( [x.normalized() for x in [ (p[0]+p[1]+p[2])/3.0-p[0], (p[3]+p[1]+p[2])/3.0-p[1],  (p[3]+p[1]+p[2])/3.0-p[2],  (p[3]+p[1]+p[2])/3.0-p[3] ] ], IECore.GeometricData.Interpretation.Normal )
+
+		# non orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromPrimitiveCentroid( mesh, orthoTangents=False, leftHanded=False )
+		tRes =  vecToCentroid
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, non left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromPrimitiveCentroid( mesh, orthoTangents=True, leftHanded=False )
+		tRes =  vecToCentroid
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [vt.cross(n).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+		# orthogonal, left handed
+		tangent, biTangent = IECoreScene.MeshAlgo.calculateTangentsFromPrimitiveCentroid( mesh, orthoTangents=True, leftHanded=True )
+		tRes =  vecToCentroid
+		btRes = IECore.V3fVectorData( [n.cross(ut).normalize() for ut, n in zip(tRes, normals)] )
+		tRes = IECore.V3fVectorData( [n.cross(vt).normalize() for vt, n in zip(btRes, normals)] )
+
+		self.assertArrayEqual( tRes, tangent.data )
+		self.assertArrayEqual( btRes, biTangent.data )
+
+
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/MeshAlgoTangentsTest.py
+++ b/test/IECoreScene/MeshAlgoTangentsTest.py
@@ -72,7 +72,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 
 	def testSingleTriangleGeneratesCorrectTangents( self ) :
 		triangle = self.makeSingleTriangleMesh()
-		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangents( triangle )
+		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle )
 
 		self.assertEqual(tangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying)
 		self.assertEqual(bitangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying)
@@ -99,7 +99,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 		mesh = IECore.ObjectReader( "test/IECore/data/cobFiles/twoTrianglesWithSharedUVs.cob" ).read()
 		self.assert_( mesh.arePrimitiveVariablesValid() )
 
-		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangents( mesh )
+		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh )
 
 		self.assertEqual( tangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( bitangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
@@ -113,7 +113,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 
 		mesh = IECore.ObjectReader( "test/IECore/data/cobFiles/twoTrianglesWithSplitAndOpposedUVs.cob" ).read()
 
-		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangents( mesh )
+		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh )
 
 		self.assertEqual( tangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( bitangentPrimVar.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
@@ -134,20 +134,20 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 
 	def testInvalidPositionPrimVarRaisesException( self ) :
 		triangle = self.makeSingleTriangleMesh()
-		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangents( triangle, position = "foo" ) )
+		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle, position = "foo" ) )
 
 	def testMissingUVsetPrimVarsRaisesException ( self ):
 		triangle = self.makeSingleTriangleMesh()
-		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangents( triangle, uvSet = "bar") )
+		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle, uvSet = "bar") )
 
 	def testIncorrectUVPrimVarInterpolationRaisesException ( self ):
 		triangle = self.makeSingleBadUVTriangleMesh()
-		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangents( triangle ) )
+		self.assertRaises( RuntimeError, lambda : IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle ) )
 
 	def testCanUseSecondUVSet( self ) :
 
 		triangle = self.makeSingleTriangleMesh()
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( triangle , uvSet = "foo" )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle , uvSet = "foo" )
 
 		self.assertEqual( len( uTangent.data ), 3 )
 		self.assertEqual( len( vTangent.data ), 3 )
@@ -163,7 +163,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 	def testCanUsePref( self ) :
 
 		triangle = self.makeSingleTriangleMesh()
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( triangle , position = "Pref")
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( triangle , position = "Pref")
 
 		self.assertEqual( len( uTangent.data ), 3 )
 		self.assertEqual( len( vTangent.data ), 3 )
@@ -181,7 +181,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 		self.assertEqual( len( mesh["P"].data ), 4 )
 		self.assertEqual( mesh.numFaces(), 1 )
 
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( mesh )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh )
 
 		self.assertEqual( len( uTangent.data ), 4)
 		self.assertEqual( len( vTangent.data ), 4)
@@ -210,7 +210,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 		uvData = IECore.V2fVectorData( [imath.V2f( 0, -0.5 ), imath.V2f( 1, 0 ), imath.V2f( 0, 0.5 ), imath.V2f( 1.5, 1 ), imath.V2f( 0.5, 1 )] )
 		mesh["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, uvData )
 
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( mesh, orthoTangents = False )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh, orthoTangents = False )
 
 		u0 = imath.V3f( 1, 0, 0 )
 		u2 = imath.V3f( 0, -1, 0 )

--- a/test/IECoreScene/MeshMergeOpTest.py
+++ b/test/IECoreScene/MeshMergeOpTest.py
@@ -141,7 +141,7 @@ class MeshMergeOpTest( unittest.TestCase ) :
 
 		IECoreScene.TriangulateOp()( input=p2, copyInput=False )
 		p2['myInt'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.IntVectorData( [ 0, 1, 2, 3, 4 ,5 ] ) )
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( p2 )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( p2 )
 		p2["uTangent"] = uTangent
 		p2["vTangent"] = vTangent
 		self.assertNotEqual( p1.keys(), p2.keys() )
@@ -175,7 +175,7 @@ class MeshMergeOpTest( unittest.TestCase ) :
 
 		IECoreScene.TriangulateOp()( input=p2, copyInput=False )
 		p2['myInt'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.IntVectorData( [ 0, 1, 2, 3, 4 ,5 ] ) )
-		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( p2 )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangentsFromUV( p2 )
 		p2["uTangent"] = uTangent
 		p2["vTangent"] = vTangent
 		self.assertNotEqual( p1.keys(), p2.keys() )


### PR DESCRIPTION
This adds new MeshAlgo functions to calculate tangents based on:
- First Edge
- Two Edges
- Primitive Centroid
All modes can be toggled to output orthogonal tangents and can be flipped to a left handed frame.

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
