### PR TITLE
Dont use libAlembic_sidefx for Houdini 17.0

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -330,6 +330,9 @@ if targetApp=="houdini" :
 	# boost install with an "h" prefix on the includes, libs, and even macros like HBOOST_VERSION.
 	BOOST_INCLUDE_PATH = "/software/tools/include/" + platform + "/boost/" + boostVersion
 
+	# we are not using libAlembic_sidefx for all versions of Houdini.
+	ALEMBIC_LIB_SUFFIX = ""
+
 	# houdini 17 ships its own USD so we link against that
 	if distutils.version.LooseVersion(houdiniVersion) >= distutils.version.LooseVersion("17.0") :
 		TBB_INCLUDE_PATH = "$HOUDINI_INCLUDE_PATH"
@@ -337,7 +340,6 @@ if targetApp=="houdini" :
 		TBB_LIB_SUFFIX = ""
 		OPENEXR_LIB_SUFFIX = ""
 		GLEW_LIB_SUFFIX = ""
-		ALEMBIC_LIB_SUFFIX = "_sidefx"
 		VDB_LIB_SUFFIX = "_sesi"
 		USD_INCLUDE_PATH = "$HOUDINI_INCLUDE_PATH"
 		USD_LIB_PATH = "$HOUDINI_LIB_PATH"
@@ -345,8 +347,6 @@ if targetApp=="houdini" :
 		WITH_USD_MONOLITHIC = True
 
 	HOUDINI_CXX_FLAGS = " ".join( houdiniReg['compilerFlags'] )
-	if distutils.version.LooseVersion(houdiniVersion) >= distutils.version.LooseVersion("17.5") :
-		ALEMBIC_LIB_SUFFIX = ""
 
 	INSTALL_HOUDINILIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 	INSTALL_HOUDINIPLUGIN_NAME = os.path.join( appPrefix, "plugins", "$IECORE_NAME" )


### PR DESCRIPTION
Fixes
---

- SConstruct: Since we change the order of include file for Houdini unconditionally to add support for Houdini 17.5, we can't use `libAlembic_sidefx` for Houdini 17.0 either anymore. (#974)

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
