### PR TITLE
A few VP2 fixes for IECoreMaya

### DIFF
--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -55,13 +55,8 @@ namespace IECoreMaya
 struct GeometryData
 {
 public :
-	GeometryData()
-	{
-	}
-
-	~GeometryData()
-	{
-	}
+	GeometryData() = default;
+	~GeometryData() = default;
 
 	IECore::ConstV3fVectorDataPtr positionData;
 	IECore::ConstV3fVectorDataPtr normalData;
@@ -109,7 +104,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 	protected :
 
-		SceneShapeSubSceneOverride( const MObject& obj );
+		explicit SceneShapeSubSceneOverride( const MObject& obj );
 
 	private :
 
@@ -123,7 +118,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		struct Instance
 		{
-			Instance( Imath::M44d transformation, bool selected, bool componentMode, MDagPath path, bool visible )
+			Instance( const Imath::M44d &transformation, bool selected, bool componentMode, const MDagPath &path, bool visible )
 				: transformation( transformation ), selected( selected ), componentMode( componentMode ), path( path ), visible( visible )
 			{
 			}
@@ -155,9 +150,9 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		RenderItemUserDataPtr acquireUserData( int componentIndex );
 		void selectedComponentIndices( IndexMap &indexMap ) const;
-		void setBuffersForRenderItem( GeometryDataPtr geometryData, MHWRender::MRenderItem *renderItem, bool useWireframeIndex, const MBoundingBox &boundingBox );
+		void setBuffersForRenderItem( GeometryDataPtr &geometryData, MHWRender::MRenderItem *renderItem, bool useWireframeIndex, const MBoundingBox &boundingBox );
 
-		void bufferEvictedCallback( const BufferPtr buffer ); // \todo
+		void bufferEvictedCallback( const BufferPtr &buffer );
 
 		SceneShape *m_sceneShape;
 

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -566,25 +566,28 @@ void fillMeshData( const Object *object, const MVertexBufferDescriptorList &desc
 	normalOp->operate();
 
 	tbb::task_group g;
-	g.run( [&geometryData, &expandulator, &meshPrimitive]
-				 {
-					 geometryData->positionData = expandulator->expandulateVertex( *(meshPrimitive->variableIndexedView<IECore::V3fVectorData>( "P" ) ) );
-				 }
+	g.run(
+		[&geometryData, &expandulator, &meshPrimitive]
+		{
+			geometryData->positionData = expandulator->expandulateVertex( *(meshPrimitive->variableIndexedView<IECore::V3fVectorData>( "P" ) ) );
+		}
 	);
 
-	g.run( [&geometryData, &expandulator, &copy]
-				 {
-					 geometryData->normalData = expandulator->expandulateVertex( *(copy->variableIndexedView<IECore::V3fVectorData>( "N") ) );
-				 }
+	g.run(
+		[&geometryData, &expandulator, &copy]
+		{
+			geometryData->normalData = expandulator->expandulateVertex( *(copy->variableIndexedView<IECore::V3fVectorData>( "N") ) );
+		}
 	);
 
 	auto uvView = meshPrimitive->variableIndexedView<IECore::V2fVectorData>( "uv" );
 	if( uvView )
 	{
-		g.run( [&geometryData, &expandulator, &uvView]
-					 {
-						 geometryData->uvData = expandulator->expandulateFacevarying( *uvView);
-					 }
+		g.run(
+			[&geometryData, &expandulator, &uvView]
+			{
+				geometryData->uvData = expandulator->expandulateFacevarying( *uvView);
+			}
 		);
 	}
 

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1612,9 +1612,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			baseItemName += "_time_" + std::to_string( m_time );
 		}
 
-		Imath::Box3d boundingBox = sceneInterface->readBound( m_time );
-		const MBoundingBox mayaBoundingBox = IECore::convert<MBoundingBox>( boundingBox );
-
 		int count = 0;
 		for( const auto &instance : m_instances )
 		{
@@ -1655,7 +1652,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 				}
 				else
 				{
-					ConstPrimitivePtr primitive = IECore::runTimeCast<const Primitive>( object );
 					geometryData = g_geometryDataCache.get( GeometryDataCacheGetterKey( primitive, renderItem->requiredVertexBuffers(), boundingBox ) );
 				}
 

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -531,7 +531,7 @@ struct ExpandulatorCacheGetterKey
 	IECore::MurmurHash hash;
 };
 
-ExpandulatorPtr expandulatorGetter( const ExpandulatorCacheGetterKey &key, size_t cost )
+ExpandulatorPtr expandulatorGetter( const ExpandulatorCacheGetterKey &key, size_t &cost )
 {
 	cost = 1;
 	return std::make_shared<Expandulator>( key.meshPrimitive.get() );


### PR DESCRIPTION
Fixes
---

- IECoreMaya SceneShape (#1018) :
  - Improved speed of SceneShape driven geometry by accounting for visibility during `requiresUpdate`
  - Fixed selection & disappearing object bugs in VP2 by making unique MRenderItems per SceneInterface location.
  - Fixed memory leak in the internal Expandulator LRUCache