### PR TITLE
IECoreArnold : Resample Vertex primvars to Varying on cubic Curves.

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ShapeAlgo.cpp
@@ -231,7 +231,7 @@ void convertPrimitiveVariable( const IECoreScene::Primitive *primitive, const Pr
 			// Arnold doesn't appear to have vertex storage, but
 			// fortunately for many primitives it is equivalent to varying.
 			// Unfortunately that is not the case for cubic CurvesPrimitives, so
-			// we can not currently export per-vertex data for cubic curves.
+			// we resample the variables to Varying (see IECoreArnold::CurvesAlgo).
 			if( primitive->variableSize( primitiveVariable.interpolation ) == primitive->variableSize( PrimitiveVariable::Varying ) )
 			{
 				arnoldInterpolation = "varying";

--- a/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
@@ -165,8 +165,8 @@ class PointsTest( unittest.TestCase ) :
 			self.assertEqual( arnold.AiArrayGetNumKeys( a.contents ), 2 )
 
 			r = arnold.AiNodeGetArray( n, "radius" )
-			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 10 )
-			self.assertEqual( arnold.AiArrayGetNumKeys( a.contents ), 2 )
+			self.assertEqual( arnold.AiArrayGetNumElements( r.contents ), 10 )
+			self.assertEqual( arnold.AiArrayGetNumKeys( r.contents ), 2 )
 
 			for i in range( 0, 10 ) :
 				self.assertEqual( arnold.AiArrayGetVec( a, i ), arnold.AtVector( 10 ) )


### PR DESCRIPTION
Arnold only supports Varying userdata for Curves, so to improve user experience, we automatically resample Vertex to Varying for arbitrary primvars.

Note that while radius is not considered userdata, it also needs to be Varying, so we perform the same conversion for radius/width.