### PR TITLE
DataTraits : CompoundDataBase should not instantiate from element

### DIFF
--- a/python/IECore/DataTraits.py
+++ b/python/IECore/DataTraits.py
@@ -190,7 +190,7 @@ __dataTypesConversionDict = {
 	#IECore.Color4dVectorData: (list, False, IECore.Color4d),
 
 	IECore.CompoundData: (dict, True, None),
-	IECore.CompoundDataBase: (dict, True, None),
+	IECore.CompoundDataBase: (dict, False, None),
 
 	IECore.TransformationMatrixfData: ( IECore.TransformationMatrixf, True ),
 	IECore.TransformationMatrixdData: ( IECore.TransformationMatrixd, True ),


### PR DESCRIPTION
- DataTraits : CompoundDataBase should not instantiate from element

Without this fix I was having difficulties using `IECore.dataFromElement()` when the element was a dictionary.

It would randomly work or fail depending on whether we picked the `CompoundDataBase` (which doesn't work) or the `CompoundData` (which works).
