### PR TITLE
Houdini scene visibility improvements

### DIFF
--- a/include/IECoreHoudini/OBJ_SceneCacheTransform.h
+++ b/include/IECoreHoudini/OBJ_SceneCacheTransform.h
@@ -107,6 +107,7 @@ class IECOREHOUDINI_API OBJ_SceneCacheTransform : public OBJ_SceneCacheNode<OBJ_
 			UT_StringMMPattern tagFilter;
 			UT_String fullPathName;
 			bool tagGroups;
+			bool visibilityFilter;
 		};
 
 		/// Called by expandHierarchy() and doExpandChildren() when the SceneCache contains an object.

--- a/include/IECoreHoudini/SOP_SceneCacheSource.h
+++ b/include/IECoreHoudini/SOP_SceneCacheSource.h
@@ -60,7 +60,6 @@ class IECOREHOUDINI_API SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 		static OP_TemplatePair *buildParameters();
 
 		static PRM_Name pObjectOnly;
-		static PRM_Name pVisibilityFilter;
 
 		bool getObjectOnly() const;
 		void setObjectOnly( bool objectOnly );
@@ -86,6 +85,8 @@ class IECOREHOUDINI_API SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 			bool tagGroups;
 			bool hasAnimatedTopology;
 			bool hasAnimatedPrimVars;
+			bool visibilityFilter;
+			bool inheritedVisibility;
 			std::vector<IECore::InternedString> animatedPrimVars;
 			std::map<std::string, GA_Range> namedRanges;
 		};
@@ -98,7 +99,7 @@ class IECOREHOUDINI_API SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 		// Convert the object to Houdini, optimizing for animated primitive variables if possible.
 		bool convertObject( const IECore::Object *object, const std::string &name, const IECoreScene::SceneInterface *scene, Parameters &params );
 
-		void loadObjects( const IECoreScene::SceneInterface *scene, Imath::M44d transform, double time, Space space, Parameters &params, size_t rootSize, std::string currentPath, bool inheritedVisibility=true );
+		void loadObjects( const IECoreScene::SceneInterface *scene, Imath::M44d transform, double time, Space space, Parameters &params, size_t rootSize, std::string currentPath );
 		IECoreScene::MatrixTransformPtr matrixTransform( Imath::M44d t );
 		std::string relativePath( const IECoreScene::SceneInterface *scene, size_t rootSize );
 

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -72,6 +72,7 @@ class IECOREHOUDINI_API SceneCacheNode : public BaseType
 		static PRM_Name pTagGroups;
 		static PRM_Name pShapeFilter;
 		static PRM_Name pFullPathName;
+		static PRM_Name pVisibilityFilter;
 
 		static PRM_Default rootDefault;
 		static PRM_Default spaceDefault;
@@ -124,6 +125,8 @@ class IECOREHOUDINI_API SceneCacheNode : public BaseType
 		void getTagFilter( UT_String &filter ) const;
 		void getTagFilter( UT_StringMMPattern &filter ) const;
 		void setTagFilter( const UT_String &filter );
+		bool getVisibilityFilter() const;
+		void setVisibilityFilter( bool visibilityFilter );
 		bool getTagGroups() const;
 		void setTagGroups( bool tagGroups );
 		void getShapeFilter( UT_String &filter ) const;

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -127,6 +127,8 @@ class IECOREHOUDINI_API SceneCacheNode : public BaseType
 		void setTagFilter( const UT_String &filter );
 		bool getVisibilityFilter() const;
 		void setVisibilityFilter( bool visibilityFilter );
+		void setVisibilityExpression();
+		void clearVisibilityExpression();
 		bool getTagGroups() const;
 		void setTagGroups( bool tagGroups );
 		void getShapeFilter( UT_String &filter ) const;

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -150,6 +150,8 @@ class IECOREHOUDINI_API SceneCacheNode : public BaseType
 		/// Determine if the given scene has any tag matching the filter
 		static bool tagged( const IECoreScene::SceneInterface *scene, const UT_StringMMPattern &filter );
 
+		bool visibility( double frame ) const;
+
 	protected :
 
 		/// Access point to the actual SceneCache. All derived classes should only access the cache

--- a/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheGeometry.cpp
@@ -129,6 +129,7 @@ void OBJ_SceneCacheGeometry::pushToHierarchy()
 		sop->setAttributeCopy( attribCopy );
 		sop->setTagFilter( tagFilter );
 		sop->setTagGroups( tagGroups );
+		sop->setVisibilityFilter( getVisibilityFilter() );
 		sop->setShapeFilter( shapeFilter );
 		sop->setFullPathName( fullPathName );
 		sop->setGeometryType( (SOP_SceneCacheSource::GeometryType)geomType );
@@ -161,6 +162,7 @@ void OBJ_SceneCacheGeometry::doExpandGeometry( const SceneInterface *scene )
 	getTagFilter( tagFilter );
 	sop->setTagFilter( tagFilter );
 	sop->setTagGroups( getTagGroups() );
+	sop->setVisibilityFilter( getVisibilityFilter() );
 	getShapeFilter( shapeFilter );
 	sop->setShapeFilter( shapeFilter );
 	getFullPathName( fullPathName );

--- a/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
@@ -406,6 +406,14 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 				xform->setTagFilter( tagFilterStr );
 				xform->setTagGroups( tagGroups );
 				xform->setVisibilityFilter( visibilityFilter );
+				if ( visibilityFilter )
+				{
+					xform->setVisibilityExpression();
+				}
+				else
+				{
+					xform->clearVisibilityExpression();
+				}
 			}
 		}
 
@@ -435,6 +443,14 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 				geo->setTagFilter( tagFilterStr );
 				geo->setTagGroups( tagGroups );
 				geo->setVisibilityFilter( visibilityFilter );
+				if ( visibilityFilter )
+				{
+					geo->setVisibilityExpression();
+				}
+				else
+				{
+					geo->clearVisibilityExpression();
+				}
 			}
 		}
 

--- a/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
+++ b/src/IECoreHoudini/OBJ_SceneCacheTransform.cpp
@@ -147,6 +147,7 @@ void OBJ_SceneCacheTransform::expandHierarchy( const SceneInterface *scene )
 	params.depth = (Depth)evalInt( pDepth.getToken(), 0, 0 );
 	params.hierarchy = (Hierarchy)evalInt( pHierarchy.getToken(), 0, 0 );
 	params.tagGroups = getTagGroups();
+	params.visibilityFilter = getVisibilityFilter();
 	getAttributeFilter( params.attributeFilter );
 	getAttributeCopy( params.attributeCopy );
 	getShapeFilter( params.shapeFilter );
@@ -372,6 +373,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 {
 	UT_String attribFilter, attribCopy, shapeFilter, fullPathName;
 	bool tagGroups = getTagGroups();
+	bool visibilityFilter = getVisibilityFilter();
 	getAttributeFilter( attribFilter );
 	getAttributeCopy( attribCopy );
 	getShapeFilter( shapeFilter );
@@ -403,6 +405,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 				visible = true;
 				xform->setTagFilter( tagFilterStr );
 				xform->setTagGroups( tagGroups );
+				xform->setVisibilityFilter( visibilityFilter );
 			}
 		}
 
@@ -431,6 +434,7 @@ void OBJ_SceneCacheTransform::pushToHierarchy()
 			{
 				geo->setTagFilter( tagFilterStr );
 				geo->setTagGroups( tagGroups );
+				geo->setVisibilityFilter( visibilityFilter );
 			}
 		}
 
@@ -455,6 +459,7 @@ OBJ_SceneCacheTransform::Parameters::Parameters( const Parameters &other )
 	tagFilterStr = other.tagFilterStr;
 	tagFilter.compile( tagFilterStr );
 	tagGroups = other.tagGroups;
+	visibilityFilter = other.visibilityFilter;
 	fullPathName = other.fullPathName;
 }
 

--- a/src/IECoreHoudini/SceneCacheNode.cpp
+++ b/src/IECoreHoudini/SceneCacheNode.cpp
@@ -101,6 +101,9 @@ template<typename BaseType>
 PRM_Name SceneCacheNode<BaseType>::pGeometryType( "geometryType", "Geometry Type" );
 
 template<typename BaseType>
+PRM_Name SceneCacheNode<BaseType>::pVisibilityFilter( "visibilityFilter", "Visibility Filter" );
+
+template<typename BaseType>
 PRM_Default SceneCacheNode<BaseType>::rootDefault( 0, "/" );
 
 template<typename BaseType>
@@ -181,6 +184,7 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildMainParameters()
 			"Path re-roots the transformation starting at the specified root path, Local uses the current level "
 			"transformations only, and Object is an identity transform"
 		);
+
 	}
 
 	static OP_TemplatePair *templatePair = 0;
@@ -198,7 +202,7 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 	static PRM_Template *thisTemplate = 0;
 	if ( !thisTemplate )
 	{
-		thisTemplate = new PRM_Template[8];
+		thisTemplate = new PRM_Template[9];
 
 		thisTemplate[0] = PRM_Template(
 			PRM_INT, 1, &pGeometryType, &geometryTypeDefault, &geometryTypeList, 0, 0, 0, 0,
@@ -235,11 +239,16 @@ OP_TemplatePair *SceneCacheNode<BaseType>::buildOptionParameters()
 		);
 
 		thisTemplate[5] = PRM_Template(
+			PRM_TOGGLE, 1, &pVisibilityFilter, 0, 0, 0, &sceneParmChangedCallback, 0, 0,
+			"Determines whether this SOP cull out hidden location or not."
+		);
+
+		thisTemplate[6] = PRM_Template(
 			PRM_TOGGLE, 1, &pTagGroups, 0, 0, 0, 0, 0, 0,
 			"Convert SCC tags into Houdini primitive groups."
 		);
 
-		thisTemplate[6] = PRM_Template(
+		thisTemplate[7] = PRM_Template(
 			PRM_STRING, 1, &pFullPathName, 0, 0, 0, 0, 0, 0,
 			"Load the full path of the object as a primitive attribute with this name. This is for user "
 			"convenience and has no meaning in terms of processing or exporting SceneCaches. If left empty, "
@@ -496,6 +505,18 @@ template<typename BaseType>
 void SceneCacheNode<BaseType>::setAttributeCopy( const UT_String &value )
 {
 	this->setString( value, CH_STRING_LITERAL, pAttributeCopy.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+bool SceneCacheNode<BaseType>::getVisibilityFilter() const
+{
+	return this->evalInt( pVisibilityFilter.getToken(), 0, 0 );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::setVisibilityFilter( bool visibilityFilter )
+{
+	this->setInt( pVisibilityFilter.getToken(), 0, 0, visibilityFilter );
 }
 
 template<typename BaseType>

--- a/src/IECoreHoudini/SceneCacheNode.cpp
+++ b/src/IECoreHoudini/SceneCacheNode.cpp
@@ -53,6 +53,8 @@ using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreHoudini;
 
+static UT_StringRef visibilityExpression( "import IECoreHoudini\nsc = IECoreHoudini.SceneCacheNode( hou.pwd() )\nreturn sc.visibility(hou.frame())" );
+
 //////////////////////////////////////////////////////////////////////////////////////////
 // SceneCacheNode implementation
 //////////////////////////////////////////////////////////////////////////////////////////
@@ -519,6 +521,22 @@ template<typename BaseType>
 void SceneCacheNode<BaseType>::setVisibilityFilter( bool visibilityFilter )
 {
 	this->setInt( pVisibilityFilter.getToken(), 0, 0, visibilityFilter );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::setVisibilityExpression()
+{
+	this->setInt( "tdisplay", 0, 0, 1 );
+	this->setString( visibilityExpression, CH_PYTHON_EXPRESSION, "display", 0, 0 );
+}
+
+template<typename BaseType>
+void SceneCacheNode<BaseType>::clearVisibilityExpression()
+{
+	this->destroyChannel( "tdisplay" );
+	this->destroyChannel( "display" );
+	this->setInt( "tdisplay", 0, 0, 0 );
+	this->setInt( "display", 0, 0, 1 );
 }
 
 template<typename BaseType>

--- a/src/IECoreHoudini/bindings/SceneCacheNodeBinding.cpp
+++ b/src/IECoreHoudini/bindings/SceneCacheNodeBinding.cpp
@@ -38,6 +38,7 @@
 
 #include "IECoreHoudini/NodeHandle.h"
 #include "IECoreHoudini/OBJ_SceneCacheTransform.h"
+#include "IECoreHoudini/OBJ_SceneCacheNode.h"
 #include "IECoreHoudini/SceneCacheNode.h"
 
 #include "IECorePython/RunTimeTypedBinding.h"
@@ -110,6 +111,21 @@ class SceneCacheNodeHelper
 			return 0;
 		}
 
+		bool visibility( double frame ) const
+		{
+			if ( !hasNode() )
+			{
+				return false;
+			}
+
+			if ( SceneCacheNode<OP_Node> *node = sceneNode( m_handle.node() ) )
+			{
+				return node->visibility( frame );
+			}
+
+			return false;
+		}
+
 	private :
 
 		NodeHandle m_handle;
@@ -121,6 +137,7 @@ void IECoreHoudini::bindSceneCacheNode()
 	scope modeCacheNodeScope = class_<SceneCacheNodeHelper>( "SceneCacheNode" )
 		.def( init<OP_Node*>() )
 		.def( "scene", &SceneCacheNodeHelper::scene )
+		.def( "visibility", &SceneCacheNodeHelper::visibility )
 	;
 
 	enum_<SceneCacheNode<OP_Node>::Space>( "Space" )


### PR DESCRIPTION
Improvements
---

- SOP_SceneCacheSource: Moved `visibilityFilter` to base class, fixed inherited visiblity when using `Shape filter` (#982 ).
- OBJ_SceneCache: Support for `visibilityFilter` (#982)
### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
