### PR TITLE
Fixing IECoreImage build issues

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1738,6 +1738,7 @@ imageEnvAppends = {
 	],
 	"LIBS" : [
 		"boost_signals" + env["BOOST_LIB_SUFFIX"],
+		"OpenImageIO$OIIO_LIB_SUFFIX",
 	],
 	"CXXFLAGS" : [
 		"-DIECoreImage_EXPORTS",

--- a/SConstruct
+++ b/SConstruct
@@ -1751,7 +1751,17 @@ if libraryPathEnvVar :
 
 if doConfigure :
 
-	c = Configure( imageEnv )
+	# Since we only build shared libraries and not exectuables,
+	# we only need to check that shared libs will link correctly.
+	# This is necessary when building against a OpenImageIO that
+	# links to extra dependencies not required by Cortex (eg a libtiff
+	# that ships with a DCC). This approach succeeds because building
+	# a shared library doesn't require resolving the unresolved symbols
+	# of the libraries that it links to.
+	imageCheckEnv = imageEnv.Clone()
+	imageCheckEnv.Append( CXXFLAGS = [ "-fPIC" ] )
+	imageCheckEnv.Append( LINKFLAGS = [ "-shared" ] )
+	c = Configure( imageCheckEnv )
 
 	if not c.CheckLibWithHeader( imageEnv.subst( "OpenImageIO$OIIO_LIB_SUFFIX" ), "OpenImageIO/imageio.h", "CXX" ) :
 


### PR DESCRIPTION
We recently discovered that libIECoreImage wasn't building for Houdini 17.5 at IE. Applying the same envCheck trick we use elsewhere in the SConstruct (vdbEnv for example) fixes the problem, as it was trying to use a different libtiff at check-time than at compile & run time.

In fixing that, I discovered that we were never actually linking to libOpenImageIO ourselves (I assume the previous configure check was inadvertently doing that for us).

@themissingcow can you verify this still works for whatever IECoreImage build issue you had previously? Was that just the Azure tests or was it something on MacOS?