### PR TITLE
FromHoudiniGeometryConverter: Fix PrimGroup to Tag export in H17.5

### DIFF
--- a/test/IECoreHoudini/LiveSceneTest.py
+++ b/test/IECoreHoudini/LiveSceneTest.py
@@ -1153,6 +1153,18 @@ class LiveSceneTest( IECoreHoudini.TestCase ) :
 		self.assertEqual( childScene.childNames(), [] )
 		self.assertEqual( childScene.readObject( 0 ).variableSize( IECoreScene.PrimitiveVariable.Interpolation.Uniform ), 100 )
 
+		# it works if we have SOP level tags too
+
+		group = wrangle.createOutputNode( "grouprange" )
+		group.parm("groupname1").set( "ieTag_foo" )
+		group.parm("start1").set( 0 )
+		group.parm("end1").set( 5 )
+		group.parm("selecttotal1").set( 1 )
+		group.parm("method1").set( 0 )
+		group.setRenderFlag( True )
+		scene = IECoreHoudini.LiveScene( geo.path() ).child( "c" ).child( "d" ).child( "e" )
+		self.assertEqual( scene.readTags(), [ "foo" ] )
+
 	def testStringArrayDetail( self ) :
 
 		obj = hou.node( "/obj" )


### PR DESCRIPTION
As with 3a54db9563ea158642353baf22e53ccdd09aeca1, the indices returned by `GA_ROHandleS` are not reliable. They are physical indices into a possibly sparse array, and we need the logical index instead, so we compute that ourselves as an index remapping.