### PR TITLE
Canceller : Add `cancelled()` method

### DIFF
--- a/include/IECore/Canceller.h
+++ b/include/IECore/Canceller.h
@@ -86,11 +86,16 @@ class Canceller : public boost::noncopyable
 			m_cancelled = true;
 		}
 
-		static void check( const Canceller *canceller )
+		bool cancelled() const
 		{
 			/// \todo Can we reduce overhead by reading
 			/// with a more relaxed memory ordering here?
-			if( canceller && canceller->m_cancelled )
+			return m_cancelled;
+		}
+
+		static void check( const Canceller *canceller )
+		{
+			if( canceller && canceller->cancelled() )
 			{
 				throw Cancelled();
 			}

--- a/src/IECorePython/CancellerBinding.cpp
+++ b/src/IECorePython/CancellerBinding.cpp
@@ -52,6 +52,7 @@ void bindCanceller()
 
 	class_<Canceller, boost::noncopyable>( "Canceller" )
 		.def( "cancel", &Canceller::cancel )
+		.def( "cancelled", &Canceller::cancelled )
 		.def( "check", &Canceller::check )
 		.staticmethod( "check" )
 	;

--- a/test/IECore/CancellerTest.py
+++ b/test/IECore/CancellerTest.py
@@ -45,8 +45,10 @@ class CancellerTest( unittest.TestCase ) :
 		IECore.Canceller.check( None )
 
 		c = IECore.Canceller()
+		self.assertFalse( c.cancelled() )
 		IECore.Canceller.check( c )
 		c.cancel()
+		self.assertTrue( c.cancelled() )
 
 		with self.assertRaises( IECore.Cancelled ) :
 			IECore.Canceller.check( c )


### PR DESCRIPTION
I was overzealous in keeping Canceller functionality to an absolute minimum. Although in all our direct use cases `check()` is preferable, we may have indirect use cases where we wish to interface Canceller with other libraries where cancellation is not implemented in terms of exceptions.

See the Interrupter class in https://github.com/GafferHQ/gaffer/pull/3565 for one example.
