### PR TITLE
Subdiv Corners/Creases in Houdini (and IECoreScene::MeshAlgo)

### DIFF
--- a/include/IECoreHoudini/FromHoudiniPolygonsConverter.h
+++ b/include/IECoreHoudini/FromHoudiniPolygonsConverter.h
@@ -65,6 +65,8 @@ class FromHoudiniPolygonsConverter : public IECoreHoudini::FromHoudiniGeometryCo
 
 	private :
 
+		IECore::CompoundObjectPtr transferMeshInterpolation( const GU_Detail *geo, const IECore::CompoundObject *operands, IECoreScene::MeshPrimitive *mesh ) const;
+
 		void convertCorners( IECoreScene::MeshPrimitive *mesh ) const;
 		void convertCreases( IECoreScene::MeshPrimitive *mesh, const std::vector<int> &vertIds, size_t numEdges ) const;
 

--- a/include/IECoreHoudini/FromHoudiniPolygonsConverter.h
+++ b/include/IECoreHoudini/FromHoudiniPolygonsConverter.h
@@ -65,6 +65,9 @@ class FromHoudiniPolygonsConverter : public IECoreHoudini::FromHoudiniGeometryCo
 
 	private :
 
+		void convertCorners( IECoreScene::MeshPrimitive *mesh ) const;
+		void convertCreases( IECoreScene::MeshPrimitive *mesh, const std::vector<int> &vertIds, size_t numEdges ) const;
+
 		static FromHoudiniGeometryConverter::Description<FromHoudiniPolygonsConverter> m_description;
 };
 

--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -86,6 +86,10 @@ IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, 
 /// completely segmententing the mesh based on the unique values in a primitive variable.
 IECORESCENE_API std::vector<MeshPrimitivePtr> segment( const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues = nullptr );
 
+/// Merge the input meshes into a single mesh.
+/// Any PrimitiveVariables that exist will be combined or extended using a default value.
+IECORESCENE_API MeshPrimitivePtr merge( const std::vector<const MeshPrimitive *> &meshes );
+
 /// Generate a new triangulated MeshPrimitive
 /// If throwExceptions is true the input mesh is validated to ensure all polygons are convex planar and only then the
 /// tolerance parameter is used to define a floating point epsilon for these checks.

--- a/include/IECoreScene/MeshMergeOp.h
+++ b/include/IECoreScene/MeshMergeOp.h
@@ -62,18 +62,6 @@ class IECORESCENE_API MeshMergeOp : public MeshPrimitiveOp
 
 	private :
 
-		struct AppendPrimVars;
-		struct PrependPrimVars;
-
-		template<class T>
-		struct DefaultValue;
-
-		template<class T>
-		struct DefaultValue<Imath::Vec3<T> >;
-
-		template<class T>
-		struct DefaultValue<Imath::Vec2<T> >;
-
 		MeshPrimitiveParameterPtr m_meshParameter;
 		IECore::BoolParameterPtr m_removePrimVarsParameter;
 

--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -301,12 +301,9 @@ void FromHoudiniPolygonsConverter::convertCorners( MeshPrimitive *mesh ) const
 
 	IntVectorDataPtr cornerIdsData = new IntVectorData();
 	auto &cornerIds = cornerIdsData->writable();
-	// likely larger than necessary, but we don't know the correct size yet
-	cornerIds.reserve( mesh->variableSize( PrimitiveVariable::Vertex ) );
 
 	FloatVectorDataPtr cornerSharpnessesData = new FloatVectorData();
 	auto &cornerSharpnesses = cornerSharpnessesData->writable();
-	cornerSharpnesses.reserve( cornerIds.size());
 
 	const auto &cornerWeights = cornerWeightData->readable();
 	for( size_t i = 0; i < cornerWeights.size(); ++i )
@@ -337,16 +334,12 @@ void FromHoudiniPolygonsConverter::convertCreases( MeshPrimitive *mesh, const st
 
 	IntVectorDataPtr creaseLengthsData = new IntVectorData();
 	auto &creaseLengths = creaseLengthsData->writable();
-	// likely larger than necessary, but we don't know the correct size yet
-	creaseLengths.reserve( numEdges );
 
 	IntVectorDataPtr creaseIdsData = new IntVectorData();
 	auto &creaseIds = creaseIdsData->writable();
-	creaseIds.reserve( creaseLengths.size() * 2 );
 
 	FloatVectorDataPtr creaseSharpnessesData = new FloatVectorData();
 	auto &creaseSharpnesses = creaseSharpnessesData->writable();
-	creaseSharpnesses.reserve( creaseLengths.size() );
 
 	// Calculate face-edge offsets based on winding order in Houdini,
 	// which is opposite to that of Cortex. We need these to map from

--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -45,15 +45,15 @@ using namespace IECoreHoudini;
 namespace
 {
 
-static InternedString g_attributeFilter( "attributeFilter" );
-static InternedString g_interpolationAttrib( "ieMeshInterpolation" );
-static InternedString g_interpolationAttribNegated( " ^ieMeshInterpolation" );
-static InternedString g_linear( "linear" );
-static InternedString g_catmullClark( "catmullClark" );
-static InternedString g_poly( "poly" );
-static InternedString g_subdiv( "subdiv" );
-static InternedString g_cornerWeightAttrib( "cornerweight" );
-static InternedString g_creaseWeightAttrib( "creaseweight" );
+const InternedString g_attributeFilter( "attributeFilter" );
+const InternedString g_interpolationAttrib( "ieMeshInterpolation" );
+const InternedString g_interpolationAttribNegated( " ^ieMeshInterpolation" );
+const InternedString g_linear( "linear" );
+const InternedString g_catmullClark( "catmullClark" );
+const InternedString g_poly( "poly" );
+const InternedString g_subdiv( "subdiv" );
+const InternedString g_cornerWeightAttrib( "cornerweight" );
+const InternedString g_creaseWeightAttrib( "creaseweight" );
 
 } // namespace
 

--- a/src/IECoreHoudini/ToHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniPolygonsConverter.cpp
@@ -41,6 +41,16 @@ using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreHoudini;
 
+namespace
+{
+
+static InternedString g_interpolationAttrib( "ieMeshInterpolation" );
+static InternedString g_catmullClark( "catmullClark" );
+static InternedString g_poly( "poly" );
+static InternedString g_subdiv( "subdiv" );
+
+} // namespace
+
 IE_CORE_DEFINERUNTIMETYPED( ToHoudiniPolygonsConverter );
 
 ToHoudiniGeometryConverter::Description<ToHoudiniPolygonsConverter> ToHoudiniPolygonsConverter::m_description( IECoreScene::MeshPrimitive::staticTypeId() );
@@ -110,8 +120,8 @@ bool ToHoudiniPolygonsConverter::doConversion( const Object *object, GU_Detail *
 	// add the interpolation type
 	if ( newPrims.isValid() )
 	{
-		std::string interpolation = ( mesh->interpolation() == "catmullClark" ) ? "subdiv" : "poly";
-		ToHoudiniStringVectorAttribConverter::convertString( "ieMeshInterpolation", interpolation, geo, newPrims );
+		std::string interpolation = ( g_catmullClark == mesh->interpolation() ) ? g_subdiv : g_poly;
+		ToHoudiniStringVectorAttribConverter::convertString( g_interpolationAttrib, interpolation, geo, newPrims );
 	}
 
 	return true;

--- a/src/IECoreHoudini/ToHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniPolygonsConverter.cpp
@@ -45,11 +45,11 @@ using namespace IECoreHoudini;
 namespace
 {
 
-static InternedString g_interpolationAttrib( "ieMeshInterpolation" );
-static InternedString g_catmullClark( "catmullClark" );
-static InternedString g_poly( "poly" );
-static InternedString g_subdiv( "subdiv" );
-static InternedString g_cornerWeightAttrib( "cornerweight" );
+const InternedString g_interpolationAttrib( "ieMeshInterpolation" );
+const InternedString g_catmullClark( "catmullClark" );
+const InternedString g_poly( "poly" );
+const InternedString g_subdiv( "subdiv" );
+const InternedString g_cornerWeightAttrib( "cornerweight" );
 
 } // namespace
 
@@ -122,7 +122,7 @@ bool ToHoudiniPolygonsConverter::doConversion( const Object *object, GU_Detail *
 	// add the interpolation type
 	if ( newPrims.isValid() )
 	{
-		std::string interpolation = ( g_catmullClark == mesh->interpolation() ) ? g_subdiv : g_poly;
+		const std::string &interpolation = ( g_catmullClark == mesh->interpolation() ) ? g_subdiv : g_poly;
 		ToHoudiniStringVectorAttribConverter::convertString( g_interpolationAttrib, interpolation, geo, newPrims );
 	}
 

--- a/src/IECoreScene/Font.cpp
+++ b/src/IECoreScene/Font.cpp
@@ -36,7 +36,7 @@
 
 #include "IECoreScene/Group.h"
 #include "IECoreScene/MatrixTransform.h"
-#include "IECoreScene/MeshMergeOp.h"
+#include "IECoreScene/MeshAlgo.h"
 #include "IECoreScene/MeshPrimitive.h"
 #include "IECoreScene/TransformOp.h"
 #include "IECoreScene/Triangulator.h"
@@ -358,9 +358,8 @@ class Font::Implementation : public IECore::RefCounted
 				return result;
 			}
 
-			MeshMergeOpPtr merger = new MeshMergeOp;
-			merger->inputParameter()->setValue( result );
-			merger->copyParameter()->setTypedValue( false );
+			std::vector<MeshPrimitivePtr> characters;
+			std::vector<const MeshPrimitive *> meshes( { result.get() } );
 
 			TransformOpPtr transformOp = new TransformOp;
 			transformOp->copyParameter()->setTypedValue( false );
@@ -385,8 +384,8 @@ class Font::Implementation : public IECore::RefCounted
 				matrixData->writable() = M44f().setTranslation( translate );
 				transformOp->operate();
 
-				merger->meshParameter()->setValue( primitive );
-				merger->operate();
+				characters.push_back( primitive );
+				meshes.push_back( primitive.get() );
 
 				if( i<text.size()-1 )
 				{
@@ -395,7 +394,7 @@ class Font::Implementation : public IECore::RefCounted
 				}
 			}
 
-			return result;
+			return MeshAlgo::merge( meshes );
 		}
 
 		GroupPtr meshGroup( const std::string &text ) const

--- a/src/IECoreScene/MeshAlgoDeleteFaces.cpp
+++ b/src/IECoreScene/MeshAlgoDeleteFaces.cpp
@@ -61,13 +61,9 @@ void deleteCorners( MeshPrimitive *out, const MeshPrimitive *in, const std::vect
 
 	IntVectorDataPtr outIdData = new IntVectorData;
 	auto &outIds = outIdData->writable();
-	// potentially too large but large enough
-	outIds.reserve( ids.size() );
 
 	FloatVectorDataPtr outSharpnessData = new FloatVectorData;
 	auto &outSharpnesses = outSharpnessData->writable();
-	// potentially too large but large enough
-	outIds.reserve( sharpnesses.size() );
 
 	for( size_t i = 0; i < ids.size(); ++i )
 	{
@@ -95,18 +91,12 @@ void deleteCreases( MeshPrimitive *out, const MeshPrimitive *in, const std::vect
 
 	IntVectorDataPtr outLengthData = new IntVectorData;
 	auto &outLengths = outLengthData->writable();
-	// potentially too large but large enough
-	outLengths.reserve( lengths.size() );
 
 	IntVectorDataPtr outIdData = new IntVectorData;
 	auto &outIds = outIdData->writable();
-	// potentially too large but large enough
-	outIds.reserve( ids.size() );
 
 	FloatVectorDataPtr outSharpnessData = new FloatVectorData;
 	auto &outSharpnesses = outSharpnessData->writable();
-	// potentially too large but large enough
-	outSharpnesses.reserve( sharpnesses.size() );
 
 	int creaseIdOffset = 0;
 	for( size_t i = 0; i < lengths.size(); ++i )

--- a/src/IECoreScene/MeshAlgoDeleteFaces.cpp
+++ b/src/IECoreScene/MeshAlgoDeleteFaces.cpp
@@ -107,6 +107,9 @@ void deleteCreases( MeshPrimitive *out, const MeshPrimitive *in, const std::vect
 			int id = remapping[ ids[creaseIdOffset + j] ];
 			if( id != -1 )
 			{
+				// \todo: This is not strictly correct. We might be adding creases
+				// for edges that no longer exist (ie when a particular creased face
+				// was deleted, but all of its original vertices remain).
 				outIds.push_back( id );
 				++outLength;
 			}

--- a/src/IECoreScene/MeshAlgoMerge.cpp
+++ b/src/IECoreScene/MeshAlgoMerge.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//  Copyright (c) 2018-2019, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -335,7 +335,10 @@ MeshPrimitivePtr IECoreScene::MeshAlgo::merge( const std::vector<const MeshPrimi
 		throw IECore::InvalidArgumentException( "IECoreScene::MeshAlgo::merge : No Mesh Primitives were provided." );
 	}
 
-	/// \todo: can this be parallelized?
+	/// \todo: This scales poorly with increasing numbers of meshes.
+	/// Rather than allocating enough memory for everything and filling
+	/// it once, we're re-allocating and re-copying from the start for
+	/// each mesh. Improve the algorithm.
 	MeshPrimitivePtr result = meshes[0]->copy();
 	auto it = meshes.begin() + 1;
 	for( ; it != meshes.end(); ++it )

--- a/src/IECoreScene/MeshAlgoMerge.cpp
+++ b/src/IECoreScene/MeshAlgoMerge.cpp
@@ -1,0 +1,297 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreScene/MeshAlgo.h"
+#include "IECoreScene/private/PrimitiveAlgoUtils.h"
+
+#include "IECore/DataAlgo.h"
+#include "IECore/DespatchTypedData.h"
+
+#include "boost/format.hpp"
+
+#include <algorithm>
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+
+namespace
+{
+
+template<class T>
+struct DefaultValue
+{
+	T operator()()
+	{
+		return T();
+	}
+};
+
+template<class T>
+struct DefaultValue<Imath::Vec3<T> >
+{
+	Imath::Vec3<T> operator()()
+	{
+		return Imath::Vec3<T>( 0 );
+	}
+};
+
+template<class T>
+struct DefaultValue<Imath::Vec2<T> >
+{
+	Imath::Vec2<T> operator()()
+	{
+		return Imath::Vec2<T>( 0 );
+	}
+};
+
+struct AppendPrimVars
+{
+		typedef void ReturnType;
+
+		AppendPrimVars( MeshPrimitive *mesh, const MeshPrimitive *mesh2, const std::string &name, const PrimitiveVariable::Interpolation interpolation, IntVectorData *indices, std::set<DataPtr> &visitedData )
+			:	m_mesh( mesh ), m_mesh2( mesh2 ), m_name( name ), m_interpolation( interpolation ), m_indices( indices ), m_visitedData( visitedData )
+		{
+		}
+
+		template<typename T>
+		ReturnType operator()( T *data )
+		{
+			if ( m_visitedData.find( data ) != m_visitedData.end() )
+			{
+				return;
+			}
+			m_visitedData.insert( data );
+
+			PrimitiveVariableMap::const_iterator it = m_mesh2->variables.find( m_name );
+			if( it != m_mesh2->variables.end() && it->second.data->isInstanceOf( data->staticTypeId() ) && it->second.interpolation == m_interpolation )
+			{
+				if( m_indices )
+				{
+					const int offset = data->readable().size();
+
+					const T *data2 = runTimeCast<const T>( it->second.data.get() );
+					data->writable().insert( data->writable().end(), data2->readable().begin(), data2->readable().end() );
+
+					if( it->second.indices )
+					{
+						/// Re-index to fit on the end of the existing data
+						/// \todo: the data would be more compact if we search
+						/// existing values rather than blindly insert.
+						std::vector<int> &indices = m_indices->writable();
+						const std::vector<int> &indices2 = it->second.indices->readable();
+						indices.reserve( indices.size() + indices2.size() );
+						for( const auto &index : indices2 )
+						{
+							indices.push_back( offset + index );
+						}
+					}
+					else
+					{
+						/// Append new indices for the second mesh
+						/// \todo: the data would be more compact if we search
+						/// existing values rather than blindly insert.
+						std::vector<int> &indices = m_indices->writable();
+						const size_t data2Size = data2->readable().size();
+						for( size_t i = 0; i < data2Size; ++i )
+						{
+							indices.push_back( offset + i );
+						}
+					}
+				}
+				else
+				{
+					/// The first mesh dictates whether the PrimitiveVariable should
+					/// be indexed. If the second mesh has indices, we must expand them.
+					typename T::Ptr expandedData2 = runTimeCast<T>( it->second.expandedData() );
+					data->writable().insert( data->writable().end(), expandedData2->readable().begin(), expandedData2->readable().end() );
+				}
+			}
+			else
+			{
+				typedef typename T::ValueType::value_type ValueType;
+				ValueType defaultValue = DefaultValue<ValueType>()();
+				size_t size = m_mesh2->variableSize( m_interpolation );
+				if( !size )
+				{
+					/// mesh2 may have an empty variableSize if it contains
+					/// no topology, so early out rather than appending.
+					return;
+				}
+
+				if( m_indices )
+				{
+					/// \todo: the data would be more compact if we search for defaultValue
+					/// in the existing data rather than blindly insert.
+					m_indices->writable().insert( m_indices->writable().end(), size, data->writable().size() );
+					data->writable().push_back( defaultValue );
+				}
+				else
+				{
+					data->writable().insert( data->writable().end(), size, defaultValue );
+				}
+			}
+		}
+
+	private :
+
+		MeshPrimitive *m_mesh;
+		const MeshPrimitive *m_mesh2;
+		const std::string m_name;
+		const PrimitiveVariable::Interpolation m_interpolation;
+		IntVectorData *m_indices;
+		std::set<DataPtr> &m_visitedData;
+
+};
+
+struct PrependPrimVars
+{
+		typedef void ReturnType;
+
+		PrependPrimVars( MeshPrimitive *mesh, const std::string &name, const PrimitiveVariable &primVar, std::map<ConstDataPtr, DataPtr> &visitedData )
+			:	m_mesh( mesh ), m_name( name ), m_primVar( primVar ), m_visitedData( visitedData )
+		{
+		}
+
+		template<typename T>
+		ReturnType operator()( const T *data )
+		{
+			PrimitiveVariableMap::iterator it = m_mesh->variables.find( m_name );
+			if( it == m_mesh->variables.end() )
+			{
+				typename T::Ptr data2 = nullptr;
+
+				std::map<ConstDataPtr, DataPtr>::iterator dataIt = m_visitedData.find( data );
+				if ( dataIt != m_visitedData.end() )
+				{
+					data2 = runTimeCast<T>( dataIt->second );
+				}
+
+				if ( !data2 )
+				{
+					typedef typename T::ValueType::value_type ValueType;
+					ValueType defaultValue = DefaultValue<ValueType>()();
+
+					typename T::Ptr expandedData = runTimeCast<T>( m_primVar.expandedData() );
+					size_t size = m_mesh->variableSize( m_primVar.interpolation ) - expandedData->readable().size();
+					data2 = new T();
+					data2->writable().insert( data2->writable().end(), size, defaultValue );
+
+					/// The first mesh dictates whether the PrimitiveVariable should
+					/// be indexed. If the second mesh has indices, we must expand them.
+					data2->writable().insert( data2->writable().end(), expandedData->readable().begin(), expandedData->readable().end() );
+				}
+
+				m_mesh->variables[m_name] = PrimitiveVariable( m_primVar.interpolation, data2 );
+
+				m_visitedData[data] = data2;
+			}
+		}
+
+	private :
+
+		MeshPrimitive *m_mesh;
+		const std::string m_name;
+		const PrimitiveVariable &m_primVar;
+		std::map<ConstDataPtr, DataPtr> &m_visitedData;
+
+};
+
+void merge( MeshPrimitive *a, const MeshPrimitive *b )
+{
+	const auto &vertexIdsA = a->vertexIds()->readable();
+	const auto &verticesPerFaceA = a->verticesPerFace()->readable();
+
+	const auto &vertexIdsB = b->vertexIds()->readable();
+	const auto &verticesPerFaceB = b->verticesPerFace()->readable();
+
+	IntVectorDataPtr verticesPerFaceData = new IntVectorData;
+	auto &verticesPerFace = verticesPerFaceData->writable();
+	verticesPerFace.resize( verticesPerFaceA.size() + verticesPerFaceB.size() );
+	auto it = std::copy( verticesPerFaceA.begin(), verticesPerFaceA.end(), verticesPerFace.begin() );
+	std::copy( verticesPerFaceB.begin(), verticesPerFaceB.end(), it );
+
+	IntVectorDataPtr vertexIdsData = new IntVectorData;
+	auto &vertexIds = vertexIdsData->writable();
+	vertexIds.resize( vertexIdsA.size() + vertexIdsB.size() );
+	it = std::copy( vertexIdsA.begin(), vertexIdsA.end(), vertexIds.begin() );
+	int vertexIdOffset = a->variableSize( PrimitiveVariable::Vertex );
+	std::transform( vertexIdsB.begin(), vertexIdsB.end(), it, std::bind2nd( std::plus<int>(), vertexIdOffset ) );
+
+	/// \todo: can we use setTopologyUnchecked?
+	a->setTopology( verticesPerFaceData, vertexIdsData, a->interpolation() );
+
+	/// \todo: can this be parallelized?
+	std::set<DataPtr> visitedData;
+	for( auto &pv : a->variables )
+	{
+		if( pv.second.interpolation != PrimitiveVariable::Constant )
+		{
+			IntVectorData *indices = pv.second.indices ? pv.second.indices.get() : nullptr;
+			AppendPrimVars f( a, b, pv.first, pv.second.interpolation, indices, visitedData );
+			despatchTypedData<AppendPrimVars, TypeTraits::IsVectorTypedData, DespatchTypedDataIgnoreError>( pv.second.data.get(), f );
+		}
+	}
+
+	/// \todo: can this be parallelized?
+	std::map<ConstDataPtr, DataPtr> visitedData2;
+	for( auto &pv : b->variables )
+	{
+		if( pv.second.interpolation != PrimitiveVariable::Constant )
+		{
+			PrependPrimVars f( a, pv.first, pv.second, visitedData2 );
+			despatchTypedData<PrependPrimVars, TypeTraits::IsVectorTypedData, DespatchTypedDataIgnoreError>( pv.second.data.get(), f );
+		}
+	}
+}
+
+} // namespace
+
+MeshPrimitivePtr IECoreScene::MeshAlgo::merge( const std::vector<const MeshPrimitive *> &meshes )
+{
+	if( meshes.empty() )
+	{
+		throw IECore::InvalidArgumentException( "IECoreScene::MeshAlgo::merge : No Mesh Primitives were provided." );
+	}
+
+	/// \todo: can this be parallelized?
+	MeshPrimitivePtr result = meshes[0]->copy();
+	auto it = meshes.begin() + 1;
+	for( ; it != meshes.end(); ++it )
+	{
+		::merge( result.get(), *it );
+	}
+
+	return result;
+}

--- a/src/IECoreScene/MeshAlgoMerge.cpp
+++ b/src/IECoreScene/MeshAlgoMerge.cpp
@@ -247,7 +247,8 @@ void merge( MeshPrimitive *a, const MeshPrimitive *b )
 	vertexIds.resize( vertexIdsA.size() + vertexIdsB.size() );
 	it = std::copy( vertexIdsA.begin(), vertexIdsA.end(), vertexIds.begin() );
 	int vertexIdOffset = a->variableSize( PrimitiveVariable::Vertex );
-	std::transform( vertexIdsB.begin(), vertexIdsB.end(), it, std::bind2nd( std::plus<int>(), vertexIdOffset ) );
+	auto idShift = [vertexIdOffset]( int id ){ return id + vertexIdOffset; };
+	std::transform( vertexIdsB.begin(), vertexIdsB.end(), it, idShift );
 
 	a->setTopologyUnchecked( verticesPerFaceData, vertexIdsData, a->variableSize( PrimitiveVariable::Vertex ) + b->variableSize( PrimitiveVariable::Vertex ), a->interpolation() );
 
@@ -259,7 +260,7 @@ void merge( MeshPrimitive *a, const MeshPrimitive *b )
 		auto &ids = idData->writable();
 		ids.resize( aCornerIds.size() + bCornerIds.size() );
 		it = std::copy( aCornerIds.begin(), aCornerIds.end(), ids.begin() );
-		std::transform( bCornerIds.begin(), bCornerIds.end(), it, std::bind2nd( std::plus<int>(), vertexIdOffset ) );
+		std::transform( bCornerIds.begin(), bCornerIds.end(), it, idShift );
 
 		const auto &aSharpnesses = a->cornerSharpnesses()->readable();
 		const auto &bSharpnesses = b->cornerSharpnesses()->readable();
@@ -288,7 +289,7 @@ void merge( MeshPrimitive *a, const MeshPrimitive *b )
 		auto &ids = idData->writable();
 		ids.resize( aCreaseIds.size() + bCreaseIds.size() );
 		it = std::copy( aCreaseIds.begin(), aCreaseIds.end(), ids.begin() );
-		std::transform( bCreaseIds.begin(), bCreaseIds.end(), it, std::bind2nd( std::plus<int>(), vertexIdOffset ) );
+		std::transform( bCreaseIds.begin(), bCreaseIds.end(), it, idShift );
 
 		const auto &aSharpnesses = a->creaseSharpnesses()->readable();
 		const auto &bSharpnesses = b->creaseSharpnesses()->readable();

--- a/src/IECoreScene/MeshAlgoTriangulate.cpp
+++ b/src/IECoreScene/MeshAlgoTriangulate.cpp
@@ -266,8 +266,7 @@ struct TriangulateFn
 			faceVertexIdStart += numFaceVerts;
 		}
 
-		// todo update to setTopologyUnchecked
-		m_mesh->setTopology( newVerticesPerFace, newVertexIds, m_mesh->interpolation() );
+		m_mesh->setTopologyUnchecked( newVerticesPerFace, newVertexIds, pReadable.size(), m_mesh->interpolation() );
 
 		/// Rebuild all the facevarying primvars, using the list of indices into the old data we created above.
 		assert( faceVaryingIndices.size() == newVertexIds->readable().size() );

--- a/src/IECoreScene/MeshMergeOp.cpp
+++ b/src/IECoreScene/MeshMergeOp.cpp
@@ -134,5 +134,7 @@ void MeshMergeOp::modifyTypedPrimitive( MeshPrimitive * mesh, const CompoundObje
 	{
 		mesh->setTopology( result->verticesPerFace(), result->vertexIds(), result->interpolation() );
 		mesh->variables = result->variables;
+		mesh->setCorners( result->cornerIds(), result->cornerSharpnesses() );
+		mesh->setCreases( result->creaseLengths(), result->creaseIds(), result->creaseSharpnesses() );
 	}
 }

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -40,6 +40,8 @@
 
 #include "IECorePython/RunTimeTypedBinding.h"
 
+#include "boost/python/suite/indexing/container_utils.hpp"
+
 using namespace boost::python;
 using namespace IECorePython;
 using namespace IECoreScene;
@@ -92,6 +94,13 @@ boost::python::list segment(const MeshPrimitive *mesh, const PrimitiveVariable &
 
 BOOST_PYTHON_FUNCTION_OVERLOADS(segmentOverLoads, segment, 2, 3);
 
+MeshPrimitivePtr merge( boost::python::list &l )
+{
+	std::vector<const MeshPrimitive *> meshes;
+	boost::python::container_utils::extend_container( meshes, l );
+	return MeshAlgo::merge( meshes );
+}
+
 } // namespace anonymous
 
 namespace IECoreSceneModule
@@ -117,6 +126,7 @@ void bindMeshAlgo()
 	def( "reorderVertices", &MeshAlgo::reorderVertices, ( arg_( "mesh" ), arg_( "id0" ), arg_( "id1" ), arg_( "id2" ) ) );
 	def( "distributePoints", &MeshAlgo::distributePoints, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "position" ) = "P" ) );
 	def( "segment", &::segment, segmentOverLoads() );
+	def( "merge", &::merge );
 	def( "triangulate", &MeshAlgo::triangulate, (arg_("mesh"), arg_("tolerance") =1e-6f, arg_("throwExceptions") = false) );
 	def( "connectedVertices", &MeshAlgo::connectedVertices );
 }

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -642,7 +642,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cd", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 
 		node.parm( "attributeFilter" ).set( "P" )
@@ -656,7 +656,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 
 		node.parm( "attributeFilter" ).set( "Cs" )
@@ -681,7 +681,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cd", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 
 		# copying as expected, including automatic translation to rest
@@ -689,7 +689,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs + ["rest"] )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cd", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 		# ensure the rest does not transform along with P by making sure it matches the static P
 		original = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
@@ -699,11 +699,11 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 			self.assertEqual( original["P"].data[ point.number() % 8 ], imath.V3f( rest[0], rest[1], rest[2] ) )
 
 		# copying multiple prim vars
-		node.parm( "attributeCopy" ).set( "P:Pref Cs:Cspecial" )
+		node.parm( "attributeCopy" ).set( "P:Pref Cs:Cspecial uv:myUvs" )
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs + ["rest"] )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cd", "Cspecial", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "myUvs", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 		# ensure the rest does not transform along with P by making sure it matches the static P
 		for point in node.geometry().points() :
@@ -719,7 +719,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cspecial", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 
 		# nonexistant prim vars are a no-op
@@ -728,7 +728,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( len(node.geometry().prims()), 18 )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().pointAttribs() ] ), TestSceneCache.PointPositionAttribs )
 		self.assertEqual( sorted( [ x.name() for x in node.geometry().primAttribs() ] ), ["Cd", "ieMeshInterpolation", "name"] )
-		self.assertEqual( node.geometry().vertexAttribs(), tuple() )
+		self.assertEqual( sorted( [ x.name() for x in node.geometry().vertexAttribs() ] ), ["N", "uv"] )
 		self.assertEqual( node.geometry().globalAttribs(), tuple() )
 
 		# still works for Cortex geo
@@ -743,7 +743,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.assertEqual( sorted( result.keys() ), [ "/1", "/1/2", "/1/2/3" ] )
 		for key in result.keys() :
 			self.assertTrue( isinstance( result[key], IECoreScene.MeshPrimitive ) )
-			self.assertEqual( sorted( result[key].keys() ), [ "Cs", "P", "Pref" ] )
+			self.assertEqual( sorted( result[key].keys() ), [ "Cs", "N", "P", "Pref", "uv" ] )
 			self.assertNotEqual( result[key]["P"], result[key]["Pref"] )
 			self.assertEqual( original["P"], result[key]["Pref"] )
 

--- a/test/IECoreHoudini/ToHoudiniCortexObjectConverter.py
+++ b/test/IECoreHoudini/ToHoudiniCortexObjectConverter.py
@@ -398,7 +398,7 @@ class TestToHoudiniCortexObjectConverter( IECoreHoudini.TestCase ) :
 
 		# verify we can filter uvs
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
-		IECoreScene.TriangulateOp()( input=mesh, copyInput=False )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 		IECoreScene.MeshNormalsOp()( input=mesh, copyInput=False )
 		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6, IECore.GeometricData.Interpretation.Color ) )
 		mesh["width"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1 ] * 4 ) )

--- a/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
@@ -1100,6 +1100,17 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 
 		self.assertEqual( list(geo.vertexFloatAttribValues( "creaseweight" )), expectedSharpnesses )
 
+		# make sure it round trips well enough
+		result = IECoreHoudini.FromHoudiniPolygonsConverter( sop ).convert()
+		self.assertEqual( result.cornerIds(), mesh.cornerIds() )
+		self.assertEqual( result.cornerSharpnesses(), mesh.cornerSharpnesses() )
+		self.assertEqual( result.creaseLengths(), IECore.IntVectorData( [ 2, 2, 2 ] ) )
+		self.assertEqual( result.creaseIds(), IECore.IntVectorData( [ 2, 3, 1, 2, 4, 5 ] ) )
+		self.assertEqual( result.creaseSharpnesses(), IECore.FloatVectorData( [ 1, 1, 5 ] ) )
+		# if we re-align result creases, everything else is an exact match
+		mesh.setCreases( result.creaseLengths(), result.creaseIds(), result.creaseSharpnesses() )
+		self.assertEqual( result, mesh )
+
 	def tearDown( self ) :
 
 		if os.path.isfile( TestToHoudiniPolygonsConverter.__testScene ) :

--- a/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
@@ -834,7 +834,7 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 
 		# verify we can filter uvs
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
-		IECoreScene.TriangulateOp()( input=mesh, copyInput=False )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 		IECoreScene.MeshNormalsOp()( input=mesh, copyInput=False )
 		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6, IECore.GeometricData.Interpretation.Color ) )
 		mesh["width"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1 ] * 4 ) )
@@ -867,7 +867,7 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 
 		sop = self.emptySop()
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
-		IECoreScene.TriangulateOp()( input=mesh, copyInput=False )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 		IECoreScene.MeshNormalsOp()( input=mesh, copyInput=False )
 		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6, IECore.GeometricData.Interpretation.Color ) )
 		mesh["width"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1 ] * 4 ) )
@@ -928,7 +928,7 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 		merge.parm( "objpath1" ).set( sop.path() )
 
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
-		IECoreScene.TriangulateOp()( input=mesh, copyInput=False )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 		IECoreScene.MeshNormalsOp()( input=mesh, copyInput=False )
 		mesh["Pref"] = mesh["P"]
 		prefData = mesh["Pref"].data

--- a/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
+++ b/test/IECoreHoudini/ToHoudiniPolygonsConverter.py
@@ -1063,6 +1063,9 @@ class TestToHoudiniPolygonsConverter( IECoreHoudini.TestCase ) :
 	def testCornersAndCreases( self ) :
 
 		mesh = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		# normals and UVs complicate the testing, and we don't need them to verify corners and creases
+		del mesh["N"]
+		del mesh["uv"]
 		cornerIds = [ 5 ]
 		cornerSharpnesses = [ 10.0 ]
 		mesh.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )

--- a/test/IECoreMaya/FromMayaMeshConverterTest.py
+++ b/test/IECoreMaya/FromMayaMeshConverterTest.py
@@ -58,7 +58,7 @@ class FromMayaMeshConverterTest( IECoreMaya.TestCase ) :
 
 		sc.writeObject( mesh, 0 )
 
-		del scene
+		del scene, sc
 
 	def testFactory( self ) :
 

--- a/test/IECoreScene/FaceVaryingPromotionOpTest.py
+++ b/test/IECoreScene/FaceVaryingPromotionOpTest.py
@@ -67,7 +67,7 @@ class FaceVaryingPromotionOpTest( unittest.TestCase ) :
 	def __plane( self, indices = False ) :
 
 		p = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
-		IECoreScene.TriangulateOp()( input=p, copyInput=False )
+		p = IECoreScene.MeshAlgo.triangulate( p )
 
 		for n in self.__inputValues.keys() :
 

--- a/test/IECoreScene/MeshAlgoDeleteFacesTest.py
+++ b/test/IECoreScene/MeshAlgoDeleteFacesTest.py
@@ -319,6 +319,35 @@ class MeshAlgoDeleteFacesTest( unittest.TestCase ) :
 		self.assertEqual( facesDeletedMesh["primvarFaceVaryingIndexed"].data, IECore.IntVectorData( [ 2 ] ) )
 		self.assertEqual( facesDeletedMesh["primvarFaceVaryingIndexed"].indices, IECore.IntVectorData( [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] ) )
 
+	def testCornersAndCreases( self ) :
+
+		deleteAttributeData = IECore.IntVectorData( [1, 0] )
+
+		mesh = self.makeQuadTriangleMesh()
+		mesh["delete"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, deleteAttributeData )
+		cornerIds = [ 1, 2 ]
+		cornerSharpnesses = [ 1.0, 2.0 ]
+		mesh.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )
+		creaseLengths = [ 3, 2 ]
+		creaseIds = [ 0, 1, 2, 2, 3 ]  # note that these are vertex ids
+		creaseSharpnesses = [ 1.0, 2.0 ]
+		mesh.setCreases( IECore.IntVectorData( creaseLengths ), IECore.IntVectorData( creaseIds ), IECore.FloatVectorData( creaseSharpnesses ) )
+
+		facesDeletedMesh = IECoreScene.MeshAlgo.deleteFaces( mesh, mesh["delete"] )
+
+		self.assertEqual( facesDeletedMesh.numFaces(), 1 )
+		self.assertEqual( facesDeletedMesh.verticesPerFace, IECore.IntVectorData( [ 3 ] ) )
+		self.assertEqual( facesDeletedMesh.vertexIds, IECore.IntVectorData( [ 0, 1, 2 ] ) )
+
+		self.assertEqual( facesDeletedMesh["P"].data, IECore.V3fVectorData( [ imath.V3f( 0, 0, 0 ), imath.V3f( 1, 1, 0 ), imath.V3f( 0, 1, 0 ) ], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( facesDeletedMesh["uv"].data, IECore.V2fVectorData( [ imath.V2f( 0, 0 ), imath.V2f( 1, 1 ), imath.V2f( 0, 1 ) ] ) )
+		self.assertEqual( facesDeletedMesh["delete"].data, IECore.IntVectorData( [ 0 ] ) )
+
+		self.assertEqual( facesDeletedMesh.cornerIds(), IECore.IntVectorData( [ 1 ] ) )
+		self.assertEqual( facesDeletedMesh.cornerSharpnesses(), IECore.FloatVectorData( [ 2.0 ] ) )
+		self.assertEqual( facesDeletedMesh.creaseLengths(), IECore.IntVectorData( [ 2, 2 ] ) )
+		self.assertEqual( facesDeletedMesh.creaseIds(), IECore.IntVectorData( [ 0, 1, 1, 2 ] ) )
+		self.assertEqual( facesDeletedMesh.creaseSharpnesses(), IECore.FloatVectorData( [ 1.0, 2.0 ] ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -48,7 +48,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		self.assertEqual( points.numPoints, points['P'].data.size() )
 		self.failUnless( points.arePrimitiveVariablesValid() )
 
-		mesh = IECoreScene.TriangulateOp()( input = mesh )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 		meshEvaluator = IECoreScene.MeshPrimitiveEvaluator( mesh )
 		result = meshEvaluator.createResult()
 		pointsPerFace = [ 0 ] * mesh.verticesPerFace.size()
@@ -93,7 +93,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 	def testDensityMaskPrimVar( self ) :
 
 		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
-		m = IECoreScene.TriangulateOp()( input = m )
+		m = IECoreScene.MeshAlgo.triangulate( m )
 		numFaces = m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		m['density'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.FloatVectorData( [ float(x)/numFaces for x in range( 0, numFaces ) ] ) )
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 100 )

--- a/test/IECoreScene/MeshAlgoMergeTest.py
+++ b/test/IECoreScene/MeshAlgoMergeTest.py
@@ -1,0 +1,204 @@
+##########################################################################
+#
+#  Copyright (c) 2018, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+
+import IECore
+import IECoreScene
+import imath
+
+
+class MeshAlgoMergeTest( unittest.TestCase ) :
+
+	def verifyPrimvars( self, primitive ):
+		for v in primitive.keys():
+			self.failUnless( primitive.isPrimitiveVariableValid(primitive[v]), "invalid primvar {0}".format( v ) )
+
+	def verifyMerge( self, merged, originals ) :
+
+		self.verifyPrimvars( merged )
+		for mesh in originals :
+			self.verifyPrimvars( mesh )
+
+		for v in IECoreScene.PrimitiveVariable.Interpolation.values :
+			i = IECoreScene.PrimitiveVariable.Interpolation( v )
+			if i!=IECoreScene.PrimitiveVariable.Interpolation.Invalid and i!=IECoreScene.PrimitiveVariable.Interpolation.Constant :
+				self.assertEqual( merged.variableSize( i ), sum([ mesh.variableSize( i ) for mesh in originals ]) )
+
+		self.verifyData( merged, originals )
+
+	def verifyData( self, merged, originals ) :
+
+		for meshIndex in range( 0, len(originals) ) :
+
+			mesh = originals[meshIndex]
+
+			for name in mesh.keys() :
+
+				self.failUnless( name in merged )
+
+				interpolation = mesh[name].interpolation
+				if merged[name].indices :
+					self.assertEqual( len(merged[name].indices), sum([ x.variableSize( interpolation ) for x in originals ]) )
+				else :
+					self.assertEqual( len(merged[name].data), sum([ x.variableSize( interpolation ) for x in originals ]) )
+
+				offset = sum([ x.variableSize( interpolation ) for x in originals[:meshIndex] ])
+
+				if merged[name].indices and mesh[name].indices :
+					for i in range( 0, len(mesh[name].indices) ) :
+						index = merged[name].indices[offset + i]
+						indexA = mesh[name].indices[i]
+						self.assertEqual( index, indexA + offset )
+						self.assertEqual( merged[name].data[index], mesh[name].data[indexA] )
+
+				elif merged[name].indices :
+					for i in range( 0, len(mesh[name].data) ) :
+						index = merged[name].indices[offset + i]
+						indexA = offset + i
+						self.assertEqual( index, indexA )
+						self.assertEqual( merged[name].data[index], mesh[name].data[i] )
+
+				elif mesh[name].indices :
+					for i in range( 0, len(mesh[name].indices) ) :
+						indexA = mesh[name].indices[i]
+						self.assertEqual( merged[name].data[offset + i], mesh[name].data[indexA] )
+
+				else :
+					for i in range( 0, len(mesh[name].data) ) :
+						self.assertEqual( merged[name].data[offset + i], mesh[name].data[i] )
+
+	def testPlanes( self ) :
+
+		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+	def testDifferentPrimVars( self ) :
+
+		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		del p2["N"]
+		self.assertNotEqual( p1.keys(), p2.keys() )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		p2 = IECoreScene.MeshAlgo.triangulate( p2 )
+		p2['myInt'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.IntVectorData( [ 0, 1, 2, 3, 4 ,5 ] ) )
+		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( p2 )
+		p2["uTangent"] = uTangent
+		p2["vTangent"] = vTangent
+		self.assertNotEqual( p1.keys(), p2.keys() )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+	def testSamePrimVarNamesWithDifferentInterpolation( self ) :
+
+		plane = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
+		IECoreScene.MeshNormalsOp()( input=plane, copyInput=False )
+		box = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) )
+		IECoreScene.MeshNormalsOp()( input=box, copyInput=False )
+		IECoreScene.FaceVaryingPromotionOp()( input=box, copyInput=False, primVarNames=IECore.StringVectorData( [ "N" ] ) )
+		self.assertEqual( plane.keys(), box.keys() )
+		merged = IECoreScene.MeshAlgo.merge( [ plane, box ] )
+		del box["N"]
+		self.verifyMerge( merged, [ plane, box ] )
+
+	def testReferencedData( self ) :
+
+		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
+		p1["Pref"] = p1["P"]
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.failUnless( "Pref" in merged )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		del p1["Pref"]
+		p2["Pref"] = p2["P"]
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.failUnless( "Pref" in merged )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+	def testIndexedPrimVars( self ) :
+
+		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 0 ) ) )
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+
+		# both meshes have indexed UVs
+		p1["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p1["uv"].data, IECore.IntVectorData( [ 0, 3, 1, 2 ] ) )
+		p2["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p2["uv"].data, IECore.IntVectorData( [ 2, 1, 0, 3 ] ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		# meshA has indexed UVs, meshB has expanded UVs
+		p2["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p2["uv"].data, None )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		# both meshes have expanded UVs
+		p1["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p1["uv"].data, None )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		# meshA has expanded UVs, meshB has indexed UVs
+		p2["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p2["uv"].data, IECore.IntVectorData( [ 2, 1, 0, 3 ] ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		# meshA has indexed UVs, meshB has no UVs
+		p1["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p1["uv"].data, IECore.IntVectorData( [ 0, 3, 1, 2 ] ) )
+		del p2["uv"]
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+		# meshA has no UVs, meshB has indexed UVs
+		del p1["uv"]
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		p2["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, p2["uv"].data, IECore.IntVectorData( [ 2, 1, 0, 3 ] ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2 ] )
+		self.verifyMerge( merged, [ p1, p2 ] )
+
+	def testMultipleMeshes( self ) :
+
+		p1 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 1 ) ) )
+		p2 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 1 ), imath.V2f( 2 ) ) )
+		p3 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 2 ), imath.V2f( 3 ) ) )
+		p4 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 3 ), imath.V2f( 4 ) ) )
+		p5 = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 4 ), imath.V2f( 5 ) ) )
+		merged = IECoreScene.MeshAlgo.merge( [ p1, p2, p3, p4, p5 ] )
+		self.verifyMerge( merged, [ p1, p2, p3, p4, p5 ] )
+
+if __name__ == "__main__" :
+	unittest.main()

--- a/test/IECoreScene/MeshAlgoMergeTest.py
+++ b/test/IECoreScene/MeshAlgoMergeTest.py
@@ -200,5 +200,35 @@ class MeshAlgoMergeTest( unittest.TestCase ) :
 		merged = IECoreScene.MeshAlgo.merge( [ p1, p2, p3, p4, p5 ] )
 		self.verifyMerge( merged, [ p1, p2, p3, p4, p5 ] )
 
+	def testCornersAndCreases( self ) :
+
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		cornerIds = [ 5 ]
+		cornerSharpnesses = [ 10.0 ]
+		m.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )
+		creaseLengths = [ 3, 2 ]
+		creaseIds = [ 1, 2, 3, 4, 5 ]  # note that these are vertex ids
+		creaseSharpnesses = [ 1, 5 ]
+		m.setCreases( IECore.IntVectorData( creaseLengths ), IECore.IntVectorData( creaseIds ), IECore.FloatVectorData( creaseSharpnesses ) )
+
+		m2 = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		cornerIds = [ 1 ]
+		cornerSharpnesses = [ 5.0 ]
+		m2.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )
+		creaseLengths = [ 2, 3, 2 ]
+		creaseIds = [ 1, 2, 3, 4, 5, 6, 7 ]  # note that these are vertex ids
+		creaseSharpnesses = [ 3, 2, 0.5 ]
+		m2.setCreases( IECore.IntVectorData( creaseLengths ), IECore.IntVectorData( creaseIds ), IECore.FloatVectorData( creaseSharpnesses ) )
+
+		merged = IECoreScene.MeshAlgo.merge( [ m, m2 ] )
+
+		# verify the corner and crease ids have been updated to match
+		self.assertTrue( merged.arePrimitiveVariablesValid() )
+		self.assertEqual( merged.cornerIds(), IECore.IntVectorData( [ 5, 9 ] ) )
+		self.assertEqual( merged.cornerSharpnesses(), IECore.FloatVectorData( [ 10.0, 5.0 ] ) )
+		self.assertEqual( merged.creaseLengths(), IECore.IntVectorData( [ 3, 2, 2, 3, 2 ] ) )
+		self.assertEqual( merged.creaseIds(), IECore.IntVectorData( [ 1, 2, 3, 4, 5, 9, 10, 11, 12, 13, 14, 15 ] ) )
+		self.assertEqual( merged.creaseSharpnesses(), IECore.FloatVectorData( [ 1, 5, 3, 2, 0.5 ] ) )
+
 if __name__ == "__main__" :
 	unittest.main()

--- a/test/IECoreScene/MeshAlgoReorderTest.py
+++ b/test/IECoreScene/MeshAlgoReorderTest.py
@@ -259,5 +259,37 @@ class MeshAlgoReorderTest( unittest.TestCase ) :
 
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
+	def testCornersAndCreases( self ) :
+
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		cornerIds = [ 5 ]
+		cornerSharpnesses = [ 10.0 ]
+		m.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )
+		creaseLengths = [ 3, 2 ]
+		creaseIds = [ 1, 2, 3, 4, 5 ]  # note that these are vertex ids
+		creaseSharpnesses = [ 1, 5 ]
+		m.setCreases( IECore.IntVectorData( creaseLengths ), IECore.IntVectorData( creaseIds ), IECore.FloatVectorData( creaseSharpnesses ) )
+
+		originalP = m["P"].data.copy()
+
+		IECoreScene.MeshAlgo.reorderVertices( m, 0, 1, 3 )
+
+		# verify the points reordered as expected
+		self.assertEqual( m["P"].data[1], originalP[1] )
+		self.assertEqual( m["P"].data[2], originalP[2] )
+		self.assertEqual( m["P"].data[3], originalP[3] )
+		self.assertEqual( m["P"].data[5], originalP[4] )
+		self.assertEqual( m["P"].data[7], originalP[5] )
+		self.assertEqual( m["P"].data[4], originalP[6] )
+		self.assertEqual( m["P"].data[6], originalP[7] )
+
+		# verify the corner and crease ids have been updated to match
+		self.assertTrue( m.arePrimitiveVariablesValid() )
+		self.assertEqual( m.cornerIds(), IECore.IntVectorData( [ 7 ] ) )
+		self.assertEqual( m.cornerSharpnesses(), IECore.FloatVectorData( cornerSharpnesses ) )
+		self.assertEqual( m.creaseLengths(), IECore.IntVectorData( creaseLengths ) )
+		self.assertEqual( m.creaseIds(), IECore.IntVectorData( [ 1, 2, 3, 5, 7 ] ) )
+		self.assertEqual( m.creaseSharpnesses(), IECore.FloatVectorData( creaseSharpnesses ) )
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/MeshAlgoTest.py
+++ b/test/IECoreScene/MeshAlgoTest.py
@@ -42,6 +42,7 @@ from MeshAlgoResampleTest import MeshAlgoResampleTest
 from MeshAlgoTangentsTest import MeshAlgoTangentsTest
 from MeshAlgoWindingTest import MeshAlgoWindingTest
 from MeshAlgoSegmentTest import MeshAlgoSegmentTest
+from MeshAlgoMergeTest import MeshAlgoMergeTest
 from MeshAlgoReorderTest import MeshAlgoReorderTest
 from MeshAlgoTriangulateTest import MeshAlgoTriangulateTest
 from MeshAlgoConnectedVerticesTest import MeshAlgoConnectedVerticesTest

--- a/test/IECoreScene/MeshAlgoTriangulateTest.py
+++ b/test/IECoreScene/MeshAlgoTriangulateTest.py
@@ -264,6 +264,26 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 		self.assertEqual( m2["myString"].data, m["myString"].data )
 		self.assertEqual( m2["myString"].indices, IECore.IntVectorData( [ 1, 1, 0, 0, 0, 0, 1, 1 ] ) )
 
+	def testCornersAndCreases( self ) :
+
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ) )
+		cornerIds = [ 5 ]
+		cornerSharpnesses = [ 10.0 ]
+		m.setCorners( IECore.IntVectorData( cornerIds ), IECore.FloatVectorData( cornerSharpnesses ) )
+		creaseLengths = [ 3, 2 ]
+		creaseIds = [ 1, 2, 3, 4, 5 ]  # note that these are vertex ids
+		creaseSharpnesses = [ 1, 5 ]
+		m.setCreases( IECore.IntVectorData( creaseLengths ), IECore.IntVectorData( creaseIds ), IECore.FloatVectorData( creaseSharpnesses ) )
+
+		m2 = IECoreScene.MeshAlgo.triangulate( m )
+
+		self.assertTrue( m2.arePrimitiveVariablesValid() )
+		self.assertEqual( m2.cornerIds(), m.cornerIds() )
+		self.assertEqual( m2.cornerSharpnesses(), m.cornerSharpnesses() )
+		self.assertEqual( m2.creaseLengths(), m.creaseLengths() )
+		self.assertEqual( m2.creaseIds(), m.creaseIds() )
+		self.assertEqual( m2.creaseSharpnesses(), m.creaseSharpnesses() )
+
 	@unittest.skipUnless( os.environ.get("CORTEX_PERFORMANCE_TEST", False), "'CORTEX_PERFORMANCE_TEST' env var not set" )
 	def testTriangulatePerformance( self ):
 

--- a/test/IECoreScene/MeshAlgoWindingTest.py
+++ b/test/IECoreScene/MeshAlgoWindingTest.py
@@ -84,7 +84,7 @@ class MeshAlgoWindingTest( unittest.TestCase ) :
 	def testPlane( self ) :
 
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 10 ) )
-		IECoreScene.TriangulateOp()( input = mesh, copyInput = False )
+		mesh = IECoreScene.MeshAlgo.triangulate( mesh )
 
 		meshReversed = mesh.copy()
 		IECoreScene.MeshAlgo.reverseWinding( meshReversed )

--- a/test/IECoreScene/MeshMergeOpTest.py
+++ b/test/IECoreScene/MeshMergeOpTest.py
@@ -139,7 +139,7 @@ class MeshMergeOpTest( unittest.TestCase ) :
 		merged = IECoreScene.MeshMergeOp()( input=p1, mesh=p2 )
 		self.verifyMerge( p1, p2, merged )
 
-		IECoreScene.TriangulateOp()( input=p2, copyInput=False )
+		p2 = IECoreScene.MeshAlgo.triangulate( p2 )
 		p2['myInt'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.IntVectorData( [ 0, 1, 2, 3, 4 ,5 ] ) )
 		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( p2 )
 		p2["uTangent"] = uTangent
@@ -173,7 +173,7 @@ class MeshMergeOpTest( unittest.TestCase ) :
 		del p1["N"]
 		self.verifyMerge( p1, p2, merged )
 
-		IECoreScene.TriangulateOp()( input=p2, copyInput=False )
+		p2 = IECoreScene.MeshAlgo.triangulate( p2 )
 		p2['myInt'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.IntVectorData( [ 0, 1, 2, 3, 4 ,5 ] ) )
 		uTangent, vTangent = IECoreScene.MeshAlgo.calculateTangents( p2 )
 		p2["uTangent"] = uTangent

--- a/test/IECoreScene/MeshPrimitive.py
+++ b/test/IECoreScene/MeshPrimitive.py
@@ -284,7 +284,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( len( m["N"].data ), len( m["P"].data ) )
 		self.assertEqual( m["N"].data, IECore.V3fVectorData( [ imath.V3f( 0, 0, 1 ) ] * len( m["P"].data ), IECore.GeometricData.Interpretation.Normal ) )
 
-		e = IECoreScene.MeshPrimitiveEvaluator( IECoreScene.TriangulateOp()( input = m ) )
+		e = IECoreScene.MeshPrimitiveEvaluator( IECoreScene.MeshAlgo.triangulate( m ) )
 
 		r = e.createResult()
 		self.assertTrue( e.pointAtUV( imath.V2f( 0, 0 ), r ) )
@@ -314,7 +314,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
 		# corners still have correct uvs
-		e = IECoreScene.MeshPrimitiveEvaluator( IECoreScene.TriangulateOp()( input = m ) )
+		e = IECoreScene.MeshPrimitiveEvaluator( IECoreScene.MeshAlgo.triangulate( m ) )
 		r = e.createResult()
 		self.assertTrue( e.pointAtUV( imath.V2f( 0, 0 ), r ) )
 		self.assertEqual( r.point(), m["P"].data[0] )
@@ -334,7 +334,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		m = IECoreScene.MeshPrimitive.createSphere( radius = 1, divisions = imath.V2i( 30, 40 ) )
 		self.assertTrue( IECore.BoxAlgo.contains( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ), m.bound() ) )
 		self.assertTrue( m.arePrimitiveVariablesValid() )
-		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.TriangulateOp()( input = m ) )
+		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.MeshAlgo.triangulate( m ) )
 		mer = me.createResult()
 		s = IECoreScene.SpherePrimitive( 1 )
 		se = IECoreScene.PrimitiveEvaluator.create( s )
@@ -354,7 +354,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		m = IECoreScene.MeshPrimitive.createSphere( radius = 1, divisions = imath.V2i( 300, 300 ) )
 		self.assertTrue( IECore.BoxAlgo.contains( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ), m.bound() ) )
 		self.assertTrue( m.arePrimitiveVariablesValid() )
-		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.TriangulateOp()( input = m ) )
+		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.MeshAlgo.triangulate( m ) )
 		mer = me.createResult()
 		for s in range( 0, 100 ) :
 			for t in range( 0, 100 ) :
@@ -373,7 +373,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertFalse( IECore.BoxAlgo.contains( imath.Box3f( imath.V3f( -1 ), imath.V3f( 1 ) ), m.bound() ) )
 		self.assertTrue( IECore.BoxAlgo.contains( imath.Box3f( imath.V3f( -2 ), imath.V3f( 2 ) ), m.bound() ) )
 		self.assertTrue( m.arePrimitiveVariablesValid() )
-		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.TriangulateOp()( input = m ) )
+		me = IECoreScene.PrimitiveEvaluator.create( IECoreScene.MeshAlgo.triangulate( m ) )
 		mer = me.createResult()
 		s = IECoreScene.SpherePrimitive( 2 )
 		se = IECoreScene.PrimitiveEvaluator.create( s )


### PR DESCRIPTION
This should finish off our push to support subdiv corners/creases in Cortex. I've:

- Added corners/crease import/export for Houdini polygons
- Fixed a bug in the mesh interpolation export from Houdini
- Updated `MeshAlgo::deleteFaces`, `MeshAlgo::triangulate`, `MeshAlgo::reorderVertices` to maintain the corners/creases
- Ported `MergeMergeOp` to `MeshAlgo::merge` and updated it to maintain the corners/creases