### PR TITLE
IECoreArnold::CameraAlgo : Set FOV from focalLength/aperture

### DIFF
--- a/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
@@ -70,6 +70,15 @@ class CameraAlgoTest( unittest.TestCase ) :
 			self.assertAlmostEqual( screenWindowMult * arnold.AiNodeGetVec2( n, "screen_window_min" ).y, screenWindow.min()[1] )
 			self.assertAlmostEqual( screenWindowMult * arnold.AiNodeGetVec2( n, "screen_window_max" ).x, screenWindow.max()[0] )
 			self.assertAlmostEqual( screenWindowMult * arnold.AiNodeGetVec2( n, "screen_window_max" ).y, screenWindow.max()[1] )
+			
+			# For perspective cameras, we set a FOV value that drives the effective screen window.
+			# As long as pixels aren't distorted, and there is no aperture offset,
+			# applying Arnold's automatic screen window computation to a default screen window
+			# should give us the correct result
+			self.assertEqual( arnold.AiNodeGetVec2( n, "screen_window_min" ).x, -1.0 )
+			self.assertEqual( arnold.AiNodeGetVec2( n, "screen_window_min" ).y, -1.0 )
+			self.assertEqual( arnold.AiNodeGetVec2( n, "screen_window_max" ).x, 1.0 )
+			self.assertEqual( arnold.AiNodeGetVec2( n, "screen_window_max" ).y, 1.0 )
 
 	def testConvertCustomProjection( self ) :
 
@@ -159,6 +168,10 @@ class CameraAlgoTest( unittest.TestCase ) :
 				self.assertAlmostEqual( windowScale * arnold.AiNodeGetVec2( n, "screen_window_min" ).y, cortexWindowScale * cortexWindow.min()[1] * aspect, places = 4 )
 				self.assertAlmostEqual( windowScale * arnold.AiNodeGetVec2( n, "screen_window_max" ).x, cortexWindowScale * cortexWindow.max()[0], places = 4 )
 				self.assertAlmostEqual( windowScale * arnold.AiNodeGetVec2( n, "screen_window_max" ).y, cortexWindowScale * cortexWindow.max()[1] * aspect, places = 4 )
+			
+				if c.parameters()["projection"].value == "perspective":	
+					self.assertAlmostEqual( arnold.AiNodeGetVec2( n, "screen_window_max" ).x - arnold.AiNodeGetVec2( n, "screen_window_min" ).x, 2.0, places = 6 )
+					self.assertAlmostEqual( arnold.AiNodeGetVec2( n, "screen_window_max" ).y - arnold.AiNodeGetVec2( n, "screen_window_min" ).y, 2.0, places = 6 )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
We store the camera frustum as a focalLength and aperture.  Arnold stores it redundantly with both a screenWindow and a FOV.  Either can be used to control the frustum, but if you want the correct NDC space to be given to uv_remap shaders, you have to use FOV.  This PR computes a FOV from the focalLength/aperture, and compensates the screenWindow accordingly.  This results in a screenWindow that will be left at the default -1 to 1 value ( down to floating point error ), unless there is an aperture offset or stretched pixels.

This is a somewhat scary change, just because any small change to camera transforms could have crucial effects on rendering ( which is why I preferred not to introduce the floating point error of an extra trig operation originally ).  But the tests were already written to check that the combined screen_window and FOV produced the correct results, so the tests are all passing with this ( I added some extra to check that we're usually leaving the screenWindow defaulted now ).  I did some test renders with a bunch of weird camera parameters, and everything matched before and after down to floating point precision, so this should be good to go.

I've also double checked, and after this change, as long as there is no aperture offset, the coordinates supplied to uv_remap and filtermap match exactly, which should make anyone trying to use uv_remap happier.