### PR TITLE
Maya LiveScene : ieAttr updates

### DIFF
--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -355,10 +355,12 @@ void LiveScene::attributeNames( NameList &attrs ) const
 	{
 		MObject attr = fnNode.attribute( i );
 		MFnAttribute fnAttr( attr );
-		MString attrName = fnAttr.name();
-		if( attrName.length() > 7 && ( strstr( attrName.asChar(),"ieAttr_" ) == attrName.asChar() ) )
+		std::string attrName = fnAttr.name().asChar();
+		if( attrName.length() > 7 && ( attrName.find( "ieAttr_" ) == 0 ) )
 		{
-			attrs.push_back( ( "user:" + attrName.substring( 7, attrName.length()-1 ) ).asChar() );
+			attrName = attrName.substr( 7, attrName.length() - 1 );
+			boost::replace_all( attrName, "__", ":" );
+			attrs.push_back( "user:" + attrName );
 		}
 	}
 
@@ -463,7 +465,12 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 
 		MStatus st;
 		MFnDependencyNode fnNode( m_dagPath.node() );
-		MPlug attrPlug = fnNode.findPlug( ( "ieAttr_" + name.string().substr(5) ).c_str(), false, &st );
+		std::string attrName = name.string().substr(5).c_str();
+
+		boost::replace_all( attrName, ":", "__" );
+		attrName = "ieAttr_" + attrName;
+
+		MPlug attrPlug = fnNode.findPlug( attrName.c_str(), false, &st );
 		if( st )
 		{
 			FromMayaConverterPtr plugConverter = FromMayaPlugConverter::create( attrPlug );

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -389,10 +389,18 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 		if( name == SceneInterface::visibilityName )
 		{
 			bool visible = true;
+			bool usingIeVis = true;
 
 			MStatus st;
 			MFnDagNode dagFn( m_dagPath );
-			MPlug visibilityPlug = dagFn.findPlug( MPxTransform::visibility, &st );
+			MPlug visibilityPlug;
+
+			visibilityPlug = dagFn.findPlug( "ieVisibility", &st );
+			if ( !st )
+			{
+				usingIeVis = false;
+				visibilityPlug = dagFn.findPlug( MPxTransform::visibility, &st );
+			}
 			if( st )
 			{
 				visible = visibilityPlug.asBool();
@@ -442,10 +450,18 @@ ConstObjectPtr LiveScene::readAttribute( const Name &name, double time ) const
 				if( childDag.isValid() )
 				{
 					MFnDagNode dagFn( childDag );
-					MPlug visibilityPlug = dagFn.findPlug( MPxSurfaceShape::visibility, &st );
-					if( st )
+					MPlug ieVisibilityPlug = dagFn.findPlug( "ieVisibility", &st );
+					if ( usingIeVis && st )
 					{
-						visible = visibilityPlug.asBool();
+						visible = ieVisibilityPlug.asBool();
+					}
+					if ( !usingIeVis )
+					{
+						MPlug visibilityPlug = dagFn.findPlug( MPxSurfaceShape::visibility, &st );
+						if( st )
+						{
+							visible = visibilityPlug.asBool();
+						}
 					}
 				}
 

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -670,6 +670,7 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		maya.cmds.addAttr( t, ln="ieAttr_time", at="time" )
 		maya.cmds.addAttr( t, ln="ieAttr_fltMatrix", at="fltMatrix" )
 		maya.cmds.addAttr( t, ln="ieAttr_string", dt="string" )
+		maya.cmds.addAttr( t, ln="ieAttr_with__namespace", dt="string" )
 
 		scene = IECoreMaya.LiveScene()
 		transformScene = scene.child(str(t))
@@ -685,7 +686,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 				"user:message",
 				"user:time",
 				"user:fltMatrix",
-				"user:string"
+				"user:string",
+				"user:with:namespace"
 			] )
 		)
 
@@ -698,6 +700,7 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		self.failUnless( isinstance( transformScene.readAttribute("user:time",0), IECore.DoubleData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:fltMatrix",0), IECore.M44dData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:string",0), IECore.StringData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:with:namespace",0), IECore.StringData ) )
 
 	def testCustomAttributes( self ) :
 

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -955,6 +955,26 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 		self.assertEqual( t2.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 
+		# test override of maya visibility with ieVisibility attribute
+		maya.cmds.addAttr( "t1", ln="ieVisibility", at="bool" )
+		maya.cmds.setAttr( "t1.visibility", False )
+		maya.cmds.setAttr( "m1.visibility", False )
+		maya.cmds.setAttr( "t1.ieVisibility", True )
+		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( True ) )
+
+		# shape ieVisibility should be ignored since we set the transform level to invisible
+		maya.cmds.addAttr( "m1", ln="ieVisibility", at="bool" )
+		maya.cmds.setAttr( "t1.visibility", False )
+		maya.cmds.setAttr( "t1.ieVisibility", False )
+		maya.cmds.setAttr( "m1.ieVisibility", True )
+		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
+
+		# shape ieVisibility should override the transform ieVisibility
+		maya.cmds.setAttr( "t1.visibility", False )
+		maya.cmds.setAttr( "t1.ieVisibility", True )
+		maya.cmds.setAttr( "m1.ieVisibility", False )
+		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
+
 	def testSceneShapeVisible( self ) :
 
 		# make sure we are at time 0


### PR DESCRIPTION
With those changes we will be able to translate `__` (double underscores) in attribute names to `:` (colons). This change is necessary to make the assetVariation attributes flow through the pipeline correctly, since we need to propagate detail attributes with namespaces.
Also we can now override the maya visibility an `ieVisibility` attribute.

LiveScene : (#956)
 - for ieAttrs, translate double underscore to colon
 - set visibility with ieVisibility if available

LiveSceneTest :  (#956)
 - added test for converting '__' to ':' in attr names
 - added tests for ieVisibility

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
