### PR TITLE
MeshAlgo calculateNormals

### DIFF
--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -47,6 +47,9 @@ namespace IECoreScene
 namespace MeshAlgo
 {
 
+/// Calculate the normals of a mesh primitive.
+IECORESCENE_API PrimitiveVariable calculateNormals( const MeshPrimitive *mesh, PrimitiveVariable::Interpolation interpolation = PrimitiveVariable::Vertex, const std::string &position = "P" );
+
 /// TODO: remove this compatibility function:
 IECORESCENE_API std::pair<PrimitiveVariable, PrimitiveVariable> calculateTangents( const MeshPrimitive *mesh, const std::string &uvSet = "uv", bool orthoTangents = true, const std::string &position = "P" );
 /// Calculate the surface tangent vectors of a mesh primitive based on UV information

--- a/src/IECoreScene/MeshAlgoNormals.cpp
+++ b/src/IECoreScene/MeshAlgoNormals.cpp
@@ -1,0 +1,117 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreScene/MeshAlgo.h"
+#include "IECoreScene/PolygonIterator.h"
+
+#include "IECore/PolygonAlgo.h"
+
+#include "boost/format.hpp"
+#include "boost/iterator/transform_iterator.hpp"
+#include "boost/iterator/zip_iterator.hpp"
+#include "boost/tuple/tuple.hpp"
+
+using namespace Imath;
+using namespace IECore;
+using namespace IECoreScene;
+
+PrimitiveVariable MeshAlgo::calculateNormals( const MeshPrimitive *mesh, PrimitiveVariable::Interpolation interpolation, const std::string &position )
+{
+	const V3fVectorData *pData = mesh->variableData<V3fVectorData>( position, PrimitiveVariable::Vertex );
+	if( !pData )
+	{
+		throw InvalidArgumentException( boost::str( boost::format( "MeshAlgo::calculateNormals : MeshPrimitive has no \"%s\" primitive variable." ) % position ) );
+	}
+	const std::vector<V3f> &points = pData->readable();
+
+	if( interpolation != PrimitiveVariable::Vertex && interpolation != PrimitiveVariable::Uniform )
+	{
+		throw InvalidArgumentException( "MeshAlgo::calculateNormals : \"interpolation\" must be Vertex or Uniform" );
+	}
+
+	V3fVectorDataPtr normalsData = new V3fVectorData;
+	normalsData->setInterpretation( GeometricData::Normal );
+	auto &normals = normalsData->writable();
+
+	const auto &verticesPerFace = mesh->verticesPerFace()->readable();
+	if( interpolation == PrimitiveVariable::Uniform )
+	{
+		normals.reserve( verticesPerFace.size() );
+	}
+	else
+	{
+		normals.resize( points.size(), Imath::V3f( 0 ) );
+	}
+
+	const auto &vertIds = mesh->vertexIds()->readable();
+	const int *vertId = &(vertIds[0]);
+	for( auto numVerts : verticesPerFace )
+	{
+		// calculate the face normal. note that this method is very naive, and doesn't
+		// cope with colinear vertices or concave faces - we could use polygonNormal() from
+		// PolygonAlgo.h to deal with that, but currently we'd prefer to avoid the overhead.
+		const V3f &p0 = points[*vertId];
+		const V3f &p1 = points[*(vertId+1)];
+		const V3f &p2 = points[*(vertId+2)];
+
+		V3f normal = ( p2 - p1 ).cross( p0 - p1 );
+		normal.normalize();
+
+		if( interpolation == PrimitiveVariable::Uniform )
+		{
+			normals.push_back( normal );
+			vertId += numVerts;
+		}
+		else
+		{
+			// accumulate the face normal onto each of the vertices for this face.
+			for( int i=0; i < numVerts; ++i )
+			{
+				normals[*vertId] += normal;
+				++vertId;
+			}
+		}
+	}
+
+	// normalize each of the vertex normals
+	if( interpolation == PrimitiveVariable::Vertex )
+	{
+		for( Imath::V3f &n : normals )
+		{
+			n.normalize();
+		}
+	}
+
+	return PrimitiveVariable( interpolation, normalsData );
+}

--- a/src/IECoreScene/MeshNormalsOp.cpp
+++ b/src/IECoreScene/MeshNormalsOp.cpp
@@ -32,6 +32,7 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "IECoreScene/MeshAlgo.h"
 #include "IECoreScene/MeshNormalsOp.h"
 
 #include "IECore/CompoundParameter.h"
@@ -111,118 +112,9 @@ const IntParameter * MeshNormalsOp::interpolationParameter() const
 	return parameters()->parameter<IntParameter>( "interpolation" );
 }
 
-struct MeshNormalsOp::CalculateNormals
-{
-	typedef DataPtr ReturnType;
-
-	CalculateNormals( const IntVectorData *vertsPerFace, const IntVectorData *vertIds, PrimitiveVariable::Interpolation interpolation )
-		:	m_vertsPerFace( vertsPerFace ), m_vertIds( vertIds ), m_interpolation( interpolation )
-	{
-	}
-
-	template<typename T>
-	ReturnType operator()( T * data )
-	{
-		typedef typename T::ValueType VecContainer;
-		typedef typename VecContainer::value_type Vec;
-
-		const typename T::ValueType &points = data->readable();
-		const vector<int> &vertsPerFace = m_vertsPerFace->readable();
-		const vector<int> &vertIds = m_vertIds->readable();
-
-		typename T::Ptr normalsData = new T;
-		normalsData->setInterpretation( GeometricData::Normal );
-		VecContainer &normals = normalsData->writable();
-		if( m_interpolation == PrimitiveVariable::Uniform )
-		{
-			normals.reserve( vertsPerFace.size() );
-		}
-		else
-		{
-			normals.resize( points.size(), Vec( 0 ) );
-		}
-
-		// loop over the faces
-		const int *vertId = &(vertIds[0]);
-		for( vector<int>::const_iterator it = vertsPerFace.begin(); it!=vertsPerFace.end(); it++ )
-		{
-			// calculate the face normal. note that this method is very naive, and doesn't
-			// cope with colinear vertices or concave faces - we could use polygonNormal() from
-			// PolygonAlgo.h to deal with that, but currently we'd prefer to avoid the overhead.
-			const Vec &p0 = points[*vertId];
-			const Vec &p1 = points[*(vertId+1)];
-			const Vec &p2 = points[*(vertId+2)];
-
-			Vec normal = (p2-p1).cross(p0-p1);
-			normal.normalize();
-
-			if( m_interpolation == PrimitiveVariable::Uniform )
-			{
-				normals.push_back( normal );
-				vertId += *it;
-			}
-			else
-			{
-				// accumulate the face normal onto each of the vertices
-				// for this face.
-				for( int i=0; i<*it; ++i )
-				{
-					normals[*vertId] += normal;
-					++vertId;
-				}
-			}
-		}
-
-		// normalize each of the vertex normals
-		if( m_interpolation == PrimitiveVariable::Vertex )
-		{
-			for( typename VecContainer::iterator it=normals.begin(), eIt=normals.end(); it != eIt; ++it )
-			{
-				it->normalize();
-			}
-		}
-
-		return normalsData;
-	}
-
-	private :
-
-		ConstIntVectorDataPtr m_vertsPerFace;
-		ConstIntVectorDataPtr m_vertIds;
-		PrimitiveVariable::Interpolation m_interpolation;
-
-};
-
-struct MeshNormalsOp::HandleErrors
-{
-	template<typename T, typename F>
-	void operator()( const T *d, const F &f )
-	{
-		string e = boost::str( boost::format( "MeshNormalsOp : pPrimVarName parameter has unsupported data type \"%s\"." ) % d->typeName() );
-		throw InvalidArgumentException( e );
-	}
-};
-
 void MeshNormalsOp::modifyTypedPrimitive( MeshPrimitive * mesh, const CompoundObject * operands )
 {
 	const std::string &pPrimVarName = pPrimVarNameParameter()->getTypedValue();
-	PrimitiveVariableMap::const_iterator pvIt = mesh->variables.find( pPrimVarName );
-	if( pvIt==mesh->variables.end() || !pvIt->second.data )
-	{
-		string e = boost::str( boost::format( "MeshNormalsOp : MeshPrimitive has no \"%s\" primitive variable." ) % pPrimVarName );
-		throw InvalidArgumentException( e );
-	}
-
-	if( !mesh->isPrimitiveVariableValid( pvIt->second ) )
-	{
-		string e = boost::str( boost::format( "MeshNormalsOp : \"%s\" primitive variable is invalid." ) % pPrimVarName );
-		throw InvalidArgumentException( e );
-	}
-
 	const PrimitiveVariable::Interpolation interpolation = static_cast<PrimitiveVariable::Interpolation>( operands->member<IntData>( "interpolation" )->readable() );
-
-	CalculateNormals f( mesh->verticesPerFace(), mesh->vertexIds(), interpolation );
-	DataPtr n = despatchTypedData<CalculateNormals, TypeTraits::IsVec3VectorTypedData, HandleErrors>( pvIt->second.data.get(), f );
-
-	mesh->variables[ nPrimVarNameParameter()->getTypedValue() ] = PrimitiveVariable( interpolation, n );
+	mesh->variables[ nPrimVarNameParameter()->getTypedValue() ] = MeshAlgo::calculateNormals( mesh, interpolation, pPrimVarName );
 }

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -116,6 +116,7 @@ void bindMeshAlgo()
 	StdPairToTupleConverter<PrimitiveVariable, PrimitiveVariable>();
 	StdPairToTupleConverter<IECore::IntVectorDataPtr, IECore::IntVectorDataPtr>();
 
+	def( "calculateNormals", &MeshAlgo::calculateNormals, ( arg_( "mesh" ), arg_( "interpolation" ) = PrimitiveVariable::Vertex, arg_( "position" ) = "P" ) );
 	def( "calculateTangents", &MeshAlgo::calculateTangents, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv", arg_( "orthoTangents" ) = true, arg_( "position" ) = "P" ) );
 	def( "calculateTangentsFromUV", &MeshAlgo::calculateTangentsFromUV, ( arg_( "mesh" ), arg_( "uvSet" ) = "uv",  arg_( "position" ) = "P", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );
 	def( "calculateTangentsFromFirstEdge", &MeshAlgo::calculateTangentsFromFirstEdge, ( arg_( "mesh" ), arg_( "position" ) = "P", arg_( "normal" ) = "N", arg_( "orthoTangents" ) = true, arg_( "leftHanded" ) = false ) );

--- a/test/IECoreScene/MeshAlgoNormalsTest.py
+++ b/test/IECoreScene/MeshAlgoNormalsTest.py
@@ -1,0 +1,95 @@
+##########################################################################
+#
+#  Copyright (c) 2019, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import math
+import unittest
+
+import IECore
+import IECoreScene
+
+import imath
+
+class MeshAlgoNormalsTest( unittest.TestCase ) :
+
+	def testPlane( self ) :
+
+		p = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ) )
+		del p["N"]
+
+		normals = IECoreScene.MeshAlgo.calculateNormals( p )
+
+		self.assertEqual( normals.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertTrue( normals.data.isInstanceOf( IECore.V3fVectorData.staticTypeId() ) )
+		self.assertEqual( normals.data.size(), p.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Vertex ) )
+		self.assertEqual( normals.data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
+
+		for n in normals.data :
+			self.assertEqual( n, imath.V3f( 0, 0, 1 ) )
+
+	def testSphere( self ) :
+
+		s = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		del s["N"]
+
+		normals = IECoreScene.MeshAlgo.calculateNormals( s )
+
+		self.assertEqual( normals.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assert_( normals.data.isInstanceOf( IECore.V3fVectorData.staticTypeId() ) )
+		self.assertEqual( normals.data.size(), s.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Vertex ) )
+		self.assertEqual( normals.data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
+
+		points = s["P"].data
+		for i in range( 0, normals.data.size() ) :
+
+			self.assertTrue( math.fabs( normals.data[i].length() - 1 ) < 0.001 )
+
+			p = points[i].normalize()
+			self.assertTrue( normals.data[i].dot( p ) > 0.99 )
+			self.assertTrue( normals.data[i].dot( p ) < 1.01 )
+
+	def testUniformInterpolation( self ) :
+
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 10 ) )
+		del m["N"]
+
+		normals = IECoreScene.MeshAlgo.calculateNormals( m, interpolation = IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( normals.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( len( normals.data ), m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Uniform ) )
+
+		for n in normals.data :
+			self.assertEqual( n, imath.V3f( 0, 0, 1 ) )
+
+if __name__ == "__main__":
+	unittest.main()

--- a/test/IECoreScene/MeshAlgoTest.py
+++ b/test/IECoreScene/MeshAlgoTest.py
@@ -46,6 +46,7 @@ from MeshAlgoMergeTest import MeshAlgoMergeTest
 from MeshAlgoReorderTest import MeshAlgoReorderTest
 from MeshAlgoTriangulateTest import MeshAlgoTriangulateTest
 from MeshAlgoConnectedVerticesTest import MeshAlgoConnectedVerticesTest
+from MeshAlgoNormalsTest import MeshAlgoNormalsTest
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This adds `IECoreScene::MeshAlgo::calculateNormals()` and reimplementes `MeshNormalsOp` to use it.

Note I haven't made changes to the algorithm at all, this is just a port to avoid the Op construction.