### PR TITLE
Canceller : Export symbols for Cancelled class

### DIFF
--- a/include/IECore/Canceller.h
+++ b/include/IECore/Canceller.h
@@ -35,6 +35,8 @@
 #ifndef IECORE_CANCELLER_H
 #define IECORE_CANCELLER_H
 
+#include "IECore/Export.h"
+
 #include "boost/noncopyable.hpp"
 
 #include <atomic>
@@ -48,7 +50,7 @@ namespace IECore
 /// suppressed or mistaken for an error. In typical
 /// use there is no need to catch exceptions of this
 /// type.
-struct Cancelled
+struct IECORE_API Cancelled
 {
 };
 


### PR DESCRIPTION
The symbol export was removed by the Windows compatibility work, but that broke the Gaffer unit tests on Mac, with errors like the following :

```
======================================================================
ERROR: testCancellation (GafferImageTest.MedianTest.MedianTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/GafferTest/TestCase.py", line 92, in __messageHandlerCleanup
    raise RuntimeError( "Unexpected message : " + mh.levelAsString( message.level ) + " : " + message.context + " : " + message.message )
RuntimeError: Unexpected message : ERROR : BackgroundTask : Traceback (most recent call last):
  File "/Users/john/dev/build/gaffer/python/GafferImageTest/MedianTest.py", line 154, in <lambda>
    bt = Gaffer.ParallelAlgo.callOnBackgroundThread( m["out"], lambda : GafferImageTest.processTiles( m["out"] ) )
RuntimeError: unidentifiable C++ exception
```

@ericmehl, I'm afraid Mac is going to have to take precedence here because we can't break currently-supported platforms for the sake of soon-to-be-supported ones. The log message on the problematic Windows commit suggests that it's not inconceivable that we only needed to remove the export for the Canceller class, rather than the Canceller too. If that's the case, it's possible that this PR is OK on Windows too. If not, could you let me know the error it throws up, and if there's anything I can do to help resolve it?