### PR TITLE
Azure: Update URL to latest Windows Doygen binary

### DIFF
--- a/config/azure/build.yaml
+++ b/config/azure/build.yaml
@@ -50,7 +50,7 @@ jobs:
        targetType: 'inline'
        script: |
          if (-not (Test-Path doxygen\doxygen.exe)) {
-           wget http://doxygen.nl/files/doxygen-1.8.15.windows.x64.bin.zip -OutFile doxygen.zip
+           wget http://doxygen.nl/files/doxygen-1.8.17.windows.x64.bin.zip -OutFile doxygen.zip
            Expand-Archive -LiteralPath doxygen.zip -DestinationPath doxygen
            Remove-Item -path doxygen.zip
          }


### PR DESCRIPTION
Version 1.8.15 is not available on `doxygen.nl` anymore, updated to latest version 1.8.17.
To prevent this from happening, we should move to SourceForge builds in the future. However, after some initial investigation, SourceForge downloads might need some additional tweaking to unzip correctly.

```
2020-01-02T08:00:50.1245212Z ##[section]Starting: Install Toolchain (Windows)
2020-01-02T08:00:50.1341037Z ==============================================================================
2020-01-02T08:00:50.1341467Z Task         : PowerShell
2020-01-02T08:00:50.1341546Z Description  : Run a PowerShell script on Linux, macOS, or Windows
2020-01-02T08:00:50.1341635Z Version      : 2.151.2
2020-01-02T08:00:50.1341695Z Author       : Microsoft Corporation
2020-01-02T08:00:50.1341761Z Help         : https://docs.microsoft.com/azure/devops/pipelines/tasks/utility/powershell
2020-01-02T08:00:50.1341883Z ==============================================================================
2020-01-02T08:00:50.8363056Z Generating script.
2020-01-02T08:00:51.1983129Z ========================== Starting Command Output ===========================
2020-01-02T08:00:51.2188453Z ##[command]"C:\windows\System32\WindowsPowerShell\v1.0\powershell.exe" -NoLogo -NoProfile -NonInteractive -ExecutionPolicy Unrestricted -Command ". 'd:\a\_temp\a8d3f40e-2d9b-4e17-b756-6a6ab44d34a8.ps1'"
2020-01-02T08:00:54.6106525Z New-Object : Exception calling ".ctor" with "3" argument(s): "End of Central Directory record could not be found."
2020-01-02T08:00:54.6107843Z At 
2020-01-02T08:00:54.6109101Z C:\windows\system32\WindowsPowerShell\v1.0\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:934 
2020-01-02T08:00:54.6109946Z char:23
2020-01-02T08:00:54.6110047Z + ... ipArchive = New-Object -TypeName System.IO.Compression.ZipArchive -Ar ...
2020-01-02T08:00:54.6110161Z +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2020-01-02T08:00:54.6110250Z     + CategoryInfo          : InvalidOperation: (:) [New-Object], MethodInvocationException
2020-01-02T08:00:54.6110360Z     + FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand
2020-01-02T08:00:54.6110436Z  
2020-01-02T08:00:54.7293434Z ##[error]PowerShell exited with code '1'.
2020-01-02T08:00:54.7571523Z ##[section]Finishing: Install Toolchain (Windows)
```

Fixes
--- 
- Azure: Update URL to latest Windows Doygen binary (#1015)