### PR TITLE
FromHoudiniPolygonsConverter : Fix the mesh id with a remap to avoid out of bounds

### DIFF
--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -222,7 +222,7 @@ CompoundObjectPtr FromHoudiniPolygonsConverter::transferMeshInterpolation( const
 		// Prepare the map of location to mesh type. We're going to store a
 		// bool because there are only 2 possible values (currently) and this
 		// is expected to be transient / never-serialized data.
-		std::vector<bool *> locationMeshTypes;
+		std::vector<bool> locationMeshTypes;
 		const GA_Attribute *nameAttr = nameAttrib.getAttribute();
 		/// \todo: replace with GA_ROHandleS somehow... its not clear how, there don't seem to be iterators.
 		const GA_AIFSharedStringTuple *nameTuple = nameAttr->getAIFSharedStringTuple();
@@ -233,7 +233,7 @@ CompoundObjectPtr FromHoudiniPolygonsConverter::transferMeshInterpolation( const
 		{
 			BoolDataPtr meshTypeData = new BoolData( false );
 			meshTypeMap.insert( { it.getString(), meshTypeData } );
-			locationMeshTypes.emplace_back( &meshTypeData->writable() );
+			locationMeshTypes.emplace_back( meshTypeData->writable() );
 			indexRemap[it.getIndex()] = i;
 		}
 
@@ -251,7 +251,7 @@ CompoundObjectPtr FromHoudiniPolygonsConverter::transferMeshInterpolation( const
 
 				if( meshTypeAttrib.getIndex( offset ) == subdivId )
 				{
-					( *locationMeshTypes[indexRemap[id]] ) = true;
+					( locationMeshTypes[indexRemap[id]] ) = true;
 				}
 			}
 		}

--- a/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPolygonsConverter.cpp
@@ -226,11 +226,15 @@ CompoundObjectPtr FromHoudiniPolygonsConverter::transferMeshInterpolation( const
 		const GA_Attribute *nameAttr = nameAttrib.getAttribute();
 		/// \todo: replace with GA_ROHandleS somehow... its not clear how, there don't seem to be iterators.
 		const GA_AIFSharedStringTuple *nameTuple = nameAttr->getAIFSharedStringTuple();
-		for( GA_AIFSharedStringTuple::iterator it = nameTuple->begin( nameAttr ); !it.atEnd(); ++it )
+		std::vector<int> indexRemap;
+		indexRemap.resize( nameTuple->getTableEntries( nameAttr ), -1 );
+		int i = 0;
+		for( GA_AIFSharedStringTuple::iterator it = nameTuple->begin( nameAttr ); !it.atEnd(); ++it, ++i )
 		{
 			BoolDataPtr meshTypeData = new BoolData( false );
 			meshTypeMap.insert( { it.getString(), meshTypeData } );
 			locationMeshTypes.emplace_back( &meshTypeData->writable() );
+			indexRemap[it.getIndex()] = i;
 		}
 
 		// Calculate the mesh type per location
@@ -247,7 +251,7 @@ CompoundObjectPtr FromHoudiniPolygonsConverter::transferMeshInterpolation( const
 
 				if( meshTypeAttrib.getIndex( offset ) == subdivId )
 				{
-					( *locationMeshTypes[id] ) = true;
+					( *locationMeshTypes[indexRemap[id]] ) = true;
 				}
 			}
 		}


### PR DESCRIPTION
Fix the mesh id with a remap to avoid out of bounds.
Changed the pointers to booleans vector, to a booleans vector instead, as apparently it seems makes no sense to have pointers.

### Related Issues ###
- Fixes the index out of bounds of the geometry.