### PR TITLE
Fix bug with `CurvesAlgo::updateEndpointMultiplicity()`

### DIFF
--- a/src/IECoreScene/CurvesAlgoUpdateEndpointMultiplicity.cpp
+++ b/src/IECoreScene/CurvesAlgoUpdateEndpointMultiplicity.cpp
@@ -39,15 +39,12 @@
 #include "tbb/concurrent_unordered_map.h"
 #include "tbb/task_group.h"
 
-#include "boost/format.hpp"
-
 using namespace IECore;
 using namespace IECoreScene;
 using namespace Imath;
 
 namespace
 {
-
 
 // replicate the first and last values an additional two times at the begining and end of the vector.
 template<typename T>
@@ -56,11 +53,9 @@ void expand( const std::vector<T> &in, std::vector<T> &out, const std::vector<in
 	out.reserve( in.size() + vertsPerCurve.size() * 4 );
 
 	size_t index = 0;
-	for( size_t i = 0; i < vertsPerCurve.size(); i++ )
+	for( size_t curveNumVerts : vertsPerCurve )
 	{
-		size_t curveNumVerts = (size_t) vertsPerCurve[i];
-
-		for( size_t j = 0; j < curveNumVerts; j++, index++ )
+		for( size_t j = 0; j < curveNumVerts; ++j, ++index )
 		{
 			out.push_back( in[index] );
 
@@ -80,10 +75,9 @@ void compress( const std::vector<T> &in, std::vector<T> &out, const std::vector<
 	out.reserve( in.size() - vertsPerCurve.size() * 4 );
 
 	size_t index = 0;
-	for( size_t i = 0; i < vertsPerCurve.size(); i++ )
+	for( size_t curveNumVerts : vertsPerCurve )
 	{
-		size_t curveNumVerts = (size_t) vertsPerCurve[i];
-		for( size_t j = 0; j < curveNumVerts; j++, index++ )
+		for( size_t j = 0; j < curveNumVerts; ++j, ++index )
 		{
 			if( j == 0 || j == 1 || j == ( curveNumVerts - 1 ) || j == ( curveNumVerts - 2 ) )
 			{
@@ -164,7 +158,7 @@ CurvesPrimitivePtr IECoreScene::CurvesAlgo::updateEndpointMultiplicity( const IE
 	// offsets.
 	tbb::task_group taskGroup;
 	tbb::concurrent_unordered_map<std::string, IECoreScene::PrimitiveVariable> newPrimVars;
-	for( const auto it : curves->variables )
+	for( const auto &it : curves->variables )
 	{
 		// only duplicate vertex interpolated end points
 		if( it.second.interpolation == IECoreScene::PrimitiveVariable::Vertex )
@@ -203,7 +197,7 @@ CurvesPrimitivePtr IECoreScene::CurvesAlgo::updateEndpointMultiplicity( const IE
 	taskGroup.run( updateTopology );
 	taskGroup.wait();
 
-	for (auto i : newPrimVars)
+	for( const auto &i : newPrimVars )
 	{
 		newCurves->variables[i.first] = i.second;
 	}

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -1664,6 +1664,8 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 		self.assertEqual( actualBSplineCurves["cPrimVar"],
 			IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData( [101, 99] ) ) )
 
+		self.assertTrue( actualBSplineCurves.arePrimitiveVariablesValid() )
+
 		backToLinear = IECoreScene.CurvesAlgo.updateEndpointMultiplicity( actualBSplineCurves, IECore.CubicBasisf.linear() )
 
 		self.assertEqual( backToLinear.basis(), IECore.CubicBasisf.linear())
@@ -1685,6 +1687,8 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
 		self.assertEqual( backToLinear["cPrimVar"],
 			IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData( [101, 99] ) ) )
+
+		self.assertTrue( backToLinear.arePrimitiveVariablesValid() )
 
 	def testSameBasisLeavesCurvesUnmodified( self ) :
 

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -1613,8 +1613,12 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 		# indexed primvar (ensure we only replicate the indices)
 		testObject["bPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [666, 3] ), IECore.IntVectorData([1,0,1,0] ) )
 
-		# non Vertex interpolated primitive variable to verify we don't do anything in this case
+		# Uniform interpolated primitive variable to verify we don't do anything in this case
 		testObject["cPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData([101,99]) )
+
+		# Varying interpolated primitive variables
+		testObject["dPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( [3, 666, 3, 666] ) )
+		testObject["ePrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( [666, 3] ), IECore.IntVectorData([1,0,1,0] ) )
 
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
@@ -1664,6 +1668,11 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 		self.assertEqual( actualBSplineCurves["cPrimVar"],
 			IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData( [101, 99] ) ) )
 
+		self.assertEqual( actualBSplineCurves["dPrimVar"].data, IECore.FloatVectorData( [3, 3, 666, 666, 3, 3, 666, 666] ) )
+
+		self.assertEqual( actualBSplineCurves["ePrimVar"].data, IECore.FloatVectorData( [666, 3] ) )
+		self.assertEqual( actualBSplineCurves["ePrimVar"].indices, IECore.IntVectorData( [1, 1, 0, 0, 1, 1, 0, 0] ) )
+
 		self.assertTrue( actualBSplineCurves.arePrimitiveVariablesValid() )
 
 		backToLinear = IECoreScene.CurvesAlgo.updateEndpointMultiplicity( actualBSplineCurves, IECore.CubicBasisf.linear() )
@@ -1687,6 +1696,11 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
 		self.assertEqual( backToLinear["cPrimVar"],
 			IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntVectorData( [101, 99] ) ) )
+
+		self.assertEqual( backToLinear["dPrimVar"].data, IECore.FloatVectorData( [3, 666, 3, 666] ) )
+
+		self.assertEqual( backToLinear["ePrimVar"].data, IECore.FloatVectorData( [666, 3] ) )
+		self.assertEqual( backToLinear["ePrimVar"].indices, IECore.IntVectorData( [1,0,1,0] ) )
 
 		self.assertTrue( backToLinear.arePrimitiveVariablesValid() )
 


### PR DESCRIPTION
It wasn't accounting for Varying primvars, which meant it could generate invalid CurvesPrimitives. This cam up because Arnold requires Varing primvars for Curves, and we have a workflow at IE to keep the curves linear until the last moment, when we switch to catmullRom.
