### PR TITLE
SConstruct : Declare Appleseed test dependency on IECoreScene module

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3251,7 +3251,7 @@ if doConfigure :
 		appleseedTestEnv["ENV"]["APPLESEED_SEARCHPATH"] = os.getcwd() + "/contrib/IECoreAppleseed/test/IECoreAppleseed/plugins"
 		appleseedTest = appleseedTestEnv.Command( "contrib/IECoreAppleseed/test/IECoreAppleseed/results.txt", appleseedPythonModule, pythonExecutable + " $TEST_APPLESEED_SCRIPT" )
 		NoCache( appleseedTest )
-		appleseedTestEnv.Depends( appleseedTest, [ corePythonModule, appleseedPythonModule, appleseedLibrary, appleseedDriverForTest ] )
+		appleseedTestEnv.Depends( appleseedTest, [ corePythonModule, scenePythonModule, appleseedPythonModule, appleseedLibrary, appleseedDriverForTest ] )
 		appleseedTestEnv.Depends( appleseedTest, glob.glob( "contrib/IECoreAppleseed/test/IECoreAppleseed/*.py" ) )
 		appleseedTestEnv.Alias( "testAppleseed", appleseedTest )
 


### PR DESCRIPTION
This omission was causing sporadic test failures on Travis.
