### PR TITLE
IECoreScene: Ensure ShaderNetwork connections are loaded from scc caches

### DIFF
--- a/src/IECoreScene/ShaderNetwork.cpp
+++ b/src/IECoreScene/ShaderNetwork.cpp
@@ -385,6 +385,11 @@ class ShaderNetwork::Implementation
 					return false;
 				}
 
+				if( node.inputConnections.size() != otherNode.inputConnections.size() )
+				{
+					return false;
+				}
+
 				for( const auto &connection : node.inputConnections )
 				{
 					auto otherConnectionIt = otherNode.inputConnections.find(
@@ -531,6 +536,7 @@ class ShaderNetwork::Implementation
 
 			ConstIndexedIOPtr connections = container->subdirectory( "connections" );
 			IndexedIO::EntryIDList connectionIndices;
+			connections->entryIds( connectionIndices );
 			for( const auto &connectionIndex : connectionIndices )
 			{
 				InternedString c[4];

--- a/test/IECoreScene/ShaderNetworkTest.py
+++ b/test/IECoreScene/ShaderNetworkTest.py
@@ -367,7 +367,11 @@ class ShaderNetworkTest( unittest.TestCase ) :
 		)
 
 		n1.addConnection( c )
+
+		# Ensure equality is order independent, as we compare lists,
+		# we need to ensure n2 being a super-set of n1 doesn't pass.
 		self.assertNotEqual( n1, n2 )
+		self.assertNotEqual( n2, n1 )
 
 		n2.addConnection( c )
 		self.assertEqual( n1, n2 )


### PR DESCRIPTION
`ShaderNetwork` was not loading connections from scene caches. This had gone un-noticed as the serialisation test relied on the equality operator catching differences. `isEqualTo` was only verifying that the other network was a super-set of the target.