### PR TITLE
 SceneShapeUI: Rewrote DAG Menu creation to use `IECoreMaya.Menu`

### DIFF
--- a/python/IECore/Enum.py
+++ b/python/IECore/Enum.py
@@ -32,6 +32,8 @@
 #
 ##########################################################################
 
+import functools
+
 ## Creates a new class which provides enum-like functionality.
 # The class has an attribute for each name passed, whose value is
 # the instance of the Enum for that name. Enum instances hold an
@@ -52,9 +54,9 @@
 # assert( E.Orange != E.Apple )
 def create( *names ) :
 
-	class Enum :
+	@functools.total_ordering
+	class Enum( object ) :
 
-		__slots__ = ( "__value" )
 		__names = names
 
 		def __init__( self, value ) :
@@ -77,10 +79,20 @@ def create( *names ) :
 
 			return hash( ( self.__class__, self.__value ) )
 
-		def __cmp__( self, other ) :
+		def __eq__( self, other ):
+			try:
+				return  self.__value == other.__value
+			except AttributeError:
+				return False
 
-			assert( type( self ) is type( other ) )
-			return cmp( self.__value, other.__value )
+		def __ne__( self, other ):
+			return not self.__eq__( other )
+
+		def __lt__( self, other ):
+			try:
+				return self.__value < other.__value
+			except AttributeError:
+				return False
 
 		def __int__( self ) :
 

--- a/python/IECore/MenuDefinition.py
+++ b/python/IECore/MenuDefinition.py
@@ -130,6 +130,13 @@ class MenuDefinition( object ) :
 		for i in toRemove :
 			del self.__items[i]
 
+	## Appends another MenuDefinition or dict to the end
+	# of the definition. Duplicate entries will be overwritten.
+	def update( self, definition ) :
+		for path, item in definition.items():
+			self.remove( path, False )
+			self.__items.append( ( path, item ) )
+
 	## Removes all menu items from the definition.
 	def clear( self ) :
 
@@ -149,17 +156,16 @@ class MenuDefinition( object ) :
 	# root.
 	def reRooted( self, root ) :
 
-		if not len( root ) :
+		if not root:
 			return MenuDefinition( [] )
 
-		if root[-1]!="/" :
-			root = root + "/"
+		root = root + "/" if not root.endswith("/") else root
 
 		newItems = []
-		for item in self.items() :
+		for path, itemDict in self.items() :
 
-			if item[0].startswith( root ) :
-				newItems.append( ( item[0][len(root)-1:], item[1] ) )
+			if path.startswith( root ) :
+				newItems.append( ( path[len(root)-1:], itemDict ) )
 
 		return MenuDefinition( newItems )
 

--- a/python/IECore/MenuDefinition.py
+++ b/python/IECore/MenuDefinition.py
@@ -150,6 +150,10 @@ class MenuDefinition( object ) :
 
 		return list(self.__items)
 
+	## Returns the size of the item list.
+	def size(self):
+		return len(self.__items)
+
 	## Returns a new MenuDefinition containing only the menu items
 	# that reside below the specified root path. The paths in this
 	# new definition are all adjusted to be relative to the requested

--- a/python/IECore/MenuDefinition.py
+++ b/python/IECore/MenuDefinition.py
@@ -41,13 +41,13 @@ from MenuItemDefinition import MenuItemDefinition
 # interface implementation to realise. This allows menus to be defined in a
 # UI agnostic way and then used with different toolkits.
 # \ingroup python
-class MenuDefinition :
+class MenuDefinition( object ) :
 
-	def __init__( self, items = [] ) :
+	def __init__( self, items = None ) :
 
 		self.__items = []
 
-		for path, item in items :
+		for path, item in items or []:
 
 			self.append( path, item )
 
@@ -141,7 +141,7 @@ class MenuDefinition :
 	# remove items.
 	def items( self ) :
 
-		return self.__items
+		return list(self.__items)
 
 	## Returns a new MenuDefinition containing only the menu items
 	# that reside below the specified root path. The paths in this

--- a/python/IECore/MenuItemDefinition.py
+++ b/python/IECore/MenuItemDefinition.py
@@ -64,9 +64,7 @@
 # \todo Validation of attribute values, so for instance divider and command
 # can't both be set at the same time.
 # \ingroup python
-class MenuItemDefinition :
-
-	__slots__ = [ "command", "secondaryCommand", "divider", "active", "description", "subMenu", "checkBox", "blindData" ]
+class MenuItemDefinition( object ) :
 
 	def __init__( self, dictionary = None, **kwArgs ) :
 
@@ -87,9 +85,5 @@ class MenuItemDefinition :
 			setattr( self, k, v )
 
 	def __repr__( self ) :
-
-		d = {}
-		for s in self.__slots__ :
-			d[s] = getattr( self, s )
-
+		d = { k:v for k,v in self.__dict__.items() if not k.startswith('_') }
 		return "MenuItemDefinition( " + repr( d ) + " )"

--- a/python/IECoreMaya/Menu.py
+++ b/python/IECoreMaya/Menu.py
@@ -127,7 +127,7 @@ class Menu( UIElement ) :
 
 			# merge items referencing this root item in their path string
 			subMenuDefinition = definition.reRooted("/" + name + "/")
-			if subMenuDefinition.items():
+			if subMenuDefinition.size():
 				if item.subMenu:
 					if callable(item.subMenu):
 						# force retrival of definition object now so we can merge menu items

--- a/python/IECoreMaya/Menu.py
+++ b/python/IECoreMaya/Menu.py
@@ -31,7 +31,7 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
-
+import functools
 import maya.cmds
 import maya.mel
 
@@ -63,18 +63,23 @@ class Menu( UIElement ) :
 	# replaceExistingMenu :
 	# determines whether we add the menu as a submenu, or overwrite the contents of the existing menu
 	# (if the parent is a menu)
-	def __init__( self, definition, parent, label="", insertAfter=None, radialPosition=None, button = 3, replaceExistingMenu = False ) :
+	#
+	# keepCallback :
+	# For use in cases where we want to extend an existing menu without overriding the postMenu callback.
+	# Overriding the callback can break Maya in specific cases, such as the VP right click context menu.
+	def __init__( self, definition, parent, label="", insertAfter=None, radialPosition=None, button = 3, replaceExistingMenu = False, keepCallback=False ) :
 
-		menu = None
 		if maya.cmds.window( parent, query=True, exists=True ) or maya.cmds.menuBarLayout( parent, query=True, exists=True ) :
 			# parent is a window - we're sticking it in the menubar
 			menu = maya.cmds.menu( label=label, parent=parent, allowOptionBoxes=True, tearOff=True )
 		elif maya.cmds.menu( parent, query=True, exists=True ) :
-			if replaceExistingMenu:
+			if keepCallback:
+				menu = parent
+			elif replaceExistingMenu :
 				# parent is a menu - we're appending to it:
 				menu = parent
 				self.__postMenu( menu, definition )
-			else:
+			else :
 				# parent is a menu - we're adding a submenu
 				kw = {}
 				if not (insertAfter is None) :
@@ -86,70 +91,91 @@ class Menu( UIElement ) :
 			# assume parent is a control which can accept a popup menu
 			menu = maya.cmds.popupMenu( parent=parent, button=button, allowOptionBoxes=True )
 
-		maya.cmds.menu( menu, edit=True, postMenuCommand = IECore.curry( self.__postMenu, menu, definition ) )
-
 		UIElement.__init__( self, menu )
 
-	def __wrapCallback( self, cb ) :
+		if not keepCallback:
+			maya.cmds.menu( menu, edit=True, postMenuCommand=functools.partial( self.__postMenu, menu, definition ) )
+		else:
+			self._parseDefinition(parent, definition)
 
-		if ( callable( cb ) ) :
-			return self._createCallback( cb )
-		else :
-			# presumably a command in string form
-			return cb
-
-	def __postMenu( self, parent, definition, *args ) :
+	def _parseDefinition( self, parent, definition ):
 
 		if callable( definition ) :
 			definition = definition()
 
-		maya.cmds.menu( parent, edit=True, deleteAllItems=True )
+		if not isinstance( definition, IECore.MenuDefinition ):
+			raise IECore.Exception( "Definition is not a valid IECore.MenuDefinition object." )
 
-		done = set()
-		for path, item in definition.items() :
+		allPaths = dict(definition.items()).keys()
+		rootItemDefinitions = IECore.MenuDefinition( [] )
 
-			pathComponents = path.strip( "/" ).split( "/" )
-			name = pathComponents[0]
+		# scan definition once and get root item definitions
+		for path, item in definition.items():
+			strippedPath = path.strip('/')
+			if '/' not in strippedPath:
+				rootItemDefinitions.append(path, item)
+				continue
 
-			if len( pathComponents ) > 1 :
-				# a submenu
-				if not name in done :
-					subMenu = maya.cmds.menuItem( label=name, subMenu=True, allowOptionBoxes=True, parent=parent, tearOff=True )
-					subMenuDefinition = definition.reRooted( "/" + name + "/" )
-					maya.cmds.menu( subMenu, edit=True, postMenuCommand=IECore.curry( self.__postMenu, subMenu, subMenuDefinition ) )
-					done.add( name )
-			else :
+			# Implicit root needed, create root item definition
+			superPath = "/{}".format(strippedPath.split("/")[0])
+			if not superPath in allPaths:
+				rootItemDefinitions.append(superPath, {})
 
-				kw = {}
+		# iterate root definitions and create menu items
+		for path, item in rootItemDefinitions.items():
+			name = path.strip('/')
 
-				if getattr( item, "bold", False ) :
-					kw["boldFont"] = True
+			# merge items referencing this root item in their path string
+			subMenuDefinition = definition.reRooted("/" + name + "/")
+			if subMenuDefinition.items():
+				if item.subMenu:
+					if callable(item.subMenu):
+						# force retrival of definition object now so we can merge menu items
+						item.subMenu = item.subMenu()
+					item.subMenu.update(subMenuDefinition)
+				else:
+					item.subMenu = subMenuDefinition
 
-				if getattr( item, "italic", False ) :
-					kw["italicized"] = True
+			# get Maya keyword args
+			kw = {}
 
-				if item.divider :
+			if getattr(item, "bold", False):
+				kw["boldFont"] = True
 
-					menuItem = maya.cmds.menuItem( parent=parent, divider=True )
+			if getattr(item, "italic", False):
+				kw["italicized"] = True
 
-				elif item.subMenu :
+			if getattr(item, "blindData", {}):
+				mayaArgs = item.blindData.get("maya", {})
+				kw.update(mayaArgs)
 
-					subMenu = maya.cmds.menuItem( label=name, subMenu=True, allowOptionBoxes=True, parent=parent, **kw )
-					maya.cmds.menu( subMenu, edit=True, postMenuCommand=IECore.curry( self.__postMenu, subMenu, item.subMenu ) )
+			# create UI
+			if item.divider:
+				menuItem = maya.cmds.menuItem(parent=parent, divider=True)
+			elif item.subMenu:
+				subMenu = maya.cmds.menuItem(label=name, subMenu=True, allowOptionBoxes=True, parent=parent, **kw)
+				maya.cmds.menu(subMenu, edit=True, postMenuCommand=functools.partial(self.__postMenu, subMenu, item.subMenu))
+			else:
+				active = item.active
+				if callable(active):
+					active = active()
 
-				else :
+				checked = item.checkBox
+				if callable(checked):
+					checked = checked()
+					kw["checkBox"] = checked
 
-					active = item.active
-					if callable( active ) :
-						active = active()
+				menuItem = maya.cmds.menuItem(label=name, parent=parent, enable=active, annotation=item.description, **kw)
+				if item.command:
+					maya.cmds.menuItem(menuItem, edit=True, command=self.__wrapCallback(item.command))
+				if item.secondaryCommand:
+					optionBox = maya.cmds.menuItem(optionBox=True, enable=active, command=self.__wrapCallback(item.secondaryCommand), parent=parent)
 
-					checked = item.checkBox
-					if callable( checked ) :
-						checked = checked()
-						kw["checkBox"] = checked
+	def __wrapCallback( self, cb ) :
 
-					menuItem = maya.cmds.menuItem( label=name, parent=parent, enable=active, annotation=item.description, **kw )
-					if item.command :
-						maya.cmds.menuItem( menuItem, edit=True, command=self.__wrapCallback( item.command ) )
-					if item.secondaryCommand :
-						optionBox = maya.cmds.menuItem( optionBox=True, enable=active, command=self.__wrapCallback( item.secondaryCommand ), parent=parent )
+		return self._createCallback( cb ) if callable( cb ) else cb
+
+	def __postMenu( self, parent, definition, *args ) :
+
+		maya.cmds.menu( parent, edit = True, deleteAllItems = True )
+		self._parseDefinition( parent, definition )

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -518,8 +518,8 @@ def __parentSceneShape( sceneShapes ):
 		if parent:
 			parentShape = maya.cmds.listRelatives( parent[0], fullPath=True, type = "ieSceneShape" )
 			if parentShape:
-			    allParentShapes.append( parentShape[0] )
-			    getParentShapes( parent[0], allParentShapes )
+				allParentShapes.append( parentShape[0] )
+				getParentShapes( parent[0], allParentShapes )
 
 	parents = None
 	for sceneShape in sceneShapes:

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -375,20 +375,17 @@ def __invalidSceneShapes( sceneShapes ):
 ## Returns all the selected scene shapes
 def __selectedSceneShapes() :
 
-	allSceneShapes = []
+	allSceneShapes = set()
 
-	selectedSceneShapes = maya.cmds.ls( sl=True, l=True )
-	for shape in selectedSceneShapes:
+	for shape in maya.cmds.ls( sl=True, l=True ):
 		# Make sure we have the shape name, it could be a component
-		shapeName = shape.split(".f[")[0]
-		if maya.cmds.nodeType( shapeName ) == "ieSceneShape" and not shapeName in allSceneShapes:
-			allSceneShapes.append( shapeName )
+		shapeName, _, _ = shape.partition(".f[")
+		if maya.cmds.objectType( shapeName ) == "ieSceneShape":
+			allSceneShapes.add( shapeName )
 		else:
 			children = maya.cmds.listRelatives( shapeName, children=True, type="ieSceneShape", fullPath=True ) or []
-			for child in children:
-				if not child in allSceneShapes:
-					allSceneShapes.append( child )
-	return allSceneShapes
+			allSceneShapes.update(children)
+	return list(allSceneShapes)
 
 ## Turns on child bounds and switches to component mode
 def __componentCallback( sceneShape, *unused ) :

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -130,13 +130,13 @@ def _menuDefinition( callbackShape ) :
 
 		# EXPAND
 		expandDef = IECore.MenuDefinition(
-			[ ("/Recursive Expand As Geometry", { "blindData" : { "maya" : { "radialPosition" : "W" } }, "command" : functools.partial( __expandAsGeometry, sceneShapes ) }) ] )
+			[ ("/Recursive Expand As Geometry", { "blindData" : { "maya" : { "radialPosition" : "W" } }, "command" : functools.partial( _expandAsGeometry, sceneShapes)})] )
 		mainDef.append( "/Expand...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandDef } )
 
 		if any( map( lambda x : x.canBeExpanded(), fnShapes ) ) :
 
 			expandDef.append( "/Expand One Level", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( __expandOnce, sceneShapes ) } )
-			expandDef.append( "/Recursive Expand", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __expandAll, sceneShapes ) } )
+			expandDef.append( "/Recursive Expand", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( _expandAll, sceneShapes)})
 
 			if len( sceneShapes ) == 1 and fnShapes[ 0 ].selectedComponentNames() :
 				expandDef.append( "/Expand to Selected Components", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __expandToSelected, sceneShapes[ 0 ] ) } )
@@ -162,15 +162,15 @@ def _menuDefinition( callbackShape ) :
 						menuDef.append( label, { "command" : functools.partial( command, sceneShapes, expandTag ) } )
 
 			filterDef = IECore.MenuDefinition( [
-				("/Display All", { "command" : functools.partial( __setTagsFilterPreviewAttributes, sceneShapes, "" ) })
+				("/Display All", { "command" : functools.partial( _setTagsFilterPreviewAttributes, sceneShapes, "")})
 			] )
 			expandTagDef = IECore.MenuDefinition()
 			expandTagGeoDef = IECore.MenuDefinition()
 			mainDef.append( "/Tags filter...", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "subMenu" : filterDef } )
 
-			addTagSubMenuItems( filterDef, __setTagsFilterPreviewAttributes )
-			addTagSubMenuItems( expandTagDef, __expandAll )
-			addTagSubMenuItems( expandTagGeoDef, __expandAsGeometry )
+			addTagSubMenuItems( filterDef, _setTagsFilterPreviewAttributes)
+			addTagSubMenuItems( expandTagDef, _expandAll)
+			addTagSubMenuItems( expandTagGeoDef, _expandAsGeometry)
 
 			expandDef.append( "/Expand by Tag...", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : expandTagDef } )
 			expandDef.append( "/Expand by Tag as Geo...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandTagGeoDef } )
@@ -290,7 +290,7 @@ def __expandOnce( sceneShapes, *unused ) :
 		maya.cmds.select( toSelect, replace=True )
 
 ## Recursively expand the scene shapes
-def __expandAll( sceneShapes, tagName=None, *unused ) :
+def _expandAll( sceneShapes, tagName=None, *unused) :
 
 	toSelect = []
 	for sceneShape in sceneShapes:
@@ -302,7 +302,7 @@ def __expandAll( sceneShapes, tagName=None, *unused ) :
 		maya.cmds.select( toSelect, replace=True )
 
 ## Recursively expand the scene shapes and converts objects to geometry
-def __expandAsGeometry( sceneShapes, tagName=None, *unused ) :
+def _expandAsGeometry( sceneShapes, tagName=None, *unused) :
 
 	for sceneShape in sceneShapes:
 		fnS = IECoreMaya.FnSceneShape( sceneShape )
@@ -397,7 +397,7 @@ def __setChildrenPreviewAttributes( sceneShapes, attributeName, value, *unused )
 				maya.cmds.setAttr( node+"."+attributeName, value )
 
 ## Sets the given tags filter attribute on the scene shapes with the given string value
-def __setTagsFilterPreviewAttributes( sceneShapes, tagName, *unused ) :
+def _setTagsFilterPreviewAttributes( sceneShapes, tagName, *unused) :
 
 	for sceneShape in sceneShapes:
 		transform = maya.cmds.listRelatives( sceneShape, parent=True, fullPath=True )

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -31,6 +31,7 @@
 #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 ##########################################################################
+import functools
 
 import maya.cmds
 
@@ -42,7 +43,7 @@ __dagMenuCallbacks = []
 ## Registers a callback to be used when creating the right click dag
 # menu for scene shapes. Callbacks should have the following signature :
 #
-# callback( menu, sceneShape ).
+# callback( menuDefinition, sceneShape ).
 def addDagMenuCallback( callback ) :
 
 	if not callback in __dagMenuCallbacks :
@@ -53,314 +54,161 @@ def removeDagMenuCallback( callback ) :
 
 	__dagMenuCallbacks.remove( callback )
 
-## This is forwarded to by the ieSceneShapeDagMenuProc function in
-# ieSceneShape.mel
-def _dagMenu( menu, sceneShape ) :
-
+def _menuDefinition( callbackShape ) :
 	sceneShapes = __selectedSceneShapes()
-	if not sceneShapes:
+	if not sceneShapes :
 		return
 
-	fnScS = []
-	for target in sceneShapes:
-		fnScS.append( IECoreMaya.FnSceneShape( target ) )
+	mainDef = IECore.MenuDefinition()
 
-	maya.cmds.setParent( menu, menu=True )
+	fnShapes = [ IECoreMaya.FnSceneShape( shape ) for shape in sceneShapes ]
 
+	# INVALID SHAPES
 	invalidSceneShapes = __invalidSceneShapes( sceneShapes )
+	if invalidSceneShapes :
+		mainDef.append( "/Invalid Inputs for selected SceneShapes!", { "blindData" : { "maya" : { "radialPosition" : "N" } } } )
+		return mainDef
 
-	if invalidSceneShapes:
-		maya.cmds.menuItem(
-		label = "Invalid Inputs for selected SceneShapes!",
-		radialPosition = "N",
-		)
+	# COMPONENT MODE
+	if fnShapes[ 0 ].selectedComponentNames() :
+		mainDef.append( "/Object", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __objectCallback, sceneShapes[ 0 ] ) } )
+		mainDef.append( "/Print Component Names", { "blindData" : { "maya" : { "radialPosition" : "NW" } }, "command" : functools.partial( __printComponents, sceneShapes[ 0 ] ) } )
+		mainDef.append( "/Print Selected Component Names", { "blindData" : { "maya" : { "radialPosition" : "NE" } }, "command" : functools.partial( __printSelectedComponents, sceneShapes[ 0 ] ) } )
 
-	# Component mode
-	elif fnScS[0].selectedComponentNames():
+		# EXPAND
+		expandDef = IECore.MenuDefinition( [
+			("/Expand to Selected Components", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __expandToSelected, sceneShapes[ 0 ] ) }),
+		] )
+		mainDef.append( "/Expand...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandDef } )
 
-			maya.cmds.menuItem(
-			label = "Object",
-			radialPosition = "N",
-			command = IECore.curry( __objectCallback, sceneShapes[0] ),
-			)
+		locatorDef = IECore.MenuDefinition( [
+			("/At Bound Min", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __createLocatorAtPoints, sceneShapes[ 0 ], [ "Min" ] ) }),
+			("/At Bound Max", { "blindData" : { "maya" : { "radialPosition" : "NE" } }, "command" : functools.partial( __createLocatorAtPoints, sceneShapes[ 0 ], [ "Max" ] ) }),
+			("/At Bound Min And Max", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( __createLocatorAtPoints, sceneShapes[ 0 ], [ "Min", "Max" ] ) }),
+			("/At Bound Centre", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "command" : functools.partial( __createLocatorAtPoints, sceneShapes[ 0 ], [ "Center" ] ) }),
+			("/At Transform Origin", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __createLocatorWithTransform, sceneShapes[ 0 ] ) }),
+		] )
+		mainDef.append( "/Create Locator", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : locatorDef } )
 
-			maya.cmds.menuItem(
-				label = "Print Component Names",
-				radialPosition = "NW",
-				command = IECore.curry( __printComponents, sceneShapes[0] )
-			)
+	# OBJECT MODE
+	else :
+		# PREVIEW
+		if len( sceneShapes ) == 1 and (maya.cmds.getAttr( sceneShapes[ 0 ] + ".drawGeometry" ) or maya.cmds.getAttr( sceneShapes[ 0 ] + ".drawChildBounds" )) :
+			mainDef.append( "/Component", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __componentCallback, sceneShapes[ 0 ] ) } )
 
-			maya.cmds.menuItem(
-				label = "Print Selected Component Names",
-				radialPosition = "NE",
-				command = IECore.curry( __printSelectedComponents, sceneShapes[0] )
-			)
+		previewDef = IECore.MenuDefinition( [
+			("/All Geometry On", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawGeometry", True ) }),
+			("/All Child Bounds On", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawChildBounds", True ) }),
+			("/All Root Bound On", { "blindData" : { "maya" : { "radialPosition" : "NE" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawRootBound", True ) }),
+			("/All Geometry Off", { "blindData" : { "maya" : { "radialPosition" : "W" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawGeometry", False ) }),
+			("/All Child Bounds Off", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawChildBounds", False ) }),
+			("/All Root Bound Off", { "blindData" : { "maya" : { "radialPosition" : "NE" } }, "command" : functools.partial( __setChildrenPreviewAttributes, sceneShapes, "drawRootBound", False ) })
+		] )
 
-			maya.cmds.menuItem(
-				label = "Expand...",
-				radialPosition = "SE",
-				subMenu = True
-			)
+		mainDef.append( "/Preview...", { "blindData" : { "maya" : { "radialPosition" : "NW" } }, "subMenu" : previewDef } )
 
-			maya.cmds.menuItem(
-				label = "Expand to Selected Components",
-				radialPosition = "S",
-				command = IECore.curry( __expandToSelected, sceneShapes[0] )
-			)
-			maya.cmds.setParent( "..", menu=True )
-
-			maya.cmds.menuItem(
-				label = "Create Locator",
-				radialPosition = "SW",
-				subMenu = True,
-			)
-
-			maya.cmds.menuItem(
-				label = "At Bound Min",
-				radialPosition = "N",
-				command = IECore.curry( __createLocatorAtPoints, sceneShapes[0], [ "Min" ] ),
-			)
-
-			maya.cmds.menuItem(
-				label = "At Bound Max",
-				radialPosition = "NE",
-				command = IECore.curry( __createLocatorAtPoints, sceneShapes[0], [ "Max" ] ),
-			)
-
-			maya.cmds.menuItem(
-				label = "At Bound Min And Max",
-				radialPosition = "E",
-				command = IECore.curry( __createLocatorAtPoints, sceneShapes[0], [ "Min", "Max" ] ),
-			)
-
-			maya.cmds.menuItem(
-				label = "At Bound Centre",
-				radialPosition = "SE",
-				command = IECore.curry( __createLocatorAtPoints, sceneShapes[0], [ "Center" ] ),
-			)
-
-			maya.cmds.menuItem(
-				label = "At Transform Origin",
-				radialPosition = "S",
-				command = IECore.curry( __createLocatorWithTransform, sceneShapes[0] ),
-			)
-			maya.cmds.setParent( "..", menu=True )
-
-	# Object mode
-	else:
-
-		if len( sceneShapes ) == 1:
-			if maya.cmds.getAttr( sceneShapes[0]+".drawGeometry" ) or maya.cmds.getAttr( sceneShapes[0]+".drawChildBounds" ):
-				maya.cmds.menuItem(
-					label = "Component",
-					radialPosition = "N",
-					command = IECore.curry( __componentCallback, sceneShapes[0] )
-					)
-
-		maya.cmds.menuItem(
-			label = "Preview...",
-			radialPosition = "NW",
-			subMenu = True
-		)
-
-		maya.cmds.menuItem(
-				label = "All Geometry On",
-				radialPosition = "E",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawGeometry", True )
-			)
-
-		maya.cmds.menuItem(
-				label = "All Child Bounds On",
-				radialPosition = "SE",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawChildBounds", True )
-			)
-
-		maya.cmds.menuItem(
-				label = "All Root Bound On",
-				radialPosition = "NE",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawRootBound", True )
-			)
-
-		maya.cmds.menuItem(
-				label = "All Geometry Off",
-				radialPosition = "W",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawGeometry", False )
-			)
-
-		maya.cmds.menuItem(
-				label = "All Child Bounds Off",
-				radialPosition = "SW",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawChildBounds", False )
-			)
-
-		maya.cmds.menuItem(
-				label = "All Root Bound Off",
-				radialPosition = "NW",
-				command = IECore.curry( __setChildrenPreviewAttributes, sceneShapes, "drawRootBound", False )
-			)
-
-		maya.cmds.setParent( "..", menu=True )
-
-
+		# get all tags that are shared between all shapes
 		commonTags = None
-		for fn in fnScS:
+		for fn in fnShapes :
 			scene = fn.sceneInterface()
-			tmpTags = scene.readTags(IECoreScene.SceneInterface.EveryTag)
-			if commonTags is None:
+			tmpTags = scene.readTags( IECoreScene.SceneInterface.EveryTag )
+			if commonTags is None :
 				commonTags = set( tmpTags )
-			else:
-				commonTags.intersection_update( set(tmpTags) )
+			else :
+				commonTags.intersection_update( set( tmpTags ) )
 
 		tagTree = dict()
-		if not commonTags is None:
-			tags = list(commonTags)
-			for tag in tags :
-				tag = str(tag)
-				parts = tag.split(":")
-				leftOverTag = tag[len(parts[0])+1:]
-				if not parts[0] in tagTree :
-					tagTree[parts[0]] = [ leftOverTag ]
+		if commonTags :
+			for tag in commonTags :
+				tag = str( tag )
+				namespace, _, subTagsString = tag.partition( ':' )
+				subTags = set( subTagsString.split( ':' ) )
+				if not namespace in tagTree :
+					tagTree[ namespace ] = subTags
 				else :
-					tagTree[parts[0]].append( leftOverTag )
-		if tagTree :
+					tagTree[ namespace ].update( subTags )
 
+		# EXPAND
+		expandDef = IECore.MenuDefinition(
+			[ ("/Recursive Expand As Geometry", { "blindData" : { "maya" : { "radialPosition" : "W" } }, "command" : functools.partial( __expandAsGeometry, sceneShapes ) }) ] )
+		mainDef.append( "/Expand...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandDef } )
+
+		if any( map( lambda x : x.canBeExpanded(), fnShapes ) ) :
+
+			expandDef.append( "/Expand One Level", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( __expandOnce, sceneShapes ) } )
+			expandDef.append( "/Recursive Expand", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __expandAll, sceneShapes ) } )
+
+			if len( sceneShapes ) == 1 and fnShapes[ 0 ].selectedComponentNames() :
+				expandDef.append( "/Expand to Selected Components", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __expandToSelected, sceneShapes[ 0 ] ) } )
+
+		if tagTree :
 			tags = tagTree.keys()
 			tags.sort()
 
-			def addTagSubMenuItems( command ):
-
+			def addTagSubMenuItems( menuDef, command ) :
 				import copy
 				copiedTagTree = copy.deepcopy( tagTree )
-
 				for tag in tags :
-
-					subtags = copiedTagTree[tag]
+					subtags = list( copiedTagTree[ tag ] )
 					subtags.sort()
 
-					if "" in subtags:
-						maya.cmds.menuItem(
-							label = tag,
-							command = IECore.curry( command, sceneShapes, tag )
-						)
-						subtags.remove("")
+					for subtag in subtags :
+						if subtag == '' :
+							label = "/{}".format( tag )
+							expandTag = tag
+						else :
+							label = "/{}/{}".format( tag, subtag )
+							expandTag = "{}:{}".format( tag, subtag )
+						menuDef.append( label, { "command" : functools.partial( command, sceneShapes, expandTag ) } )
 
-					if subtags:
-						maya.cmds.menuItem(
-							label = tag,
-							subMenu = True
-						)
+			filterDef = IECore.MenuDefinition( [
+				("/Display All", { "command" : functools.partial( __setTagsFilterPreviewAttributes, sceneShapes, "" ) })
+			] )
+			expandTagDef = IECore.MenuDefinition()
+			expandTagGeoDef = IECore.MenuDefinition()
+			mainDef.append( "/Tags filter...", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "subMenu" : filterDef } )
 
-						for tagSuffix in subtags :
-							maya.cmds.menuItem(
-								label = tagSuffix,
-								command = IECore.curry( command, sceneShapes, tag + ":" + tagSuffix )
-							)
-						maya.cmds.setParent( "..", menu=True )
+			addTagSubMenuItems( filterDef, __setTagsFilterPreviewAttributes )
+			addTagSubMenuItems( expandTagDef, __expandAll )
+			addTagSubMenuItems( expandTagGeoDef, __expandAsGeometry )
 
-			maya.cmds.menuItem(
-				label = "Tags filter...",
-				radialPosition = "S",
-				subMenu = True
-			)
-
-			maya.cmds.menuItem(
-				label = "Display All",
-				command = IECore.curry( __setTagsFilterPreviewAttributes, sceneShapes, "" )
-			)
-
-			addTagSubMenuItems( __setTagsFilterPreviewAttributes )
-
-			maya.cmds.setParent( "..", menu=True )
-
-		maya.cmds.menuItem(
-			label = "Expand...",
-			radialPosition = "SE",
-			subMenu = True
-		)
-
-		maya.cmds.menuItem(
-				label = "Recursive Expand As Geometry",
-				radialPosition = "W",
-				command = IECore.curry( __expandAsGeometry, sceneShapes )
-			)
-
-		if any( map(lambda x: x.canBeExpanded(), fnScS) ):
-
-			maya.cmds.menuItem(
-				label = "Expand One Level",
-				radialPosition = "E",
-				command = IECore.curry( __expandOnce, sceneShapes )
-			)
-
-			maya.cmds.menuItem(
-				label = "Recursive Expand",
-				radialPosition = "N",
-				command = IECore.curry( __expandAll, sceneShapes )
-			)
-
-			if len( sceneShapes ) == 1:
-				if fnScS[0].selectedComponentNames() :
-					maya.cmds.menuItem(
-						label = "Expand to Selected Components",
-						radialPosition = "S",
-						command = IECore.curry( __expandToSelected, sceneShapes[0] )
-					)
-
-		if tagTree :
-			maya.cmds.menuItem(
-				label = "Expand by Tag...",
-				radialPosition = "SW",
-				subMenu = True
-			)
-
-			addTagSubMenuItems( __expandAll )
-
-			maya.cmds.setParent( "..", menu=True )
-
-			# expand as geometry
-			maya.cmds.menuItem(
-				label = "Expand by Tag as Geo...",
-				radialPosition = "SE",
-				subMenu = True
-			)
-
-			addTagSubMenuItems( __expandAsGeometry )
-
-			maya.cmds.setParent( "..", menu=True )
-
-		maya.cmds.setParent( "..", menu=True )
+			expandDef.append( "/Expand by Tag...", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : expandTagDef } )
+			expandDef.append( "/Expand by Tag as Geo...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandTagGeoDef } )
 
 		parentSceneShape = __parentSceneShape( sceneShapes )
 
-		if any( map(lambda x: x.canBeCollapsed(), fnScS) ) or ( parentSceneShape and IECoreMaya.FnSceneShape( parentSceneShape ).canBeCollapsed() ):
+		# COLLAPSE
+		if any( map( lambda x : x.canBeCollapsed(), fnShapes ) ) or (parentSceneShape and IECoreMaya.FnSceneShape( parentSceneShape ).canBeCollapsed()) :
 
-			maya.cmds.menuItem(
-					label = "Collapse...",
-					radialPosition = "SW",
-					subMenu = True
-				)
+			collapseDef = IECore.MenuDefinition()
 
-			if parentSceneShape and IECoreMaya.FnSceneShape( parentSceneShape ).canBeCollapsed():
+			if parentSceneShape and IECoreMaya.FnSceneShape( parentSceneShape ).canBeCollapsed() :
+				parentName = maya.cmds.listRelatives( parentSceneShape, p = True )[ 0 ]
+				collapseDef.append( "/Collapse to Parent: {}".format( parentName ),
+					{ "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( __collapseChildren, [ parentSceneShape ] ) } )
 
-				parentName = maya.cmds.listRelatives( parentSceneShape, p=True )[0]
-				maya.cmds.menuItem(
-						label = "Collapse to Parent: "+parentName,
-						radialPosition = "N",
-						command = IECore.curry( __collapseChildren, [parentSceneShape] )
-					)
+			if any( map( lambda x : x.canBeCollapsed(), fnShapes ) ) :
+				collapseDef.append( "/Collapse Children", { "blindData" : { "maya" : { "radialPosition" : "W" } }, "command" : functools.partial( __collapseChildren, sceneShapes ) } )
 
-			if any( map(lambda x: x.canBeCollapsed(), fnScS) ):
-				maya.cmds.menuItem(
-						label = "Collapse Children",
-						radialPosition = "W",
-						command = IECore.curry( __collapseChildren, sceneShapes )
-					)
+			mainDef.append( "/Collapse...", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : collapseDef } )
 
-			maya.cmds.setParent( "..", menu=True )
+	return mainDef
 
-	for c in __dagMenuCallbacks :
 
-		c( menu, sceneShape )
+## This is forwarded to by the ieSceneShapeDagMenuProc function in
+# ieSceneShape.mel
+def _dagMenu( parentMenu, sceneShape ) :
+	menuDef = _menuDefinition( sceneShape )
+	if not menuDef :
+		return
+
+	# Pass menu definition to registered callbacks to collect changes / additions
+	for callback in __dagMenuCallbacks :
+		callback( menuDef, sceneShape )
+
+	# build menu from menu definition
+	cortexMenu = IECoreMaya.Menu( menuDef, parentMenu, keepCallback = True )
+
 
 ## Returns all the sceneShapes that do not have a valid scene interface
 def __invalidSceneShapes( sceneShapes ):
@@ -579,4 +427,3 @@ def __createLocatorWithTransform( sceneShape, *unused ) :
 		locators.append( fnSc.createLocatorAtTransform( name ) )
 
 	maya.cmds.select( locators, replace=True )
-


### PR DESCRIPTION
Requirements
---
- Cortex (#1009) 

Breaking Changes
---
- `IECoreMaya.SceneShapeUI`: Callbacks registered via `addDagMenuCallback` should now have the signature `callback( menuDefinition, sceneShape )` instead of `callback( menu, sceneShape )` and have to use the menu definition to add new entries / modify exisiting ones.

Improvements
---
- SceneShapeUI: Rewrote DAG Menu to use `IECoreMaya.Menu` (#1008)
- MenuDefinition: added `size()` (#1008)

API
---
- Menu: added support for menu generation without overriding postMenu callback (#1008)
