### PR TITLE
ExceptionBinding : Avoid `boost::make_unique`

### DIFF
--- a/include/IECorePython/ExceptionBinding.inl
+++ b/include/IECorePython/ExceptionBinding.inl
@@ -35,8 +35,6 @@
 #ifndef IECOREPYTHON_EXCEPTIONBINDING_INL
 #define IECOREPYTHON_EXCEPTIONBINDING_INL
 
-#include "boost/make_unique.hpp"
-
 namespace IECorePython
 {
 
@@ -138,7 +136,7 @@ ExceptionClass<T>::ExceptionClass( const char *className, PyObject *base )
 	// `ExceptionClass.def()`.
 	{
 		boost::python::scope privateScope( exceptionClassObject );
-		m_implementationClass = boost::make_unique<ImplementationClass>( "__Implementation", boost::python::no_init );
+		m_implementationClass.reset( new ImplementationClass( "__Implementation", boost::python::no_init ) );
 		m_implementationClass->def( "__exceptionPointer", &Detail::implementationExceptionPointer<T> );
 		m_implementationClass->def( "__str__", &Detail::implementationStr<T> );
 	}


### PR DESCRIPTION
VFXPlatform says we can use `std::make_unique` as of 2018, because that mandates C++14. But we're still supporting C++11 because of certain DCCs. VFXPlatform says we can use `boost::make_unique` as of 2017, because that mandates Boost 1.61. But apparently we're still supporting Boost 1.55 for RV. VFXPlatform needs teeth.
