### PR TITLE
SConstruct : Fix Mac build break

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1410,7 +1410,7 @@ if doConfigure :
 
 	c = Configure( pythonEnv )
 
-	if not c.CheckHeader( "Python.h", "\"\"", "C++" ) :
+	if not c.CheckHeader( "boost/python.hpp", language = "C++" ) :
 		sys.stderr.write( "ERROR : unable to find the Python headers, check PYTHON_INCLUDE_PATH.\n" )
 		Exit( 1 )
 


### PR DESCRIPTION
This fixes Mac build errors when using the `PYTHON_CONFIG` build variable rather than the `PYTHON_INCLUDE_PATH` and `PYTHON_LINK_FLAGS`. In this case, we don't include Python with `-isystem` and the configure step fails with the following error :

```
/Users/john/dev/gafferBuild/dependencies-0.54.2.0-source/gafferDependenciesBuild/lib/Python.framework/Versions/2.7/include/python2.7/unicodeobject.h:534:5: error: 'register' storage class specifier is deprecated and incompatible with C++17 [-Werror,-Wdeprecated-register]
    register PyObject *obj,     /* Object */
    ^~~~~~~~~
```

I don't know why a `C++17` error is triggered when we're explicitly passing `-std=c++11`, but it is. By testing for `boost/python.hpp` instead, we benefit from various magic boost does to suppress errors from the `Python.h` that it includes indirectly.
