### PR TITLE
IECoreMaya SceneShape : Fix drawing in VP2 Flat Shaded mode.

### DIFF
--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1660,7 +1660,7 @@ void SceneShapeSubSceneOverride::checkDisplayOverrides( unsigned int displayStyl
 
 	// Determine if we need to render shaded geometry
 	mask.reset( (int)RenderStyle::Solid );
-	if( geometryOverride && ( displayStyle & ( MHWRender::MFrameContext::kGouraudShaded | MHWRender::MFrameContext::kTextured ) ) > 0 )
+	if( geometryOverride && ( displayStyle & ( MHWRender::MFrameContext::kGouraudShaded | MHWRender::MFrameContext::kTextured | MHWRender::MFrameContext::kFlatShaded ) ) > 0 )
 	{
 		mask.set( (int)RenderStyle::Solid );
 	}


### PR DESCRIPTION
This is just drawing the same as it would for smooth shaded... that's not ideal, but its better than what we have now (not drawing at all). Unfortunately I don't see an MStockShader set to flat mode...