### PR TITLE
SceneShapeSubSceneOverride : check for viewport filtered elements

### DIFF
--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -68,6 +68,7 @@
 #include "maya/MSelectionList.h"
 #include "maya/MShaderManager.h"
 #include "maya/MUserData.h"
+#include "maya/M3dView.h"
 
 #include "boost/lexical_cast.hpp"
 
@@ -1356,7 +1357,30 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 		}
 	}
 
-	if( allInvisible )
+	// check if there are viewport filters that hide the shape
+	M3dView view;
+	MString panelName;
+	MSelectionList viewSelectedSet;
+	MObject component;
+	frameContext.renderingDestination( panelName );
+	view.getM3dViewFromModelPanel( panelName, view );
+	view.filteredObjectList( viewSelectedSet );
+
+	bool allInvisibleByFilter = false;
+	if ( view.viewIsFiltered() )
+	{
+		allInvisibleByFilter = true;
+		for( auto &instance : m_instances )
+		{
+			if ( viewSelectedSet.hasItemPartly( instance.path, component ) )
+			{
+				allInvisibleByFilter = false;
+				break;
+			}
+		}
+	}
+
+	if( allInvisible || allInvisibleByFilter )
 	{
 		return; // no need to do any scene traversing
 	}


### PR DESCRIPTION
SceneShapeSubSceneOverride : check for viewport filtered elements, otherwise VP2 isolate select will still traverse the locations and create renderItems. 



### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
