### PR TITLE
Protect Against Crashes From Invalid Primitive Variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1063,9 +1063,17 @@ env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )
 if "clang++" in os.path.basename( env["CXX"] ) :
 	env.Append( CXXFLAGS = ["-Wno-unused-local-typedef"] )
 
-	if env["ASAN"] :
-		env.Append( CXXFLAGS = ["-fsanitize=address", "-shared-libasan"] )
-		env.Append( LINKFLAGS = ["-fsanitize=address", "-shared-libasan"] )
+if env["ASAN"] :
+	env.Append(
+		CXXFLAGS = [ "-fsanitize=address" ],
+		LINKFLAGS = [ "-fsanitize=address" ]
+	)
+	if "clang++" in os.path.basename( env["CXX"] ) :
+		env.Append(
+			CXXFLAGS = [ "-shared-libasan" ],
+			LINKFLAGS = [ "-shared-libasan" ],
+		)
+
 
 if env["WARNINGS_AS_ERRORS"] :
 	env.Append(

--- a/src/IECoreScene/CurvesAlgo.cpp
+++ b/src/IECoreScene/CurvesAlgo.cpp
@@ -383,6 +383,12 @@ CurvesPrimitivePtr deleteCurves(
 
 	for (PrimitiveVariableMap::const_iterator it = curvesPrimitive->variables.begin(), e = curvesPrimitive->variables.end(); it != e; ++it)
 	{
+		if( !curvesPrimitive->isPrimitiveVariableValid( it->second ) )
+		{
+			throw InvalidArgumentException(
+				boost::str ( boost::format( "CurvesAlgo::deleteCurves cannot process invalid primitive variable \"%s\"" ) % it->first ) );
+		}
+
 		switch( it->second.interpolation )
 		{
 			case PrimitiveVariable::Constant:

--- a/src/IECoreScene/MeshAlgoDeleteFaces.cpp
+++ b/src/IECoreScene/MeshAlgoDeleteFaces.cpp
@@ -166,6 +166,12 @@ MeshPrimitivePtr deleteFaces( const MeshPrimitive *meshPrimitive, PrimitiveVaria
 
 	for( PrimitiveVariableMap::const_iterator it = meshPrimitive->variables.begin(), e = meshPrimitive->variables.end(); it != e; ++it )
 	{
+		if( !meshPrimitive->isPrimitiveVariableValid( it->second ) )
+		{
+			throw InvalidArgumentException(
+				boost::str ( boost::format( "MeshAlgo::deleteFaces cannot process invalid primitive variable \"%s\"" ) % it->first ) );
+		}
+
 		switch( it->second.interpolation )
 		{
 			case PrimitiveVariable::Uniform:

--- a/src/IECoreScene/PointsAlgo.cpp
+++ b/src/IECoreScene/PointsAlgo.cpp
@@ -122,6 +122,11 @@ PointsPrimitivePtr deletePoints( const PointsPrimitive *pointsPrimitive, IECoreS
 			case PrimitiveVariable::Varying:
 			case PrimitiveVariable::FaceVarying:
 			{
+				if( !pointsPrimitive->isPrimitiveVariableValid( it->second ) )
+				{
+					throw InvalidArgumentException(
+						boost::str ( boost::format( "PointsAlgo::deletePoints cannot process invalid primitive variable \"%s\"" ) % it->first ) );
+				}
 				const IECore::Data *inputData = it->second.data.get();
 				vertexFunctor.setIndices( it->second.indices.get() );
 				IECoreScene::PrimitiveVariableAlgos::IndexedData indexedData = dispatch( inputData, vertexFunctor );

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -1560,6 +1560,36 @@ class CurvesAlgoDeleteCurvesTest ( unittest.TestCase ):
 		self.assertEqual( actualCurves["eIndexed"].indices, IECore.IntVectorData( [0, 0, 0, 0, 0, 0] ) )
 		self.assertEqual( actualCurves["eIndexed"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 
+	def curvesBad( self ) :
+
+		testObject = IECoreScene.CurvesPrimitive(
+
+			IECore.IntVectorData( [ 2, 2 ] ),
+			IECore.CubicBasisf.linear(),
+			False,
+			IECore.V3fVectorData(
+				[
+					imath.V3f( 0, 0, 0 ),
+					imath.V3f( 0, 1, 0 ),
+					imath.V3f( 0, 0, 0 ),
+					imath.V3f( 1, 0, 0 )
+				]
+			)
+		)
+
+		testObject["a"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 5 ) ) )
+		testObject["b"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 3 ) ) )
+
+		return testObject
+
+	def testDeleteInvalidPrimVars( self ):
+
+		deletePrimVar = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+			IECore.IntVectorData( [1, 0] ) )
+
+		curves = self.curvesBad()
+		self.assertRaises( RuntimeError, IECoreScene.CurvesAlgo.deleteCurves, curves, deletePrimVar )
+
 
 class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
@@ -1668,6 +1698,9 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
 		newBSplineCurves = IECoreScene.CurvesAlgo.updateEndpointMultiplicity( bSplineCurves, IECore.CubicBasisf.bSpline() )
 		self.assertEqual( newBSplineCurves, bSplineCurves )
+
+
+	
 
 
 if __name__ == "__main__":

--- a/test/IECoreScene/MeshAlgoDeleteFacesTest.py
+++ b/test/IECoreScene/MeshAlgoDeleteFacesTest.py
@@ -349,5 +349,17 @@ class MeshAlgoDeleteFacesTest( unittest.TestCase ) :
 		self.assertEqual( facesDeletedMesh.creaseIds(), IECore.IntVectorData( [ 0, 1, 1, 2 ] ) )
 		self.assertEqual( facesDeletedMesh.creaseSharpnesses(), IECore.FloatVectorData( [ 1.0, 2.0 ] ) )
 
+	def testBadPrimitiveVariables( self ):
+
+		planeMesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 1, 1 ) )
+		planeMesh["a"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 5 ) ) )
+
+		planeMesh["b"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 5 ) ) )
+
+		primvarDelete = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform,
+			IECore.IntVectorData( [1] ) )
+
+		self.assertRaises( RuntimeError, IECoreScene.MeshAlgo.deleteFaces, planeMesh, primvarDelete  )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/PointsAlgoTest.py
+++ b/test/IECoreScene/PointsAlgoTest.py
@@ -455,6 +455,17 @@ class DeletePointsTest( unittest.TestCase ) :
 		self.assertEqual( points["indexed_b"].indices, IECore.IntVectorData( [0, 0, 1, 2, 2] ) )
 		self.assertEqual( points["indexed_b"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 
+	def testDeleteBadPrimVars( self ) :
+
+		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 4 ) ] ) )
+
+		points["a"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 5 ) ) )
+		points["b"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( range( 3 ) ) )
+
+		delete = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.IntVectorData( [1, 0, 1, 0] ) )
+
+		self.assertRaises( RuntimeError, IECoreScene.PointsAlgo.deletePoints, points, delete )
+
 
 class MergePointsTest( unittest.TestCase ) :
 


### PR DESCRIPTION
Belatedly cleaning up some commits from my branch when I was tracking down a tough Gaffer crash.

This wasn't the issue in the end, but it did muddy the waters:  DeleteFlagged isn't safe to call with bad prim vars, and this was causing some random crashes.