### PR TITLE
IECoreMaya SceneShape VP2 : Fixes for component selection

### DIFF
--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1456,9 +1456,6 @@ bool SceneShapeInterface::buildComponentIndexMap()
 		return false;
 	}
 
-	m_nameToGroupMap.clear();
-	m_indexToNameMap.clear();
-
 	IECoreGL::RendererPtr renderer = new IECoreGL::Renderer();
 	renderer->setOption( "gl:mode", new StringData( "deferred" ) );
 
@@ -1468,8 +1465,12 @@ bool SceneShapeInterface::buildComponentIndexMap()
 	}
 	renderer->worldEnd();
 
+	// Update component name to group map
+	m_nameToGroupMap.clear();
+	m_indexToNameMap.clear();
 	IECoreGL::ConstStatePtr defaultState = IECoreGL::State::defaultState();
 	buildGroups( defaultState->get<const IECoreGL::NameStateComponent>(), renderer->scene()->root() );
+	createInstances();
 
 	return true;
 }

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1028,6 +1028,29 @@ bool sceneIsAnimated( const SceneInterface *sceneInterface )
 	return ( !scene || scene->numBoundSamples() > 1 );
 }
 
+/// \todo: this is copied from a private member of SceneShapeInterface.
+/// Either remove the need for it here or make that method public.
+std::string relativePathName( const SceneInterface::Path &root, const SceneInterface::Path &path )
+{
+	if( root == path )
+	{
+		return "/";
+	}
+
+	std::string pathName;
+
+	SceneInterface::Path::const_iterator it = path.begin();
+	it += root.size();
+
+	for ( ; it != path.end(); it++ )
+	{
+		pathName += '/';
+		pathName += it->value();
+	}
+
+	return pathName;
+}
+
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////////////////////////
@@ -1600,8 +1623,10 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	// We're going to render this object - compute its bounds only once and reuse them.
 	const MBoundingBox bound = IECore::convert<MBoundingBox>( sceneInterface->readBound( m_time ) );
 
+	SceneInterface::Path rootPath;
+	m_sceneShape->getSceneInterface()->path( rootPath );
 	/// \todo: stop using the SceneShapeInterface selectionIndex. It relies on a secondary IECoreGL render.
-	int componentIndex = m_sceneShape->selectionIndex( location );
+	int componentIndex = m_sceneShape->selectionIndex( ::relativePathName( rootPath, path ) );
 
 	// Adding RenderItems as needed
 	// ----------------------------

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1422,7 +1422,13 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	drawAllBoundsPlug.getValue( m_drawChildBounds );
 
 	// The objectOnly toggle determines if we need to recurse our internal scene locations
-	MPlug( m_sceneShape->thisMObject(), SceneShape::aObjectOnly ).getValue( m_objectOnly );
+	bool tmpObjectOnly = MPlug( m_sceneShape->thisMObject(), SceneShape::aObjectOnly ).asBool();
+	if( tmpObjectOnly != m_objectOnly )
+	{
+		m_objectOnly = tmpObjectOnly;
+		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
+		m_sceneShape->buildComponentIndexMap();
+	}
 
 	// TAGS
 	MString tmpTagsFilter;

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1379,6 +1379,7 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 		// All data in the container is invalid now and we can safely clear it
 		container.clear();
 		m_sceneInterface = tmpSceneInterface;
+		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
 		m_sceneShape->buildComponentIndexMap();
 	}
 
@@ -1407,6 +1408,7 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	if( tmpTagsFilter.asChar() != m_drawTagsFilter )
 	{
 		m_drawTagsFilter = tmpTagsFilter.asChar();
+		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
 		m_sceneShape->buildComponentIndexMap();
 	}
 
@@ -1503,6 +1505,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	}
 
 	// Dispatch to children only if we need to draw them
+	/// \todo: we should be accounting for the tag filter when recursing to children
 	if( ( m_geometryVisible || m_drawChildBounds ) && !m_objectOnly )
 	{
 		SceneInterface::NameList childNames;
@@ -1597,6 +1600,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	// We're going to render this object - compute its bounds only once and reuse them.
 	const MBoundingBox bound = IECore::convert<MBoundingBox>( sceneInterface->readBound( m_time ) );
 
+	/// \todo: stop using the SceneShapeInterface selectionIndex. It relies on a secondary IECoreGL render.
 	int componentIndex = m_sceneShape->selectionIndex( location );
 
 	// Adding RenderItems as needed
@@ -1657,6 +1661,7 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 
 			// Before setting geometry, a shader has to be assigned so that the data requirements are clear.
 			std::string pathKey = instance.path.fullPathName().asChar();
+			/// \todo: we're inserting pathKey into the map regardless of whether it existed before
 			bool componentSelected = m_selectedComponents[pathKey].count( componentIndex ) > 0;
 
 			MShaderInstance *shader = m_allShaders->getShader( style, instance.componentMode, instance.componentMode ? componentSelected : instance.selected );
@@ -1888,6 +1893,8 @@ void SceneShapeSubSceneOverride::selectedComponentIndices( SceneShapeSubSceneOve
 		std::string key = selectedPath.fullPathName().asChar();
 		for( size_t i = 0; i < componentIndices.length(); ++i )
 		{
+			/// \todo: this is inserting selected paths into the map regardless
+			/// of whether they match the dag paths of our node.
 			indexMap[key].insert( componentIndices[i] );
 		}
 	}


### PR DESCRIPTION
This fixes 4 bugs:

- Fixed component selection for partially expanded shapes.
- Fixed component selection for newly collapsed shapes.
- Fixed component selection for linked locations (eg instanced props in an environment).
- Fixed a crash when switching from VP2 back to VP1.

Note we still have outstanding selection issues: Marquee selection is not working (its not on master either) and I still have one production case that isn't selecting correctly. But I think this is worth pushing out anyways as it makes VP2 more production ready, and I'm going to take a week or two to get back to these other issues.

I also added several todos, some about performance and some about removing our use of IECoreGL for selection. I'm hoping to address those in followup PRs.