### PR TITLE
MeshAlgoTangents : Corrected size of faceIdPerVert vector

### DIFF
--- a/src/IECoreScene/MeshAlgoTangents.cpp
+++ b/src/IECoreScene/MeshAlgoTangents.cpp
@@ -305,7 +305,7 @@ std::pair<PrimitiveVariable, PrimitiveVariable> IECoreScene::MeshAlgo::calculate
 	const IntVectorData::ValueType &vertIds = vertIdsData->readable();
 
 	std::vector<V3f> centroids( vertsPerFace.size(), V3f( 0 ) );
-	std::vector<int> faceIdPerVert( vertIds.size(), -1 );
+	std::vector<int> faceIdPerVert( numPoints, -1 );
 
 	// calculate centroids
 	// TODO: generalize this to MeshAlgo::calculateCentroid


### PR DESCRIPTION
MeshAlgoTangents : Corrected size of faceIdPerVert vector in IESceneCoreScene::MeshAlgo::calculateTangentsFromPrimitiveCentroid.

Generally describe what this PR will do, and why it is needed.

- Fixes small bug in IECoreScene::MeshAlgo::calculateTangentsFromPrimitiveCentroid where the internal vector `faceIdPerVert` allocates the incorrect number of elements.

### Related Issues ###

- Issue 995

### Dependencies ###

- No other dependencies

### Breaking Changes ###

- No breaking API nor ABI changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
