### PR TITLE
IECortexMaya: added "Expand by Tag as Geo..." to radial menu

### DIFF
--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -397,10 +397,10 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 	## Recursively converts all objects in the scene interface to compatible maya geometry
 	# All scene shape nodes in the hierarchy are turned into an intermediate object.
-	def convertAllToGeometry( self, preserveNamespace=False ) :
+	def convertAllToGeometry( self, preserveNamespace=False, tagName=None ) :
 
 		# Expand scene first, then for each scene shape we turn them into an intermediate object and connect a mesh
-		self.expandAll( preserveNamespace )
+		self.expandAll( preserveNamespace, tagName )
 		transform = maya.cmds.listRelatives( self.fullPathName(), parent=True, f=True )[0]
 
 		allSceneShapes = maya.cmds.listRelatives( transform, ad=True, f=True, type="ieSceneShape" )

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -309,11 +309,22 @@ def _dagMenu( menu, sceneShape ) :
 		if tagTree :
 			maya.cmds.menuItem(
 				label = "Expand by Tag...",
-				radialPosition = "S",
+				radialPosition = "SW",
 				subMenu = True
 			)
 
 			addTagSubMenuItems( __expandAll )
+
+			maya.cmds.setParent( "..", menu=True )
+
+			# expand as geometry
+			maya.cmds.menuItem(
+				label = "Expand by Tag as Geo...",
+				radialPosition = "SE",
+				subMenu = True
+			)
+
+			addTagSubMenuItems( __expandAsGeometry )
 
 			maya.cmds.setParent( "..", menu=True )
 
@@ -446,11 +457,11 @@ def __expandAll( sceneShapes, tagName=None, *unused ) :
 		maya.cmds.select( toSelect, replace=True )
 
 ## Recursively expand the scene shapes and converts objects to geometry
-def __expandAsGeometry( sceneShapes, *unused ) :
+def __expandAsGeometry( sceneShapes, tagName=None, *unused ) :
 
 	for sceneShape in sceneShapes:
 		fnS = IECoreMaya.FnSceneShape( sceneShape )
-		fnS.convertAllToGeometry( True )
+		fnS.convertAllToGeometry( True, tagName )
 
 ## Expand the scene shape the minimal amount to reach the selected components
 def __expandToSelected( sceneShape, *unused ) :


### PR DESCRIPTION
IECortexMaya: added "Expand by Tag as Geo..." to radial menu
- new expansion option to expand by tag to Maya geometry