### PR TITLE
IECoreMaya SceneShape VP2 : Combined the 3 internal caches

### DIFF
--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -37,6 +37,7 @@
 #include "IECoreMaya/Export.h"
 #include "IECoreMaya/SceneShape.h"
 
+#include "IECoreScene/Primitive.h"
 #include "IECoreScene/SceneInterface.h"
 
 #include "IECore/InternedString.h"
@@ -51,22 +52,6 @@
 
 namespace IECoreMaya
 {
-
-struct GeometryData
-{
-public :
-	GeometryData() = default;
-	~GeometryData() = default;
-
-	IECore::ConstV3fVectorDataPtr positionData;
-	IECore::ConstV3fVectorDataPtr normalData;
-	IECore::ConstV2fVectorDataPtr uvData;
-
-	IECore::ConstIntVectorDataPtr indexData;
-	IECore::ConstIntVectorDataPtr wireframeIndexData;
-};
-
-using GeometryDataPtr = std::shared_ptr<GeometryData>;
 
 using VertexBufferPtr = std::shared_ptr<MHWRender::MVertexBuffer>;
 using IndexBufferPtr = std::shared_ptr<MHWRender::MIndexBuffer>;
@@ -150,7 +135,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		RenderItemUserDataPtr acquireUserData( int componentIndex );
 		void selectedComponentIndices( IndexMap &indexMap ) const;
-		void setBuffersForRenderItem( GeometryDataPtr &geometryData, MHWRender::MRenderItem *renderItem, bool useWireframeIndex, const MBoundingBox &boundingBox );
+		void setBuffersForRenderItem( const IECoreScene::Primitive *primitive, MHWRender::MRenderItem *renderItem, bool wireframe, const MBoundingBox &bound );
 
 		void bufferEvictedCallback( const BufferPtr &buffer );
 


### PR DESCRIPTION
The primary motivation here was to use the single user-facing memory setting `IECORE_MAYA_VP2_MEMORY` directly as the memory limit of our internal cache. Previously we were arbitrarily splitting that memory budget between 3 caches.

A side benefit is that that we've decoupled the various primvar data (P, N, uv) as well as the wireframe vs non-wireframe indices for meshes, so we can compute them all independantly on-demand, and avoid the performance & memory cost if we don't need one of them. For example, if the user never activates Textured mode in the viewport, then we never compute the expandulated UVs.

I've also fixed the index buffers for PointsPrimitives, so they're now drawing correctly.

I realize this single uber commit is very hard to review.... by the time I'd figured out what I was doing, there wasn't any way to create sensible commits out of it so I just squashed it all down... if anyone has suggestions how to break this up more to make the review easier, I'm happy to try...