### PR TITLE
ToGLStateConverter : Support gl:depthTest attributes.

### DIFF
--- a/src/IECoreGL/ToGLStateConverter.cpp
+++ b/src/IECoreGL/ToGLStateConverter.cpp
@@ -172,6 +172,7 @@ const AttributeToStateMap &attributeToStateMap()
 		m["gl:smoothing:lines"] = attributeToTypedState<LineSmoothingStateComponent>;
 		m["gl:smoothing:polygons"] = attributeToTypedState<PolygonSmoothingStateComponent>;
 		m["gl:surface"] = attributeToShaderState;
+		m["gl:depthTest"] = attributeToTypedState<DepthTestStateComponent>;
 	}
 	return m;
 }


### PR DESCRIPTION
This is required by https://github.com/GafferHQ/gaffer/pull/3344