### PR TITLE
OpenImageIO 2 and Appleseed 2.1 compatibility

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -276,12 +276,8 @@ class DisplayTileCallback : public ProgressTileCallback
 
 	public :
 
-		DisplayTileCallback( const DisplayLayersPtr &layers )
+		explicit DisplayTileCallback( const DisplayLayersPtr &layers )
 			:	m_layers( layers )
-		{
-		}
-
-		~DisplayTileCallback() override
 		{
 		}
 
@@ -292,10 +288,12 @@ class DisplayTileCallback : public ProgressTileCallback
 
 		void on_tile_begin(const asr::Frame *frame, const size_t tileX, const size_t tileY) override
 		{
+			ProgressTileCallback::on_tile_begin( frame, tileX, tileY );
+
 			const asf::CanvasProperties &props = frame->image().properties();
 			const size_t x = tileX * props.m_tile_width;
 			const size_t y = tileY * props.m_tile_height;
-			for( auto &layer : *m_layers )
+			for( const auto &layer : *m_layers )
 			{
 				layer->initDisplay( frame );
 				layer->highlightRegion( x, y, props.m_tile_width, props.m_tile_height );
@@ -306,7 +304,7 @@ class DisplayTileCallback : public ProgressTileCallback
 		{
 			ProgressTileCallback::on_tile_end( frame, tileX, tileY );
 
-			for( auto &layer : *m_layers )
+			for( const auto &layer : *m_layers )
 			{
 				layer->initDisplay( frame );
 				layer->writeTile( tileX, tileY );
@@ -321,7 +319,7 @@ class DisplayTileCallback : public ProgressTileCallback
 			{
 				for( size_t tx = 0; tx < frame_props.m_tile_count_x; ++tx )
 				{
-					for( auto &layer : *m_layers )
+					for( const auto &layer : *m_layers )
 					{
 						layer->initDisplay( frame );
 						layer->writeTile( tx, ty );

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -315,13 +315,17 @@ class DisplayTileCallback : public ProgressTileCallback
 		{
 			const asf::CanvasProperties &frame_props = frame->image().properties();
 
+			for( const auto &layer : *m_layers )
+			{
+				layer->initDisplay( frame );
+			}
+
 			for( size_t ty = 0; ty < frame_props.m_tile_count_y; ++ty )
 			{
 				for( size_t tx = 0; tx < frame_props.m_tile_count_x; ++tx )
 				{
 					for( const auto &layer : *m_layers )
 					{
-						layer->initDisplay( frame );
 						layer->writeTile( tx, ty );
 					}
 				}

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/outputDriver/DisplayTileCallback.cpp
@@ -50,7 +50,6 @@
 #include "renderer/api/log.h"
 #include "renderer/api/rendering.h"
 #include "renderer/api/utility.h"
-#include "renderer/api/version.h"
 
 #include <vector>
 
@@ -272,8 +271,7 @@ class DisplayTileCallback : public ProgressTileCallback
 
 		void release() override
 		{
-			// We don't need to do anything here.
-			// The tile callback factory deletes this instance.
+			delete this;
 		}
 
 		void on_tile_begin(const asr::Frame *frame, const size_t tileX, const size_t tileY) override
@@ -359,13 +357,12 @@ class DisplayTileCallbackFactory : public asr::ITileCallbackFactory
 	public:
 
 		explicit DisplayTileCallbackFactory( const asr::ParamArray &params )
+			:	m_params( params )
 		{
-			m_callback = new DisplayTileCallback( params );
 		}
 
 		~DisplayTileCallbackFactory() override
 		{
-			delete m_callback;
 		}
 
 		// Delete this instance.
@@ -377,12 +374,12 @@ class DisplayTileCallbackFactory : public asr::ITileCallbackFactory
 		// Return a new tile callback instance.
 		asr::ITileCallback *create() override
 		{
-			return m_callback;
+			return new DisplayTileCallback( m_params );
 		}
 
 	private:
 
-		DisplayTileCallback *m_callback;
+		const asr::ParamArray m_params;
 
 };
 

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -60,6 +60,39 @@ using namespace IECoreImage;
 
 IE_CORE_DEFINERUNTIMETYPED( ImageReader );
 
+namespace
+{
+
+#if OIIO_VERSION > 20000
+
+using ImageInputPtr = ImageInput::unique_ptr;
+ImageInputPtr createImageInput( const std::string &fileName )
+{
+	return ImageInput::create( fileName );
+}
+
+ImageInputPtr openImageInput( const std::string &fileName )
+{
+	return ImageInput::open( fileName );
+}
+
+#else
+
+using ImageInputPtr = unique_ptr<ImageInput, decltype(&ImageInput::destroy)>;
+ImageInputPtr createImageInput( const std::string &fileName )
+{
+	return ImageInputPtr( ImageInput::create( fileName ), &ImageInput::destroy );
+}
+
+ImageInputPtr openImageInput( const std::string &fileName )
+{
+	return ImageInputPtr( ImageInput::open( fileName ), &ImageInput::destroy );
+}
+
+#endif
+
+} // namespace
+
 ////////////////////////////////////////////////////////////////////////////////
 // ImageReader::Implementation
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,10 +115,10 @@ class ImageReader::Implementation
 		{
 			bool result = false;
 
-			if( ImageInput *input = ImageInput::create( filename ) )
+			ImageInputPtr input = createImageInput( filename );
+			if( input )
 			{
 				result = input->valid_file( filename );
-				ImageInput::destroy( input );
 			}
 
 			return result;
@@ -106,7 +139,7 @@ class ImageReader::Implementation
 				if( isDeep() )
 				{
 					DeepData deepData;
-					ImageInput *input = ImageInput::open( m_inputFileName.c_str() );
+					ImageInputPtr input = openImageInput( m_inputFileName.c_str() );
 
 					// Note that the spec we get from the image cache has a tiling setting
 					// based on the caching settings, not the file on disk, so we have to


### PR DESCRIPTION
This started out as an innocent little tweak to support OIIO 2 in IECoreImage. But OIIO 2 begat OSL 1.10, which begat Appleseed 2.1, which begat many happy hours of debugging. I've presented a sequence of commits to fix the Appleseed problem, starting with a minimal hack that seems sufficient, and culminating in what I believe is the truly correct fix. I'd like to keep the history of that intact in case there turns out to be anything wrong with the more complex solution.

This is all in aid of getting an updated set of dependencies for Gaffer 0.56, as OIIO 2 has some nice new features that might help us with our performance goals. Here the CI will run against the old dependencies package though, hopefully demonstrating that my changes haven't broken anything for the current setup.