### PR TITLE
MeshPrimitive::createBox : Added uvs

### DIFF
--- a/contrib/IECoreAlembic/src/IECoreAlembic/MeshWriter.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/MeshWriter.cpp
@@ -100,11 +100,24 @@ class MeshWriter : public PrimitiveWriter
 			{
 				OPolyMeshSchema::Sample sample;
 
-				if( const V3fVectorData *n = meshPrimitive->variableData<V3fVectorData>( "N" ) )
+				std::vector<unsigned int> indices;
+				PrimitiveVariableMap::const_iterator nIt = meshPrimitive->variables.find( "N" );
+				if( nIt != meshPrimitive->variables.end() )
 				{
-					sample.setNormals(
-						ON3fGeomParam::Sample( n->readable(), geometryScope( meshPrimitive->variables.find( "N" )->second.interpolation ) )
-					);
+					const V3fVectorData *nData = runTimeCast<V3fVectorData>( nIt->second.data.get() );
+					if( nData )
+					{
+						ON3fGeomParam::Sample nSample( nData->readable(), geometryScope( nIt->second.interpolation ) );
+
+						if( nIt->second.indices )
+						{
+							const std::vector<int> &indexValues = nIt->second.indices->readable();
+							indices = std::vector<unsigned int>( indexValues.begin(), indexValues.end() );
+							nSample.setIndices( indices );
+						}
+
+						sample.setNormals( nSample );
+					}
 				}
 
 				writeSampleInternal( meshPrimitive.get(), sample, boost::get<OPolyMesh>( m_state ).getSchema() );

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -1612,6 +1612,7 @@ class AlembicSceneTest( unittest.TestCase ) :
 	def testRoundTripCornersAndCreases( self ) :
 
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		del mesh["N"] # Reference caches created without normals
 		mesh.setInterpolation( "catmullClark" )
 		mesh.setCorners( IECore.IntVectorData( [ 3 ] ), IECore.FloatVectorData( [ 2 ] ) )
 		mesh.setCreases( IECore.IntVectorData( [ 2 ] ), IECore.IntVectorData( [ 0, 1 ] ), IECore.FloatVectorData( [ 2.5 ] ) )

--- a/src/IECoreScene/MeshPrimitive.cpp
+++ b/src/IECoreScene/MeshPrimitive.cpp
@@ -588,6 +588,26 @@ MeshPrimitivePtr MeshPrimitive::createBox( const Box3f &b )
 
 	result->variables["uv"] = PrimitiveVariable( PrimitiveVariable::FaceVarying, uvData, new IntVectorData ( uvIndices ) );
 
+	std::vector<Imath::V3f> normals {
+		Imath::V3f( 0, 0, 1 ),
+		Imath::V3f( 0, 0, -1 ),
+		Imath::V3f( 0, 1, 0 ),
+		Imath::V3f( 0, -1, 0 ),
+		Imath::V3f( 1, 0, 0 ),
+		Imath::V3f( -1, 0, 0 ),
+	};
+
+	std::vector<int> nIndices {
+		1,1,1,1,
+		4,4,4,4,
+		0,0,0,0,
+		5,5,5,5,
+		2,2,2,2,
+		3,3,3,3,
+	};
+
+	result->variables["N"] = PrimitiveVariable( PrimitiveVariable::FaceVarying, new V3fVectorData( normals, GeometricData::Normal ), new IntVectorData ( nIndices ) );
+
 	return result;
 }
 

--- a/src/IECoreScene/MeshPrimitive.cpp
+++ b/src/IECoreScene/MeshPrimitive.cpp
@@ -535,14 +535,12 @@ void MeshPrimitive::topologyHash( MurmurHash &h ) const
 
 MeshPrimitivePtr MeshPrimitive::createBox( const Box3f &b )
 {
-	vector< int > verticesPerFaceVec;
-	vector< int > vertexIdsVec;
 	std::string interpolation = "linear";
 	vector< V3f > p;
-	int verticesPerFace[] = {
+	std::vector<int> verticesPerFace {
 		4, 4, 4, 4, 4, 4
 	};
-	int vertexIds[] = {
+	std::vector<int> vertexIds {
 		3,2,1,0,
 		1,2,5,4,
 		4,5,7,6,
@@ -560,13 +558,37 @@ MeshPrimitivePtr MeshPrimitive::createBox( const Box3f &b )
 	p.push_back( V3f( b.min.x, b.min.y, b.max.z ) );	// 6
 	p.push_back( V3f( b.min.x, b.max.y, b.max.z ) );	// 7
 
-	verticesPerFaceVec.resize( sizeof( verticesPerFace ) / sizeof( int ) );
-	memcpy( &verticesPerFaceVec[0], &verticesPerFace[0], sizeof( verticesPerFace ) );
+	MeshPrimitivePtr result = new MeshPrimitive( new IntVectorData(verticesPerFace), new IntVectorData(vertexIds), interpolation, new V3fVectorData(p) );
 
-	vertexIdsVec.resize( sizeof( vertexIds ) / sizeof( int ) );
-	memcpy( &vertexIdsVec[0], &vertexIds[0], sizeof( vertexIds ) );
 
-	return new MeshPrimitive( new IntVectorData(verticesPerFaceVec), new IntVectorData(vertexIdsVec), interpolation, new V3fVectorData(p) );
+	V2fVectorDataPtr uvData = new V2fVectorData;
+	uvData->setInterpretation( GeometricData::UV );
+	std::vector<Imath::V2f> &uvs = uvData->writable();
+
+	for( int i = 0; i < 5; i++ )
+	{
+		uvs.push_back( Imath::V2f( 0.375f, 0.25f * i ) );
+		uvs.push_back( Imath::V2f( 0.625f, 0.25f * i ) );
+	}
+
+	for( int i = 0; i < 2; i++ )
+	{
+		uvs.push_back( Imath::V2f( 0.125f, 0.25f * i ) );
+		uvs.push_back( Imath::V2f( 0.875f, 0.25f * i ) );
+	}
+
+	std::vector<int> uvIndices {
+		4,5,7,6,
+		11,13,3,1,
+		1,3,2,0,
+		0,2,12,10,
+		5,4,2,3,
+		6,7,9,8,
+	};
+
+	result->variables["uv"] = PrimitiveVariable( PrimitiveVariable::FaceVarying, uvData, new IntVectorData ( uvIndices ) );
+
+	return result;
 }
 
 MeshPrimitivePtr MeshPrimitive::createPlane( const Box2f &b, const Imath::V2i &divisions )

--- a/src/IECoreScene/MeshPrimitive.cpp
+++ b/src/IECoreScene/MeshPrimitive.cpp
@@ -670,6 +670,12 @@ MeshPrimitivePtr MeshPrimitive::createPlane( const Box2f &b, const Imath::V2i &d
 	//     since several tests use `createPlane()`.
 	result->variables["uv"] = PrimitiveVariable( PrimitiveVariable::FaceVarying, uvData, vertexIds );
 
+	V3fVectorDataPtr nData = new V3fVectorData;
+	nData->setInterpretation( GeometricData::Normal );
+	nData->writable().resize( p.size(), V3f( 0, 0, 1 ) );
+	
+	result->variables["N"] = PrimitiveVariable( PrimitiveVariable::Vertex, nData );
+
 	return result;
 }
 

--- a/test/IECoreScene/MeshMergeOpTest.py
+++ b/test/IECoreScene/MeshMergeOpTest.py
@@ -133,8 +133,8 @@ class MeshMergeOpTest( unittest.TestCase ) :
 	def testDifferentPrimVars( self ) :
 
 		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
-		IECoreScene.MeshNormalsOp()( input=p1, copyInput=False )
 		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		del p2["N"]
 		self.assertNotEqual( p1.keys(), p2.keys() )
 		merged = IECoreScene.MeshMergeOp()( input=p1, mesh=p2 )
 		self.verifyMerge( p1, p2, merged )
@@ -163,8 +163,8 @@ class MeshMergeOpTest( unittest.TestCase ) :
 	def testRemovePrimVars( self ) :
 
 		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
-		IECoreScene.MeshNormalsOp()( input=p1, copyInput=False )
 		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		del p2["N"]
 		self.assertNotEqual( p1.keys(), p2.keys() )
 		merged = IECoreScene.MeshMergeOp()( input=p1, mesh=p2, removeNonMatchingPrimVars=False )
 		self.failUnless( "N" in merged )

--- a/test/IECoreScene/MeshMergeOpTest.py
+++ b/test/IECoreScene/MeshMergeOpTest.py
@@ -151,7 +151,6 @@ class MeshMergeOpTest( unittest.TestCase ) :
 	def testSamePrimVarNamesWithDifferentInterpolation( self ) :
 
 		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
-		del plane["uv"]
 		IECoreScene.MeshNormalsOp()( input=plane, copyInput=False )
 		box = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) )
 		IECoreScene.MeshNormalsOp()( input=box, copyInput=False )

--- a/test/IECoreScene/MeshNormalsOpTest.py
+++ b/test/IECoreScene/MeshNormalsOpTest.py
@@ -64,6 +64,7 @@ class MeshNormalsOpTest( unittest.TestCase ) :
 	def testOnlyNAdded( self ) :
 
 		p = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		del p["N"]
 		pp = IECoreScene.MeshNormalsOp()( input=p )
 		del pp["N"]
 
@@ -97,6 +98,7 @@ class MeshNormalsOpTest( unittest.TestCase ) :
 	def testUniformInterpolation( self ) :
 
 		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 10 ) )
+		del m["N"]
 		self.assertTrue( "N" not in m )
 
 		m2 = IECoreScene.MeshNormalsOp()( input = m, interpolation = IECoreScene.PrimitiveVariable.Interpolation.Uniform )

--- a/test/IECoreScene/MeshPrimitive.py
+++ b/test/IECoreScene/MeshPrimitive.py
@@ -254,6 +254,11 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertLess( len( m["uv"].data ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
 		self.assertEqual( len( m["uv"].indices ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
 
+		# verify normals
+		self.assertEqual( m["N"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( len( m["N"].data ), 6 )
+		self.assertEqual( len( m["uv"].indices ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
+
 
 	def testPlane( self ) :
 

--- a/test/IECoreScene/MeshPrimitive.py
+++ b/test/IECoreScene/MeshPrimitive.py
@@ -279,6 +279,11 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( len( m["uv"].data ), len( m["P"].data ) )
 		self.assertEqual( m["uv"].indices, m.vertexIds )
 
+		# verify uvs
+		self.assertEqual( m["N"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( len( m["N"].data ), len( m["P"].data ) )
+		self.assertEqual( m["N"].data, IECore.V3fVectorData( [ imath.V3f( 0, 0, 1 ) ] * len( m["P"].data ), IECore.GeometricData.Interpretation.Normal ) )
+
 		e = IECoreScene.MeshPrimitiveEvaluator( IECoreScene.TriangulateOp()( input = m ) )
 
 		r = e.createResult()

--- a/test/IECoreScene/MeshPrimitive.py
+++ b/test/IECoreScene/MeshPrimitive.py
@@ -248,6 +248,13 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( m.bound(), imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) )
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
+		# verify uvs
+		self.assertEqual( m["uv"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertGreater( len( m["uv"].data ), len( m["P"].data ) )
+		self.assertLess( len( m["uv"].data ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
+		self.assertEqual( len( m["uv"].indices ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ) )
+
+
 	def testPlane( self ) :
 
 		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )

--- a/test/IECoreScene/ObjectInterpolationTest.py
+++ b/test/IECoreScene/ObjectInterpolationTest.py
@@ -44,10 +44,10 @@ class ObjectInterpolationTest( unittest.TestCase ) :
 	def testPrimitiveInterpolation( self ) :
 
 		m1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
-		m2 = IECoreScene.TransformOp()( input=m1, matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 2 ) ) ) )
+		m2 = IECoreScene.TransformOp()( input=m1, primVarsToModify = IECore.StringVectorData( [ "P" ] ), matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 2 ) ) ) )
 
 		m3 = IECore.linearObjectInterpolation( m1, m2, 0.5 )
-		self.assertEqual( m3, IECoreScene.TransformOp()( input=m1, matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 1.5 ) ) ) ) )
+		self.assertEqual( m3, IECoreScene.TransformOp()( input=m1, primVarsToModify = IECore.StringVectorData( [ "P" ] ), matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 1.5 ) ) ) ) )
 
 	def testPrimitiveInterpolationMaintainsUninterpolableValuesFromFirstPrimitive( self ) :
 

--- a/test/IECoreScene/PointVelocityDisplaceOp.py
+++ b/test/IECoreScene/PointVelocityDisplaceOp.py
@@ -118,10 +118,11 @@ class TestPointVelocityDisplaceOp( unittest.TestCase ) :
 		o = IECoreScene.PointVelocityDisplaceOp()
 		c = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f(0), imath.V3f(1) ) )
 		IECoreScene.MeshNormalsOp()( input=c, copyInput=False )
+		self.assertEqual( len(c.keys()), 3 )
 		self.assertTrue( "N" in c )
 		c['bob'] = c['P']
 		del c['P']
-		self.assertEqual( len(c.keys()), 2 )
+		self.assertEqual( len(c.keys()), 3 )
 		c2 = o(input=c, positionVar="bob", velocityVar="N")
 		for i in range(8):
 			self.assertEqual( c2['bob'].data[i], c['bob'].data[i] + c['N'].data[i] )

--- a/test/IECoreScene/TransformOpTest.py
+++ b/test/IECoreScene/TransformOpTest.py
@@ -52,7 +52,7 @@ class TestTransformOp( unittest.TestCase ) :
 		m["vel"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [ imath.V3f( 0.5 ) ] * 8, IECore.GeometricData.Interpretation.Vector ) )
 		m["notVel"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [ imath.V3f( 0.5 ) ] * 8 ) )
 
-		mt = IECoreScene.TransformOp()( input=m, primVarsToModify = IECore.StringVectorData( m.keys() ), matrix = IECore.M44fData( imath.M44f().translate( imath.V3f( 1 ) ) ) )
+		mt = IECoreScene.TransformOp()( input=m, primVarsToModify = IECore.StringVectorData( ["N", "P", "vel", "notVel"] ), matrix = IECore.M44fData( imath.M44f().translate( imath.V3f( 1 ) ) ) )
 
 		self.assertEqual( mt.bound(), imath.Box3f( imath.V3f( 0 ), imath.V3f( 2 ) ) )
 		self.assertEqual( mt["P"].data, IECore.V3fVectorData( [ x + imath.V3f( 1 ) for x in m["P"].data ], IECore.GeometricData.Interpretation.Point ) )
@@ -60,7 +60,7 @@ class TestTransformOp( unittest.TestCase ) :
 		self.assertEqual( mt["vel"].data, m["vel"].data )
 		self.assertEqual( mt["notVel"].data, m["notVel"].data )
 
-		ms = IECoreScene.TransformOp()( input=m, primVarsToModify = IECore.StringVectorData( m.keys() ), matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 1, 2, 3 ) ) ) )
+		ms = IECoreScene.TransformOp()( input=m, primVarsToModify = IECore.StringVectorData( ["N", "P", "vel", "notVel"] ), matrix = IECore.M44fData( imath.M44f().scale( imath.V3f( 1, 2, 3 ) ) ) )
 
 		self.assertEqual( ms.bound(), imath.Box3f( imath.V3f( -1, -2, -3 ), imath.V3f( 1, 2, 3 ) ) )
 		self.assertEqual( ms["P"].data, IECore.V3fVectorData( [ x * imath.V3f( 1, 2, 3 ) for x in m["P"].data ], IECore.GeometricData.Interpretation.Point ) )


### PR DESCRIPTION
Got tired of not having UVs on the default cube in Gaffer.

These UVs match the default cube in Maya.