### PR TITLE
Build : Use -D_GLIBCXX_USE_CXX11_ABI=0 when needed

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1118,6 +1118,13 @@ if env["PLATFORM"] != "win32" :
 		if osxVersion[0] == 10 and osxVersion[1] > 7 :
 			env.Append( CXXFLAGS = [ "-Wno-unused-local-typedef", "-Wno-deprecated-declarations" ] )
 
+	elif env["PLATFORM"]=="posix" :
+		if "g++" in os.path.basename( env["CXX"] ) :
+			gccVersion = subprocess.Popen( [ env["CXX"], "-dumpversion" ], env=env["ENV"], stdout=subprocess.PIPE ).stdout.read().strip()
+			gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
+			if gccVersion >= [ 5, 1 ] :
+				env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )
+
 	env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )
 
 	if "clang++" in os.path.basename( env["CXX"] ) :

--- a/config/ie/options
+++ b/config/ie/options
@@ -125,7 +125,7 @@ os.environ["COMPILER"] = compiler
 os.environ["COMPILER_VERSION"] = compilerVersion
 
 CXX = os.path.join( compilerReg["location"], compilerReg["bin"] )
-CXXSTD = cxxStd
+CXXSTD = getOption( "CXXSTD", cxxStd )
 
 m = re.compile( "^([0-9]+)\.([0-9]+)\.([0-9]+)$" ).match( compilerVersion )
 if m :


### PR DESCRIPTION
VFX Platform requires this flag when using modern GCC. I'd originally added it as an IE option, but then I saw Gaffer is doing this in the SConstruct directly, so I've followed that example instead.