### PR TITLE
IECoreMaya : Fixed unit test related to FromMayaEnumPlugConverter

### DIFF
--- a/include/IECoreMaya/FromMayaPlugConverter.h
+++ b/include/IECoreMaya/FromMayaPlugConverter.h
@@ -75,10 +75,14 @@ class IECOREMAYA_API FromMayaPlugConverter : public FromMayaConverter
 
 		/// Creating a static instance of one of these (templated on your converter type)
 		/// within your class will register your converter with the factory mechanism.
+		///
+		/// The default constructor will perform type registration but will not register
+		/// the converter with the factory mechanism (this is needed for enum plugs)
 		template<class T>
 		class Description
 		{
 			public :
+				Description();
 				Description( MFnData::Type fromType, IECore::TypeId resultType, bool isDefaultConverter );
 				Description( MFnNumericData::Type fromType, IECore::TypeId resultType, bool isDefaultConverter );
 				Description( MFnUnitAttribute::Type fromType, IECore::TypeId resultType, bool isDefaultConverter );

--- a/include/IECoreMaya/FromMayaPlugConverter.inl
+++ b/include/IECoreMaya/FromMayaPlugConverter.inl
@@ -41,6 +41,13 @@ namespace IECoreMaya
 {
 
 template<class T>
+FromMayaPlugConverter::Description<T>::Description()
+{
+	/// \todo Derive FromMayaPlugConverter::Description from RunTimeTyped::TypeDescription instead of calling this manually.
+	IECore::RunTimeTyped::registerType( T::staticTypeId(), T::staticTypeName(), T::baseTypeId() );
+}
+
+template<class T>
 FromMayaPlugConverter::Description<T>::Description( MFnNumericData::Type fromType, IECore::TypeId resultType, bool isDefaultConverter )
 {
 	FromMayaPlugConverter::registerConverter( fromType, resultType, isDefaultConverter, creator );

--- a/src/IECoreMaya/FromMayaEnumPlugConverter.cpp
+++ b/src/IECoreMaya/FromMayaEnumPlugConverter.cpp
@@ -46,6 +46,8 @@ using namespace IECore;
 namespace IECoreMaya
 {
 
+template<typename T>
+FromMayaPlugConverter::Description< FromMayaEnumPlugConverter<T> > FromMayaEnumPlugConverter<T>::m_description{};
 
 template<typename T>
 const MString FromMayaEnumPlugConverter<T>::convertToStringCategory = "ieConvertToStringData";

--- a/src/IECoreMaya/bindings/TypeIdBinding.cpp
+++ b/src/IECoreMaya/bindings/TypeIdBinding.cpp
@@ -128,6 +128,8 @@ void bindTypeId()
 		.value( "FromMayaArrayDataConverterPV3f", FromMayaArrayDataConverterPV3fTypeId )
 		.value( "FromMayaArrayDataConverterPV3d", FromMayaArrayDataConverterPV3dTypeId )
 		.value( "FromMayaInstancerConverter", FromMayaInstancerConverterTypeId)
+		.value( "FromMayaEnumPlugConverterst", FromMayaEnumPlugConverterstTypeId)
+		.value( "FromMayaEnumPlugConvertersh", FromMayaEnumPlugConvertershTypeId)
 	;
 }
 


### PR DESCRIPTION
Added a default constructor to FromMayaPlugConverter::Description which allows a converter
to be registered with the RTTI system without registering it with the factory mechanism.

The factory logic for enum plugs is already handled directly in FromMayaPlugConverter. We
just needed to register the type, which wasn't previously done due to the lack of a valid
registration function. Creating a new registration function just for enums is a bit overkill
since it would just be registering a short with conversions to shortData and stringData.

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
