### PR TITLE
 IECore module : Bind tbb::global_control 

### DIFF
--- a/src/IECorePythonModule/IECore.cpp
+++ b/src/IECorePythonModule/IECore.cpp
@@ -39,7 +39,7 @@
 
 #include "boost/python.hpp"
 
-#include "tbb/tbb_thread.h"
+#include "TBBBinding.h"
 
 #include "OpenEXR/ImathEuler.h"
 
@@ -154,12 +154,12 @@
 #include "IECorePython/StringAlgoBinding.h"
 #include "IECorePython/PathMatcherBinding.h"
 #include "IECorePython/CancellerBinding.h"
-#include "IECorePython/TaskSchedulerInit.h"
 #include "IECorePython/IndexedIOAlgoBinding.h"
 
 #include "IECore/IECore.h"
 
 using namespace IECorePython;
+using namespace IECorePythonModule;
 using namespace boost::python;
 
 
@@ -297,8 +297,8 @@ BOOST_PYTHON_MODULE(_IECore)
 	bindStringAlgo();
 	bindPathMatcher();
 	bindCanceller();
-	bindTaskSchedulerInit();
 	bindIndexedIOAlgo();
+	bindTBB();
 
 	def( "majorVersion", &IECore::majorVersion );
 	def( "minorVersion", &IECore::minorVersion );
@@ -307,7 +307,6 @@ BOOST_PYTHON_MODULE(_IECore)
 	def( "isDebug", &::isDebug );
 	def( "withFreeType", &IECore::withFreeType );
 	def( "initThreads", &PyEval_InitThreads );
-	def( "hardwareConcurrency", &tbb::tbb_thread::hardware_concurrency );
 
 	// Expose our own implementation of `repr()` for all the Imath
 	// types, along with a fallback version for all other types. This

--- a/src/IECorePythonModule/TBBBinding.cpp
+++ b/src/IECorePythonModule/TBBBinding.cpp
@@ -40,6 +40,9 @@
 
 #include "tbb/tbb.h"
 
+#define TBB_PREVIEW_GLOBAL_CONTROL 1
+#include "tbb/global_control.h"
+
 using namespace boost::python;
 
 namespace
@@ -79,6 +82,35 @@ class TaskSchedulerInitWrapper : public tbb::task_scheduler_init
 
 };
 
+class GlobalControlWrapper : public boost::noncopyable
+{
+
+	public :
+
+		GlobalControlWrapper( tbb::global_control::parameter parameter, size_t value )
+			:	m_parameter( parameter ), m_value( value )
+		{
+		}
+
+		void enter()
+		{
+			m_globalControl.reset( new tbb::global_control( m_parameter, m_value ) );
+		}
+
+		bool exit( boost::python::object excType, boost::python::object excValue, boost::python::object excTraceBack )
+		{
+			m_globalControl.reset();
+			return false; // don't suppress exceptions
+		}
+
+	private :
+
+		const tbb::global_control::parameter m_parameter;
+		const size_t m_value;
+		std::unique_ptr<tbb::global_control> m_globalControl;
+
+};
+
 } // namespace
 
 void IECorePythonModule::bindTBB()
@@ -90,6 +122,21 @@ void IECorePythonModule::bindTBB()
 	;
 	tsi.attr( "automatic" ) = int( tbb::task_scheduler_init::automatic );
 
+	class_<GlobalControlWrapper, boost::noncopyable> globalControl( "tbb_global_control", no_init );
+	{
+		scope globalControlScope = globalControl;
+		enum_<tbb::global_control::parameter>( "parameter" )
+			.value( "max_allowed_parallelism", tbb::global_control::max_allowed_parallelism )
+			.value( "thread_stack_size", tbb::global_control::thread_stack_size )
+		;
+	}
+	globalControl
+		.def( init<tbb::global_control::parameter, size_t>() )
+		.def( "__enter__", &GlobalControlWrapper::enter, return_self<>() )
+		.def( "__exit__", &GlobalControlWrapper::exit )
+	;
+
 	def( "hardwareConcurrency", &tbb::tbb_thread::hardware_concurrency );
+
 }
 

--- a/src/IECorePythonModule/TBBBinding.cpp
+++ b/src/IECorePythonModule/TBBBinding.cpp
@@ -36,7 +36,7 @@
 
 #include "boost/python.hpp"
 
-#include "IECorePython/TaskSchedulerInit.h"
+#include "TBBBinding.h"
 
 #include "tbb/tbb.h"
 
@@ -81,8 +81,7 @@ class TaskSchedulerInitWrapper : public tbb::task_scheduler_init
 
 } // namespace
 
-
-void IECorePython::bindTaskSchedulerInit()
+void IECorePythonModule::bindTBB()
 {
 	object tsi = class_<TaskSchedulerInitWrapper, boost::noncopyable>( "tbb_task_scheduler_init", no_init )
 		.def( init<int>( arg( "max_threads" ) = int( tbb::task_scheduler_init::automatic ) ) )
@@ -90,5 +89,7 @@ void IECorePython::bindTaskSchedulerInit()
 		.def( "__exit__", &TaskSchedulerInitWrapper::exit )
 	;
 	tsi.attr( "automatic" ) = int( tbb::task_scheduler_init::automatic );
+
+	def( "hardwareConcurrency", &tbb::tbb_thread::hardware_concurrency );
 }
 

--- a/src/IECorePythonModule/TBBBinding.h
+++ b/src/IECorePythonModule/TBBBinding.h
@@ -34,16 +34,14 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#ifndef IECOREPYTHON_TASKSCHEDULERINIT_H
-#define IECOREPYTHON_TASKSCHEDULERINIT_H
+#ifndef IECOREPYTHONMODULE_TBBBINDING_H
+#define IECOREPYTHONMODULE_TBBBINDING_H
 
-#include "IECorePython/Export.h"
-
-namespace IECorePython
+namespace IECorePythonModule
 {
 
-IECOREPYTHON_API void bindTaskSchedulerInit();
+void bindTBB();
 
-} // namespace IECorePython
+} // namespace IECorePythonModule
 
-#endif // IECOREPYTHON_TASKSCHEDULERINIT_H
+#endif // IECOREPYTHONMODULE_TBBBINDING_H


### PR DESCRIPTION
In Gaffer we have been using the already-bound task_scheduler_init to limit the number of threads for the application, but that is not sufficient. If a thread creates an arena, then this ignores the task_scheduler_init and maxes out the thread count again. The global_control is the one true way to specify the maximum number of threads TBB may use.