### PR TITLE
Nuke Scene Cache visibility support

### DIFF
--- a/include/IECoreNuke/SceneCacheReader.h
+++ b/include/IECoreNuke/SceneCacheReader.h
@@ -159,6 +159,7 @@ class IECORENUKE_API SceneCacheReader : public DD::Image::SourceGeo
 		std::string m_filter; // The text to filter the scene with.
 		bool m_worldSpace; // Set to ignore local transforms..
 		DD::Image::Matrix4 m_baseParentMatrix; // The global matrix that is applied to the geo.
+		bool m_visibilityFilter;
 
 		// Pointers to various knobs.
 		DD::Image::Knob *m_filePathKnob;
@@ -167,6 +168,7 @@ class IECORENUKE_API SceneCacheReader : public DD::Image::SourceGeo
 		DD::Image::Knob *m_tagFilterKnob;
 		DD::Image::Knob *m_sceneFilterKnob;
 		DD::Image::Knob *m_rootKnob;
+		DD::Image::Knob *m_visibilityFilterKnob;
 
 		// only the first reader allocates the shared data
 		SharedData *m_data;

--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -1055,6 +1055,17 @@ void SceneCacheReader::loadPrimitive( DD::Image::GeometryList &out, const std::s
 	if( sceneInterface )
 	{
 		double time = outputContext().frame() / DD::Image::root_real_fps();
+		if ( m_visibilityFilter )
+		{
+			if ( sceneInterface->hasAttribute( IECoreScene::SceneInterface::visibilityName ) )
+			{
+				IECore::ConstBoolDataPtr visibility = IECore::runTimeCast< const IECore::BoolData >( sceneInterface->readAttribute( IECoreScene::SceneInterface::visibilityName, time ) );
+				if ( !visibility->readable() )
+				{
+					return;
+				}
+			}
+		}
 		IECore::ConstObjectPtr object = sceneInterface->readObject( time );
 		IECoreScene::SceneInterface::Path rootPath;
 		if( m_worldSpace )

--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -264,8 +264,9 @@ void SceneCacheReader::knobs( DD::Image::Knob_Callback f )
 	);
 
 	Bool_knob( f, &m_worldSpace, "worldSpace", "World Space" );
+	SetFlags( f, DD::Image::Knob::STARTLINE | DD::Image::Knob::ALWAYS_SAVE | DD::Image::Knob::KNOB_CHANGED_ALWAYS );
 	Tooltip( f,
-		"Use world space as opposed to root."
+		"Use world space as opposed to root to calculate transform for each location."
 	);
 
 	// transform knobs

--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -157,12 +157,14 @@ SceneCacheReader::SceneCacheReader( Node *node )
 		m_root( "/" ),
 		m_filter( "" ),
 		m_worldSpace( false ),
+		m_visibilityFilter( false ),
 		m_filePathKnob( NULL ),
 		m_baseParentMatrixKnob( NULL ),
 		m_sceneKnob( NULL ),
 		m_tagFilterKnob( NULL ),
 		m_sceneFilterKnob( NULL ),
 		m_rootKnob( NULL ),
+		m_visibilityFilterKnob( NULL ),
 		m_data(NULL)
 {
 	m_baseParentMatrix.makeIdentity();
@@ -249,6 +251,12 @@ void SceneCacheReader::knobs( DD::Image::Knob_Callback f )
 	SetFlags( f, DD::Image::Knob::ALWAYS_SAVE | DD::Image::Knob::KNOB_CHANGED_ALWAYS );
 	Tooltip( f,
 		"Filter items in the scene by their tagged attributes."
+	);
+
+	m_visibilityFilterKnob = Bool_knob( f, &m_visibilityFilter, "visibilityFilter" );
+	SetFlags( f, DD::Image::Knob::STARTLINE | DD::Image::Knob::ALWAYS_SAVE | DD::Image::Knob::KNOB_CHANGED_ALWAYS );
+	Tooltip( f,
+		"Filter items in the scene based on their visibility attribute"
 	);
 
 	m_sceneFilterKnob = String_knob( f, &m_filter, "filterByName", "Filter Name" );
@@ -912,6 +920,7 @@ void SceneCacheReader::append( DD::Image::Hash &hash )
 	hash.append( sceneHash() );
 	hash.append( selectionHash(true) );
 	hash.append( m_worldSpace );
+	hash.append( m_visibilityFilter );
 	hash.append( outputContext().frame() );
 }
 
@@ -921,6 +930,7 @@ void SceneCacheReader::get_geometry_hash()
 	geo_hash[Group_Primitives].append( sceneHash() );
 	geo_hash[Group_Primitives].append( selectionHash() );
 	geo_hash[Group_Primitives].append( m_worldSpace );
+	geo_hash[Group_Primitives].append( m_visibilityFilter );
 
 	IECoreScene::ConstSceneCachePtr sceneInterface = IECore::runTimeCast< const IECoreScene::SceneCache >(getSceneInterface());
 	bool isAnimated = false;
@@ -936,6 +946,7 @@ void SceneCacheReader::get_geometry_hash()
 		geo_hash[*g].append( sceneHash() );
 		geo_hash[*g].append( selectionHash() );
 		geo_hash[*g].append( m_worldSpace );
+		geo_hash[*g].append( m_visibilityFilter );
 		if( isAnimated )
 		{
 			geo_hash[*g].append( outputContext().frame() );


### PR DESCRIPTION
Adds support for visibility attribute when reading scene cache in Nuke.
### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
