### PR TITLE
IECoreMaya : SceneShape Attribute Promotion

### DIFF
--- a/include/IECoreMaya/SceneShape.h
+++ b/include/IECoreMaya/SceneShape.h
@@ -73,6 +73,9 @@ class IECOREMAYA_API SceneShape : public SceneShapeInterface
 		 * Custom
 		 */
 
+		/// \todo Perhaps getSceneInterface() should return a raw pointer?
+		/// Also perhaps it shouldn't be prefixed with "get" since there is no
+		/// corresponding set.
 		virtual IECoreScene::ConstSceneInterfacePtr getSceneInterface();
 
 	private :
@@ -84,7 +87,7 @@ class IECOREMAYA_API SceneShape : public SceneShapeInterface
 		IECoreScene::ConstSceneInterfacePtr m_scene;
 
 
-		static SceneShape *findScene( const MDagPath &p, bool noIntermediate, MDagPath *dagPath = 0 );
+		static SceneShape *findScene( const MDagPath &p, bool noIntermediate, MDagPath *dagPath = nullptr );
 
 		/// functions registered in LiveScene as custom object and custom attributes
 		struct LiveSceneAddOn

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -57,6 +57,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 	## Creates a new node under a transform of the specified name. Returns a function set instance operating on this new node.
 	@staticmethod
+	@IECoreMaya.UndoFlush()
 	def create( parentName, transformParent = None ) :
 		try:
 			parentNode = maya.cmds.createNode( "transform", name=parentName, skipSelect=True, parent = transformParent )
@@ -68,6 +69,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 	## Create a scene shape under the given node. Returns a function set instance operating on this shape.
 	@staticmethod
+	@IECoreMaya.UndoFlush()
 	def createShape( parentNode ) :
 		parentShort = parentNode.rpartition( "|" )[-1]
 		numbersMatch = re.search( "[0-9]+$", parentShort )
@@ -95,6 +97,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		return fnScS
 
 	## Returns a set of the names of any currently selected components.
+	@IECoreMaya.UndoDisabled()
 	def selectedComponentNames( self ) :
 		result = set()
 		s = maya.OpenMaya.MSelectionList()
@@ -272,6 +275,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	## create the given child for the scene shape
 	# Returns a the function set for the child scene shape.
 	# If preserveNamespace is True, it creates the child with the same namespace as the one this sceneShape node has.
+	@IECoreMaya.UndoFlush()
 	def createChild( self, childName, sceneFile, sceneRoot, drawGeo = False, drawChildBounds = False, drawRootBound = True, drawTagsFilter = "", preserveNamespace=False) :
 		if preserveNamespace:
 			selfNamespaceList = self.fullPathName().split("|")[-1].split( ":" )[:-1]
@@ -292,6 +296,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	# Returns a list of function sets for the child scene shapes.
 	# Missing child transforms and shapes will be created, missing connections and attribute values will be reset.
 	# If preserveNamespace is True, it creates transforms and shapes with the same namespace as the one this sceneShape node has.
+	@IECoreMaya.UndoFlush()
 	def expandOnce( self, preserveNamespace=False ) :
 		scene = self.sceneInterface()
 		if not scene:
@@ -327,6 +332,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	# Returns a list of function sets for all the child scene shapes.
 	# If preserveNamespace is True, it creates transforms and shapes with the same namespace as the one this sceneShape node has.
 	# If tagName is specified, each scene in the hierarchy expands only if at least one child has the tag
+	@IECoreMaya.UndoFlush()
 	def expandAll( self, preserveNamespace=False, tagName=None ):
 		newFn = []
 
@@ -344,6 +350,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		return newFn
 
 	## Collapses all children up to this scene shape.
+	@IECoreMaya.UndoFlush()
 	def collapse( self ) :
 		node = self.fullPathName()
 		transform = maya.cmds.listRelatives( node, parent=True, f=True )[0]
@@ -378,7 +385,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		return result
 
 	## Recursively converts all objects in the scene interface to compatible maya geometry
-	# All scene shape nodes in the hierarchy are turned into an intermediate object.
+	# All scene shape nodes which have an object are turned into intermediate objects
+	@IECoreMaya.UndoFlush()
 	def convertAllToGeometry( self, preserveNamespace=False, tagName=None ) :
 
 		# Expand scene first, then for each scene shape we turn them into an intermediate object and connect a mesh
@@ -560,6 +568,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	# If a shape with the expected name but incompatible type is found under the transform, we rename it and create a new proper shape.
 	# The shape is connected to the scene shape object output only if it isn't already connected or locked.
 	# transformNode parameter can be used to specify the parent of the geometry. If None, uses the transform of the scene shape.
+	@IECoreMaya.UndoFlush()
 	def convertObjectToGeometry( self, transformNode = None ):
 		# Check that we have a valid scene interface and an object
 		scene = self.sceneInterface()

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -243,6 +243,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 				dgMod.newPlugValueBool( fnChildTransform.findPlug( "visibility" ), False )
 			else:
 				dgMod.newPlugValueString( fnChild.findPlug( "drawTagsFilter" ), " ".join( commonTags ) )
+				dgMod.newPlugValueBool( fnChildTransform.findPlug( "visibility" ), True )
 
 		# Drive the child's transforms through the parent sceneShapes plugs
 		index = self.__queryIndexForPath( "/" + childName )

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -126,7 +126,10 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	## Selects the components specified by the passed names.
 	def selectComponentNames( self, componentNames ) :
 		if not isinstance( componentNames, set ) :
-			componentNames = set( componentNames )
+			if isinstance( componentNames, basestring ):
+				componentNames = set( (componentNames, ) )
+			else:
+				componentNames = set( componentNames )
 
 		fullPathName = self.fullPathName()
 		allNames = self.componentNames()
@@ -135,9 +138,10 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 			if name in componentNames:
 				toSelect.append( fullPathName + ".f[" + str( i ) + "]" )
 
+		transform = maya.cmds.listRelatives( fullPathName, parent=True, fullPath=True )[0]
+		maya.cmds.hilite( transform )
 		maya.cmds.select( clear=True )
-		maya.cmds.selectMode( component=True )
-		maya.cmds.hilite( fullPathName )
+		maya.cmds.selectType( allComponents=False, facet=True )
 		if toSelect:
 			maya.cmds.select( toSelect, replace=True )
 

--- a/python/IECoreMaya/__init__.py
+++ b/python/IECoreMaya/__init__.py
@@ -94,10 +94,12 @@ from ManipulatorUI import *
 from TransformationMatrixParameterUI import TransformationMatrixParameterUI
 from LineSegmentParameterUI import LineSegmentParameterUI
 from Collapsible import Collapsible
+from RefreshDisabled import RefreshDisabled
+from UndoChunk import UndoChunk
+from UndoFlush import UndoFlush
+
 import Menus
 import SceneShapeUI
 from FnSceneShape import FnSceneShape
-from RefreshDisabled import RefreshDisabled
-from UndoChunk import UndoChunk
 
 __import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", subdirectory = "IECoreMaya" )

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -315,6 +315,27 @@ bool LiveScene::hasAttribute( const Name &name ) const
 		return true;
 	}
 
+	// Start by checking the native maya transform
+	// Translate attributes names starting with "ieAttr_" to "user:"
+	MFnDependencyNode fnNode( m_dagPath.node() );
+	unsigned int n = fnNode.attributeCount();
+	for( unsigned int i = 0; i < n; i++ )
+	{
+		MObject attr = fnNode.attribute( i );
+		MFnAttribute fnAttr( attr );
+		std::string attrName = fnAttr.name().asChar();
+		if( attrName.length() > 7 && ( attrName.find( "ieAttr_" ) == 0 ) )
+		{
+			boost::replace_first( attrName, "ieAttr_", "user:" );
+			boost::replace_all( attrName, "__", ":" );
+			if( name == attrName )
+			{
+				return true;
+			}
+		}
+	}
+
+	// If the attribute was not found on the maya transform loop custom readers
 	std::vector< CustomAttributeReader > &attributeReaders = customAttributeReaders();
 	for ( std::vector< CustomAttributeReader >::const_iterator it = attributeReaders.begin(); it != attributeReaders.end(); ++it )
 	{
@@ -339,6 +360,7 @@ bool LiveScene::hasAttribute( const Name &name ) const
 			return true;
 		}
 	}
+
 	return false;
 }
 

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -1079,7 +1079,7 @@ IECoreScene::SceneInterfacePtr LiveScene::retrieveChild( const Name &name, Missi
 		{
 			throw Exception( "IECoreMaya::LiveScene::retrieveChild: Couldn't find transform at specified path " + std::string( path.fullPathName().asChar() ) );
 		}
-		return 0;
+		return nullptr;
 	}
 
 	return duplicate( path );
@@ -1097,7 +1097,7 @@ ConstSceneInterfacePtr LiveScene::child( const Name &name, MissingBehaviour miss
 
 SceneInterfacePtr LiveScene::createChild( const Name &name )
 {
-	return 0;
+	return nullptr;
 }
 
 SceneInterfacePtr LiveScene::retrieveScene( const Path &path, MissingBehaviour missingBehaviour ) const
@@ -1134,7 +1134,7 @@ SceneInterfacePtr LiveScene::retrieveScene( const Path &path, MissingBehaviour m
 
 			throw Exception( "IECoreMaya::LiveScene::retrieveScene: Couldn't find transform at specified path " + pathName );
 		}
-		return 0;
+		return nullptr;
 	}
 
 	MDagPath dagPath;
@@ -1156,7 +1156,7 @@ SceneInterfacePtr LiveScene::retrieveScene( const Path &path, MissingBehaviour m
 
 			throw Exception( "IECoreMaya::LiveScene::retrieveScene: Couldn't find transform at specified path " + pathName );
 		}
-		return 0;
+		return nullptr;
 	}
 
 }

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -361,12 +361,12 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		maya.cmds.file( new=True, f=True )
 
 		def createSceneFile():
-		    scene = IECoreScene.SceneCache( FnSceneShapeTest.__testFile, IECore.IndexedIO.OpenMode.Write )
-		    sc = scene.createChild( str(1) )
-		    curves = IECoreScene.CurvesPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))) # 6 curves.
-		    sc.writeObject( curves, 0.0 )
-		    matrix = imath.M44d().translate( imath.V3d( 0, 0, 0 ) )
-		    sc.writeTransform( IECore.M44dData( matrix ), 0.0 )
+			scene = IECoreScene.SceneCache( FnSceneShapeTest.__testFile, IECore.IndexedIO.OpenMode.Write )
+			sc = scene.createChild( str(1) )
+			curves = IECoreScene.CurvesPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1))) # 6 curves.
+			sc.writeObject( curves, 0.0 )
+			matrix = imath.M44d().translate( imath.V3d( 0, 0, 0 ) )
+			sc.writeTransform( IECore.M44dData( matrix ), 0.0 )
 
 		createSceneFile()
 

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -72,6 +72,46 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 
 		return scene
 
+	def __setupTableProp( self ):
+		boxSize = imath.Box3f( imath.V3f( -.5, -.5, -.5 ), imath.V3f( .5, .5, .5 ) )
+
+		table = IECoreScene.SceneCache( FnSceneShapeTest.__testFile, IECore.IndexedIO.Write )
+		table.writeAttribute( 'scene:visible', IECore.BoolData( True ), 0 )
+		table.writeAttribute( 'user:testBool', IECore.BoolData( True ), 0 )
+		table.writeAttribute( 'user:testShort', IECore.ShortData( 2 ), 0 )
+		table.writeAttribute( 'user:testInt', IECore.IntData( 3 ), 0 )
+		table.writeAttribute( 'user:testInt64', IECore.Int64Data( 4 ), 0 )
+		table.writeAttribute( 'user:testFloat', IECore.FloatData( 5 ), 0 )
+		table.writeAttribute( 'user:testDouble', IECore.DoubleData( 6 ), 0 )
+		table.writeAttribute( 'user:testString', IECore.StringData( 'seven' ), 0 )
+		mat = imath.M44d( ( 8, 9, 10, 11 ), ( 12, 13, 14, 15 ), ( 16, 17, 18, 19 ), ( 20, 21, 22, 23 ) )
+		table.writeAttribute( 'user:testMatrixd', IECore.M44dData(mat), 0 )
+		mat = imath.M44f( ( 24, 25, 26, 27 ), ( 28, 29, 30, 31 ), ( 32, 33, 34, 35 ), ( 36, 37, 38, 39 ) )
+		table.writeAttribute( 'user:testMatrixf', IECore.M44fData(mat), 0 )
+
+		pedestal_GEO = table.createChild( 'pedestal_GEO' )
+		pedestal_GEO.writeObject( IECoreScene.MeshPrimitive.createBox(boxSize), 0 )
+		s = imath.V3d(15, 1, 15)
+		r = imath.Eulerd()
+		t = imath.V3d(0, .5, 0)
+		mat = IECore.TransformationMatrixd( s, r, t )
+		pedestal_GEO.writeTransform( IECore.TransformationMatrixdData(mat), 0 )
+
+		column_GEO = pedestal_GEO.createChild( 'column_GEO' )
+		column_GEO.writeObject( IECoreScene.MeshPrimitive.createBox(boxSize), 0 )
+		s = imath.V3d(.25, 20, .25)
+		r = imath.Eulerd()
+		t = imath.V3d(0, 10.5, 0)
+		mat = IECore.TransformationMatrixd( s, r, t )
+		column_GEO.writeTransform( IECore.TransformationMatrixdData(mat), 0 )
+
+		tableTop_GEO = column_GEO.createChild( 'tableTop_GEO' )
+		tableTop_GEO.writeObject( IECoreScene.MeshPrimitive.createBox(boxSize), 0 )
+		s = imath.V3d(10, 0.05, 10)
+		r = imath.Eulerd()
+		t = imath.V3d(0, .525, 0)
+		mat = IECore.TransformationMatrixd( s, r, t )
+		tableTop_GEO.writeTransform( IECore.TransformationMatrixdData(mat), 0 )
 
 	def testSceneInterface( self ) :
 
@@ -357,6 +397,54 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 		maya.cmds.setAttr( fn.fullPathName()+".queryConvertParameters[1]", "-index 0", type="string" )
 
 		self.assertEqual( maya.cmds.pointPosition(curveShape0 + '.cv[0]' ), maya.cmds.pointPosition(curveShape1 + '.cv[0]' ) )
+
+	def testPromotableAttributeNames( self ):
+		maya.cmds.file( new=True, force=True )
+		self.__setupTableProp()
+
+		sceneShapeFn = IECoreMaya.FnSceneShape.create( 'table' )
+		sceneShapeFn.findPlug( 'file' ).setString( FnSceneShapeTest.__testFile )
+
+		expectedAttrs = [
+			'user:testBool', 'user:testShort', 'user:testInt', 'user:testInt64', 'user:testFloat',
+			'user:testDouble', 'user:testString', 'user:testMatrixd', 'user:testMatrixf', 'scene:visible'
+		]
+
+		self.assertEquals( set( sceneShapeFn.promotableAttributeNames() ), set( expectedAttrs ) )
+
+	def testPromoteAttribute( self ):
+		maya.cmds.file( new=True, force=True )
+		self.__setupTableProp()
+
+		sceneShapeFn = IECoreMaya.FnSceneShape.create( 'table' )
+		sceneShapeFn.findPlug( 'file' ).setString( FnSceneShapeTest.__testFile )
+
+		for pAttr in sceneShapeFn.promotableAttributeNames():
+			sceneShapeFn.promoteAttribute( pAttr )
+
+		sceneShape = sceneShapeFn.fullPathName()
+		table = maya.cmds.listRelatives( sceneShape, parent=True )[0]
+		testVisibility = maya.cmds.getAttr( table + '.ieVisibility' )
+		testBool = maya.cmds.getAttr( table + '.ieAttr_testBool' )
+		testShort = maya.cmds.getAttr( table + '.ieAttr_testShort' )
+		testInt = maya.cmds.getAttr( table + '.ieAttr_testInt' )
+		testInt64 = maya.cmds.getAttr( table + '.ieAttr_testInt64' )
+		testFloat = maya.cmds.getAttr( table + '.ieAttr_testFloat' )
+		testDouble = maya.cmds.getAttr( table + '.ieAttr_testDouble' )
+		testString = maya.cmds.getAttr( table + '.ieAttr_testString' )
+		testMatrixd = maya.cmds.getAttr( table + '.ieAttr_testMatrixd' )
+		testMatrixf = maya.cmds.getAttr( table + '.ieAttr_testMatrixf' )
+
+		self.assertTrue( testVisibility )
+		self.assertTrue( testBool )
+		self.assertEquals( testShort, 2 )
+		self.assertEquals( testInt, 3 )
+		self.assertEquals( testInt64, 4 )
+		self.assertEquals( testFloat, 5. )
+		self.assertEquals( testDouble, 6. )
+		self.assertEquals( testString, 'seven' )
+		self.assertEquals( testMatrixd, [ 8., 9., 10., 11., 12., 13., 14., 15., 16., 17., 18., 19., 20., 21., 22., 23. ] )
+		self.assertEquals( testMatrixf, [ 24., 25., 26., 27., 28., 29., 30., 31., 32., 33., 34., 35., 36., 37., 38., 39. ] )
 
 	def tearDown( self ) :
 

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -1238,7 +1238,7 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		"""
 
 		def createSCC():
-			outScene = IECoreScene.SceneCache(testSccFile, IECore.IndexedIO.OpenMode.Write)
+			outScene = IECoreScene.SceneCache( LiveSceneTest.__testFile, IECore.IndexedIO.OpenMode.Write )
 
 			rootSc = outScene.createChild('rootXform')
 			expandSc = rootSc.createChild('expand')
@@ -1254,13 +1254,12 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 			boxBSc.writeObject(mesh, 0)
 
 		# create test scene
-		testSccFile = "{tmpdir}/testRecursive.scc".format(tmpdir=tempfile.mkdtemp())
 		createSCC()
 
 		# create shape with SCC path
 		nodeName = 'sceneFile'
 		sceneShape = str(IECoreMaya.FnSceneShape.create(nodeName).fullPathName())
-		maya.cmds.setAttr(sceneShape + '.file', testSccFile, type='string')
+		maya.cmds.setAttr(sceneShape + '.file', LiveSceneTest.__testFile, type='string')
 		maya.cmds.setAttr(sceneShape + '.root', '/', type='string')
 
 		# test live scene content

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -729,6 +729,16 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		self.failUnless( isinstance( transformScene.readAttribute("user:string",0), IECore.StringData ) )
 		self.failUnless( isinstance( transformScene.readAttribute("user:with:namespace",0), IECore.StringData ) )
 
+	def testHasAttribute( self ):
+		maya.cmds.currentTime( '0sec' )
+		t = maya.cmds.createNode( 'transform', name='t1' )
+		maya.cmds.addAttr( t, longName='ieAttr_bool', attributeType='bool' )
+
+		scene = IECoreMaya.LiveScene()
+		transformScene = scene.child( str( t ) )
+
+		self.assertTrue( transformScene.hasAttribute( 'user:bool' ) )
+
 	def testCustomAttributes( self ) :
 
 		t = maya.cmds.createNode( "transform" )
@@ -804,7 +814,7 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 			# Disable custom attribute functions so they don't mess with other tests
 			doTest = False
 
-	def testCustomAttributes( self ) :
+	def testCustomAttributesMightHave( self ) :
 
 		t = maya.cmds.createNode( "transform" )
 		maya.cmds.select( clear = True )


### PR DESCRIPTION
The primary purpose of this PR is add the ability to promote attributes exposed through the SceneShape node onto maya plugs. This allows the user to override an attribute's value since LiveScene will check for promoted attributes of the form "ieAttr_" before checking for the equivalent attribute from SceneShape.

- Added `FnSceneShape.promotableAttributeNames`
- Added `FnSceneShape.promoteAttribute`

### Related Issues ###

I addition to adding the ability to promote attributes, this PR cleans up a couple of small bugs related to SceneShapes:
- Tidied up FnSceneShape, removed some extra imports and made several functions a bit more readable
- Updated several context managers to support use as decorators
- Added an UndoFlush context manager / decorator
- Fixed some crashes caused by trying to "undo" after expanding or collapsing SceneShapes.
- Fixed a bug when using `FnSceneShape.selectComponentNames` which left the SceneShape menu hidden from the user.
- Updated some pointer ownership semantic in SceneShape and LiveScene. Now using nullptr instead of 0.
- Cleaned up the LiveScene visibility logic (same functionality - but more readable code)
- Fixed a few bugs related to collapsing and expanded with tags. Fixed the draw attributes on the nodes when expanding. Changed querySpace to local when expanding children to opt out of extra computation.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
