### PR TITLE
Allow Maya to save any rotation order

### DIFF
--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -279,8 +279,8 @@ ConstDataPtr LiveScene::readTransform( double time ) const
 
 	if( m_dagPath.hasFn( MFn::kTransform ) )
 	{
-		MFnDagNode dagFn( m_dagPath );
-		return new IECore::TransformationMatrixdData( IECore::convert<IECore::TransformationMatrixd, MTransformationMatrix>( dagFn.transformationMatrix() ) );
+		MFnTransform dagFn( m_dagPath );
+		return new IECore::TransformationMatrixdData( IECore::convert<IECore::TransformationMatrixd, MTransformationMatrix>( dagFn.transformation() ) );
 	}
 	else
 	{

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -229,6 +229,11 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 
 		self.assertEqual( transform.transform, transformChild.readTransformAsMatrix( 0 ) )
 
+		# Test rotation order
+		maya.cmds.setAttr( "pSphere1.rotateOrder", 2 )
+		transform = transformChild.readTransform( 0 ).value
+		self.assertEqual( transform.rotate.order().name, 'ZXY' )
+
 	def testTimeException( self ) :
 
 		sphere = maya.cmds.polySphere( name="pSphere1" )


### PR DESCRIPTION
TranformationMatrixData can store Euler transformations, which currently are lost because Maya was storing a transformation matrix. This change will store the matrix and also  Euler transformations from Maya into the TransformationMatrixData, which have the rotation order of the object to be stored.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
