### PR TITLE
Added FromMayaEnumPlugConverter

### DIFF
--- a/include/IECoreMaya/FromMayaEnumPlugConverter.h
+++ b/include/IECoreMaya/FromMayaEnumPlugConverter.h
@@ -1,0 +1,75 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IE_COREMAYA_FROMMAYAENUMPLUGCONVERTER_H
+#define IE_COREMAYA_FROMMAYAENUMPLUGCONVERTER_H
+
+#include "IECoreMaya/FromMayaPlugConverter.h"
+
+#include "IECore/SimpleTypedData.h"
+
+
+namespace IECoreMaya
+{
+
+template<typename T>
+class IECOREMAYA_API FromMayaEnumPlugConverter : public FromMayaPlugConverter
+{
+
+	public :
+
+		IECORE_RUNTIMETYPED_DECLARETEMPLATE( FromMayaEnumPlugConverter, FromMayaPlugConverter )
+
+		FromMayaEnumPlugConverter( const MPlug &plug );
+
+		// Attribute category we can add to an enum, so it automatically
+		// converts the enum field to StringData (without having to specify the resultType)
+		static const MString convertToStringCategory;
+
+	protected :
+
+		virtual IECore::ObjectPtr doConversion( IECore::ConstCompoundObjectPtr operands ) const;
+
+	private :
+
+		static Description<FromMayaEnumPlugConverter> m_description;
+
+};
+
+typedef FromMayaEnumPlugConverter<IECore::StringData> FromMayaEnumPlugConverterst;
+typedef FromMayaEnumPlugConverter<IECore::ShortData> FromMayaEnumPlugConvertersh;
+
+} // namespace IECoreMaya
+
+#endif // IE_COREMAYA_FROMMAYAENUMPLUGCONVERTER_H

--- a/include/IECoreMaya/TypeIds.h
+++ b/include/IECoreMaya/TypeIds.h
@@ -127,6 +127,8 @@ enum TypeId
 	FromMayaNumericPlugConverterssTypeId = 109080,
 	FromMayaSkinClusterWeightsConverterTypeId = 109081,
 	ToMayaSkinClusterWeightsConverterTypeId = 109082,
+	FromMayaEnumPlugConverterstTypeId = 109083,
+	FromMayaEnumPlugConvertershTypeId = 109084,
 	// Remember to update TypeIdBinding.cpp
 	LastTypeId = 109999
 };

--- a/include/IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.h
+++ b/include/IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.h
@@ -1,0 +1,45 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREMAYA_FROMMAYAENUMPLUGCONVERTERBINDING_H
+#define IECOREMAYA_FROMMAYAENUMPLUGCONVERTERBINDING_H
+
+namespace IECoreMaya
+{
+
+void bindFromMayaEnumPlugConverter();
+
+}
+
+#endif // IECOREMAYA_FROMMAYAENUMPLUGCONVERTERBINDING_H

--- a/src/IECoreMaya/FromMayaEnumPlugConverter.cpp
+++ b/src/IECoreMaya/FromMayaEnumPlugConverter.cpp
@@ -1,0 +1,77 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreMaya/FromMayaEnumPlugConverter.h"
+
+#include "IECore/MessageHandler.h"
+
+#include "maya/MString.h"
+#include "maya/MFnEnumAttribute.h"
+
+
+
+using namespace IECore;
+
+namespace IECoreMaya
+{
+
+
+template<typename T>
+const MString FromMayaEnumPlugConverter<T>::convertToStringCategory = "ieConvertToStringData";
+
+template<typename T>
+FromMayaEnumPlugConverter<T>::FromMayaEnumPlugConverter( const MPlug &plug )
+	: FromMayaPlugConverter( plug )
+{
+}
+
+template<>
+IECore::ObjectPtr FromMayaEnumPlugConverter<IECore::ShortData>::doConversion( IECore::ConstCompoundObjectPtr operands ) const
+{
+	return new IECore::ShortData( plug().asShort() );
+}
+
+template<>
+IECore::ObjectPtr FromMayaEnumPlugConverter<IECore::StringData>::doConversion( IECore::ConstCompoundObjectPtr operands ) const
+{
+	MFnEnumAttribute fne( plug().attribute() );
+	return new IECore::StringData( fne.fieldName( plug().asShort() ).asChar() );
+}
+
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaEnumPlugConverterst, FromMayaEnumPlugConverterstTypeId )
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( FromMayaEnumPlugConvertersh, FromMayaEnumPlugConvertershTypeId )
+
+template class FromMayaEnumPlugConverter<IECore::StringData>;
+template class FromMayaEnumPlugConverter<IECore::ShortData>;
+}

--- a/src/IECoreMaya/FromMayaPlugConverter.cpp
+++ b/src/IECoreMaya/FromMayaPlugConverter.cpp
@@ -43,6 +43,7 @@
 #include "IECore/MessageHandler.h"
 
 #include "IECoreMaya/FromMayaObjectConverter.h"
+#include "IECoreMaya/FromMayaEnumPlugConverter.h"
 #include "IECoreMaya/FromMayaPlugConverter.h"
 
 using namespace IECoreMaya;
@@ -206,23 +207,14 @@ FromMayaConverterPtr FromMayaPlugConverter::create( const MPlug &plug, IECore::T
 	}
 	if( attribute.hasFn( MFn::kEnumAttribute ) )
 	{
-		// return FromMayaNumericPlugConverter<short, IECore::ShortData>(plug);
 		MFnEnumAttribute fnEAttr( attribute );
-
-		const NumericTypesToFnsMap &m = numericTypesToFns();
-		NumericTypesToFnsMap::const_iterator it = m.find( NumericTypePair( MFnNumericData::kShort , resultType ) );
-		if( it!=m.end() )
+		if ( resultType == IECore::TypeId::StringDataTypeId || ( resultType == IECore::InvalidTypeId && fnEAttr.hasCategory( FromMayaEnumPlugConverter<IECore::StringData>::convertToStringCategory ) ) )
 		{
-			return it->second( plug );
+			return new FromMayaEnumPlugConverter<IECore::StringData>( plug );
 		}
-		NumericDefaultConvertersMap &dc = numericDefaultConverters();
-		NumericDefaultConvertersMap::const_iterator dcIt = dc.find( MFnNumericData::kShort );
-		if( dcIt != dc.end() )
+		else
 		{
-			if( resultType==IECore::InvalidTypeId || RunTimeTyped::inheritsFrom( dcIt->second->first.second, resultType ) )
-			{
-				return dcIt->second->second( plug );
-			}
+			return new FromMayaEnumPlugConverter<IECore::ShortData>( plug );
 		}
 	}
 

--- a/src/IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.cpp
+++ b/src/IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.cpp
@@ -1,0 +1,60 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "boost/python.hpp"
+
+#include "IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.h"
+
+#include "IECoreMaya/FromMayaEnumPlugConverter.h"
+
+#include "IECorePython/RunTimeTypedBinding.h"
+
+#include "maya/MString.h"
+
+
+using namespace IECoreMaya;
+using namespace boost::python;
+
+void IECoreMaya::bindFromMayaEnumPlugConverter()
+{
+	{
+		scope sh = IECorePython::RunTimeTypedClass<FromMayaEnumPlugConvertersh>();
+		sh.attr( "convertToStringCategory" ) = FromMayaEnumPlugConvertersh::convertToStringCategory.asChar();
+	}
+
+	{
+		scope st = IECorePython::RunTimeTypedClass<FromMayaEnumPlugConverterst>();
+		st.attr( "convertToStringCategory" ) = FromMayaEnumPlugConverterst::convertToStringCategory.asChar();
+	}
+}

--- a/src/IECoreMaya/bindings/IECoreMaya.cpp
+++ b/src/IECoreMaya/bindings/IECoreMaya.cpp
@@ -96,6 +96,7 @@
 #include "IECoreMaya/bindings/FromMayaLocatorConverterBinding.h"
 #include "IECoreMaya/bindings/ToMayaLocatorConverterBinding.h"
 #include "IECoreMaya/bindings/FromMayaInstancerConverterBinding.h"
+#include "IECoreMaya/bindings/FromMayaEnumPlugConverterBinding.h"
 
 using namespace IECore;
 using namespace IECoreMaya;
@@ -165,4 +166,5 @@ BOOST_PYTHON_MODULE(_IECoreMaya)
 	bindFromMayaLocatorConverter();
 	bindToMayaLocatorConverter();
 	bindFromMayaInstancerConverter();
+	bindFromMayaEnumPlugConverter();
 }

--- a/test/IECoreMaya/FromMayaPlugConverterTest.py
+++ b/test/IECoreMaya/FromMayaPlugConverterTest.py
@@ -74,8 +74,11 @@ class FromMayaPlugConverterTest( IECoreMaya.TestCase ) :
 		converter = IECoreMaya.FromMayaPlugConverter.create( locator + ".scaleX", IECore.FloatData.staticTypeId() )
 		self.failUnless( converter.isInstanceOf( IECoreMaya.FromMayaNumericPlugConverterdf.staticTypeId() ) )
 
-		converter = IECoreMaya.FromMayaPlugConverter.create( str( locator ) + ".testEnum" )
-		self.failUnless( converter.isInstanceOf( IECoreMaya.FromMayaNumericPlugConverterss.staticTypeId() ) )
+		converter = IECoreMaya.FromMayaPlugConverter.create( str( locator ) + ".testEnum", IECore.StringData.staticTypeId() )
+		self.failUnless( converter.isInstanceOf( IECoreMaya.FromMayaEnumPlugConverterst.staticTypeId() ) )
+
+		converter = IECoreMaya.FromMayaPlugConverter.create( str( locator ) + ".testEnum", IECore.ShortData.staticTypeId() )
+		self.failUnless( converter.isInstanceOf( IECoreMaya.FromMayaEnumPlugConvertersh.staticTypeId() ) )
 
 	def testTypedConverterFactory( self ) :
 
@@ -215,6 +218,12 @@ class FromMayaPlugConverterTest( IECoreMaya.TestCase ) :
 		self.assert_(isinstance(cValue, attr[1]))
 		self.assertAlmostEqual(cValue.value, attr[2])
 
+		# read enum as string
+		converter = IECoreMaya.FromMayaPlugConverter.create( IECoreMaya.plugFromString(locator + '.' + attr[0]), IECore.StringData.staticTypeId() )
+		self.assert_(converter)
+		cValue = converter.convert()
+		self.assert_(isinstance(cValue, IECore.StringData))
+		self.assertAlmostEqual(cValue.value, "B")
 
 if __name__ == "__main__":
 	IECoreMaya.TestProgram()

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -672,6 +672,14 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		maya.cmds.addAttr( t, ln="ieAttr_string", dt="string" )
 		maya.cmds.addAttr( t, ln="ieAttr_with__namespace", dt="string" )
 
+		maya.cmds.addAttr( t, ln="ieAttr_enum", at="enum", en="ABC:DEF:"  )
+		maya.cmds.addAttr( t, ln="ieAttr_enumAsString", at="enum", en="GHI:JKL:"  )
+
+		# add ieConvertToStringData category
+		p = IECoreMaya.plugFromString( t+'.ieAttr_enumAsString' )
+		fn = OpenMaya.MFnEnumAttribute( p.attribute() )
+		fn.addToCategory( IECoreMaya.FromMayaEnumPlugConverterst.convertToStringCategory )
+
 		scene = IECoreMaya.LiveScene()
 		transformScene = scene.child(str(t))
 
@@ -679,6 +687,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 			set( [
 				"scene:visible",
 				"user:bool",
+				"user:enum",
+				"user:enumAsString",
 				"user:float",
 				"user:double",
 				"user:doubleAngle",
@@ -692,6 +702,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		)
 
 		self.failUnless( isinstance( transformScene.readAttribute("user:bool",0), IECore.BoolData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:enum",0), IECore.ShortData ) )
+		self.failUnless( isinstance( transformScene.readAttribute("user:enumAsString",0), IECore.StringData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:float",0), IECore.FloatData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:double",0), IECore.DoubleData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:doubleAngle",0), IECore.DoubleData ) )


### PR DESCRIPTION
Currently we can only convert maya enums to short data. Those changes add a `FromMayaEnumPlugConverter` with ShortData and StringData result types to also be able to read the string value of an enum. To tag an enum attribute to be read as string, without specifying the resultType explicitly, we can add a `category` to the attribute. 

This update is necessary to be able to read the assetVariation enum on a rig.


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
