### PR TITLE
IECoreMaya SceneShape VP2 : Fixed draw errors for expanded shapes

### DIFF
--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -168,6 +168,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		bool m_instancedRendering;
 		IECoreScene::ConstSceneInterfacePtr m_sceneInterface;
 		bool m_geometryVisible;
+		bool m_objectOnly;
 
 		std::map<const std::string, MDagPath> m_renderItemNameToDagPath;
 		IndexMap m_selectedComponents;

--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -118,7 +118,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		struct Instance
 		{
-			Instance( const Imath::M44d &transformation, bool selected, bool componentMode, const MDagPath &path, bool visible )
+			Instance( const MMatrix &transformation, bool selected, bool componentMode, const MDagPath &path, bool visible )
 				: transformation( transformation ), selected( selected ), componentMode( componentMode ), path( path ), visible( visible )
 			{
 			}
@@ -128,7 +128,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 				return transformation == rhs.transformation && selected == rhs.selected && path == rhs.path && componentMode == rhs.componentMode && visible == rhs.visible;
 			}
 
-			Imath::M44d transformation;
+			MMatrix transformation;
 			bool selected;
 			bool componentMode;
 			MDagPath path;
@@ -138,7 +138,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		using Instances = std::vector<Instance>;
 
 		// Traverse the scene and create MRenderItems as necessary while collecting all matrices to be associated with them.
-		void visitSceneLocations( const IECoreScene::SceneInterface *sceneInterface, RenderItemMap &renderItems, MHWRender::MSubSceneContainer &container, const Imath::M44d &matrix, bool isRoot = false );
+		void visitSceneLocations( const IECoreScene::SceneInterface *sceneInterface, RenderItemMap &renderItems, MHWRender::MSubSceneContainer &container, const MMatrix &matrix, bool isRoot = false );
 
 		// Provide information about the instances that need drawing as
 		// SubSceneOverrides are responsible for drawing all instances of the

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1489,8 +1489,11 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 		return;
 	}
 
-	Imath::M44d accumulatedMatrix = sceneInterface->readTransformAsMatrix( m_time ) * matrix;
-	MMatrix mayaMatrix = IECore::convert<MMatrix, Imath::M44d>( accumulatedMatrix );
+	Imath::M44d accumulatedMatrix;
+	if( !isRoot )
+	{
+		accumulatedMatrix = sceneInterface->readTransformAsMatrix( m_time ) * matrix;
+	}
 
 	// Dispatch to children only if we need to draw them
 	if( ( m_geometryVisible || m_drawChildBounds ) && !m_objectOnly )
@@ -1549,7 +1552,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 				}
 			}
 
-			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( accumulatedMatrix * instance.transformation );
+			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( instance.transformation );
 			addInstanceTransform( *renderItem, instanceMatrix );
 		}
 	}
@@ -1689,7 +1692,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 
 			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( accumulatedMatrix * instance.transformation );
 			addInstanceTransform( *renderItem, instanceMatrix );
-
 		}
 	}
 }

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1473,7 +1473,7 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 
 	// Create and enable MRenderItems while traversing the scene hierarchy
 	RenderItemMap renderItems;
-	visitSceneLocations( m_sceneInterface.get(), renderItems, container, Imath::M44d(), /* isRoot = */ true );
+	visitSceneLocations( m_sceneInterface.get(), renderItems, container, MMatrix(), /* isRoot = */ true );
 
 	for( auto *item : m_renderItemsToEnable )
 	{
@@ -1482,17 +1482,17 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	m_renderItemsToEnable.clear();
 }
 
-void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *sceneInterface, RenderItemMap &renderItems, MSubSceneContainer &container, const Imath::M44d &matrix, bool isRoot )
+void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *sceneInterface, RenderItemMap &renderItems, MSubSceneContainer &container, const MMatrix &matrix, bool isRoot )
 {
 	if( !sceneInterface )
 	{
 		return;
 	}
 
-	Imath::M44d accumulatedMatrix;
+	MMatrix accumulatedMatrix;
 	if( !isRoot )
 	{
-		accumulatedMatrix = sceneInterface->readTransformAsMatrix( m_time ) * matrix;
+		accumulatedMatrix = IECore::convert<MMatrix, Imath::M44d>( sceneInterface->readTransformAsMatrix( m_time ) ) * matrix;
 	}
 
 	// Dispatch to children only if we need to draw them
@@ -1552,8 +1552,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 				}
 			}
 
-			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( instance.transformation );
-			addInstanceTransform( *renderItem, instanceMatrix );
+			addInstanceTransform( *renderItem, instance.transformation );
 		}
 	}
 
@@ -1690,8 +1689,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 				}
 			}
 
-			MMatrix instanceMatrix = IECore::convert<MMatrix, Imath::M44d>( accumulatedMatrix * instance.transformation );
-			addInstanceTransform( *renderItem, instanceMatrix );
+			addInstanceTransform( *renderItem, accumulatedMatrix * instance.transformation );
 		}
 	}
 }
@@ -1933,7 +1931,7 @@ void SceneShapeSubSceneOverride::collectInstances( Instances &instances ) const
 	for( size_t pathIndex = 0; pathIndex < numInstances; ++pathIndex )
 	{
 		MDagPath& path = dagPaths[pathIndex];
-		Imath::M44d matrix = IECore::convert<Imath::M44d, MMatrix>( path.inclusiveMatrix() );
+		MMatrix matrix = path.inclusiveMatrix();
 		bool pathSelected = isPathSelected( selectionList, path );
 		bool componentMode = componentsSelectable( path );
 		MFnDagNode nodeFn( path );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1288,6 +1288,14 @@ bool SceneShapeSubSceneOverride::requiresUpdate(const MSubSceneContainer& contai
 		return true;
 	}
 
+	// The objectOnly toggle determines if we need to recurse our internal scene locations
+	bool tmpObjectOnly;
+	MPlug( m_sceneShape->thisMObject(), SceneShape::aObjectOnly ).getValue( tmpObjectOnly );
+	if( tmpObjectOnly != m_objectOnly )
+	{
+		return true;
+	}
+
 	// TAGS FILTER UPDATED?
 	MString tmpTagsFilter;
 	MPlug drawTagsFilterPlug( m_sceneShape->thisMObject(), SceneShape::aDrawTagsFilter );


### PR DESCRIPTION
We had 2 issues with expanded SceneShapes. First, we weren't respecting the `objectOnly` toggle, so we were drawing child locations even when expanded and real MDagPaths exist for the child locations.

Second, we were doubling up matrices for the root locations. This went unnoticed because the matrices are often identity (eg for a deforming character) and for collapsed SceneShapes we nearly always have an identity matrix at the root. However, for a transform animation (eg a vehicle) which is expanded in Maya, we do have non-identity matrices and root locations. Since we're already getting the root matrix from the Maya MDagPath for the root, we don't need to read it from the SceneInterface directly.

The last commit here isn't strictly necessary, but it seems like a worthwhile cleanup while I was touching that part of the code.