### PR TITLE
ExceptionBinding : add needed include for Boost-1.55 compatibility

### DIFF
--- a/include/IECorePython/ExceptionBinding.inl
+++ b/include/IECorePython/ExceptionBinding.inl
@@ -35,6 +35,8 @@
 #ifndef IECOREPYTHON_EXCEPTIONBINDING_INL
 #define IECOREPYTHON_EXCEPTIONBINDING_INL
 
+#include "boost/python/raw_function.hpp"
+
 namespace IECorePython
 {
 


### PR DESCRIPTION
Hey John,

as per our chat - this should be ok?

I think I'll try to retag the a58 release to include this once we've merged...

Thanks,

Matti.