### PR TITLE
Enum: Removed assertion in favor of deprecation warning

### DIFF
--- a/python/IECore/Enum.py
+++ b/python/IECore/Enum.py
@@ -82,7 +82,9 @@ def create( *names ) :
 
 		def __eq__( self, other ):
 
-			assert( type( self ) is type( other ) )
+			if type( self ) is not type( other ):
+				return False
+
 			return  self.__value == other.__value
 
 		def __ne__( self, other ):
@@ -91,7 +93,9 @@ def create( *names ) :
 
 		def __lt__( self, other ):
 
-			assert( type( self ) is type( other ) )
+			if type( self ) is not type( other ):
+				raise TypeError( "Comparison not supported between instances of different Enum." )
+
 			return self.__value < other.__value
 
 		def __int__( self ) :

--- a/test/IECore/Enum.py
+++ b/test/IECore/Enum.py
@@ -79,6 +79,19 @@ class TestEnum( unittest.TestCase ) :
 		self.assertEqual( d[E.Red], "a" )
 		self.assertEqual( d[E2.Red], "b" )
 
+	def testMultiEnum( self ):
+
+		E = IECore.Enum.create( "Red", "Green", "Blue" )
+		E2 = IECore.Enum.create( "Red", "Green", "Blue" )
+
+		self.assertEqual( E.Red, E.Red )
+		self.assertEqual( E2.Red, E2.Red )
+		self.assertNotEqual( E.Red, E2.Red )
+		self.assertTrue( E.Green > E.Red )
+
+		with self.assertRaises( TypeError ):
+			result = E.Red < E2.Red
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
Breaking change
---
Since we moved to Python 3 compatible code, the assertion previously used in the comparisons would break certain functionality, since it would only now start to fail. Keeping it around breaks to many things immediately. As a countermeasure we decided to let the comparison return `False` instead. This helps in cases where we are testing for variables memberships that would currently fail because any comparison against anything else but a matching Enum class would throw an assertion error, breaking some Gaffer functionality.

The downside here is that there rare case where two Enums that are not of the same class, but were expected to match, would fail now silently. Catching these cases with warning is hard, since we cannot determine what and what is not a valid comparison without analyzing the code.

Fixes
---
- Enum: Removed assertion in favor of deprecation warning (#1032)
- Enum: added multi Enum comparison test case (#1032)