### PR TITLE
LRUCache : Fix double-release in serial policy

### DIFF
--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -171,7 +171,9 @@ class Serial
 			{
 				if( m_inited )
 				{
+					assert( m_it->hasHandle );
 					m_it->hasHandle = false;
+					m_inited = false;
 				}
 			}
 


### PR DESCRIPTION
This could occur in `LRUCache::get()` because it makes an explicit call to `handle.release()`, and then the handle destructor makes a second call. The new `assert()` demonstrates the problem, and before the associated fix was being triggered from `LRUCacheTest.testSerialRecursion()`. I think we've got away with this because for `m_it` to be invalidated prior to the second `release()`, we'd need to pop the handle from `limitCost()`, and that is incredibly unlikely due to the handle being the most recently used item.
