### PR TITLE
Houdini LiveScene : Release GIL during construction.

### DIFF
--- a/src/IECoreHoudini/bindings/LiveSceneBinding.cpp
+++ b/src/IECoreHoudini/bindings/LiveSceneBinding.cpp
@@ -70,6 +70,10 @@ LiveScenePtr constructor( const std::string n, const list &c, const list &r, dou
 	listToPath( c, contentPath );
 	listToPath( r, rootPath );
 
+	// constructing a LiveScene can cause SOPs to cook (via the DetailSplitter),
+	// which can cause further python evaluations (eg parm expressions), so we
+	// must release the GIL to avoid deadlocks.
+	IECorePython::ScopedGILRelease gilRelease;
 	return new LiveScene( nodePath, contentPath, rootPath, defaultTime );
 }
 


### PR DESCRIPTION
Constructing a LiveScene can cause SOPs to cook (via the DetailSplitter), which can cause further python evaluations (eg parm expressions), so we must release the GIL to avoid deadlocks.