### PR TITLE
IECoreMaya : Expand indexed normals in ToMayaMeshConverter.

### DIFF
--- a/src/IECoreMaya/ToMayaMeshConverter.cpp
+++ b/src/IECoreMaya/ToMayaMeshConverter.cpp
@@ -273,12 +273,13 @@ bool ToMayaMeshConverter::doConversion( IECore::ConstObjectPtr from, MObject &to
 			IECore::ConstV3fVectorDataPtr n = IECore::runTimeCast<const IECore::V3fVectorData>(it->second.data);
 			if (n)
 			{
-				int numVertexNormals = n->readable().size();
+				IECoreScene::PrimitiveVariable::IndexedView<Imath::V3f> normalView = IECoreScene::PrimitiveVariable::IndexedView<Imath::V3f>( it->second );
+				vertexNormalsArray.setLength( normalView.size() );
 
-				vertexNormalsArray.setLength( numVertexNormals );
-				for (int i = 0; i < numVertexNormals; i++)
+				size_t i = 0;
+				for(const auto& normal : normalView)
 				{
-					vertexNormalsArray[i] = IECore::convert<MVector, Imath::V3f>( n->readable()[i] );
+					vertexNormalsArray[i++] = IECore::convert<MVector, Imath::V3f>( normal );
 				}
 			}
 			else
@@ -286,12 +287,13 @@ bool ToMayaMeshConverter::doConversion( IECore::ConstObjectPtr from, MObject &to
 				IECore::ConstV3dVectorDataPtr n = IECore::runTimeCast<const IECore::V3dVectorData>(it->second.data);
 				if (n)
 				{
-					int numVertexNormals = n->readable().size();
+					IECoreScene::PrimitiveVariable::IndexedView<Imath::V3d> normalView = IECoreScene::PrimitiveVariable::IndexedView<Imath::V3d>( it->second );
+					vertexNormalsArray.setLength( normalView.size() );
 
-					vertexNormalsArray.setLength( numVertexNormals );
-					for (int i = 0; i < numVertexNormals; i++)
+					size_t i = 0;
+					for(const auto& normal : normalView)
 					{
-						vertexNormalsArray[i] = IECore::convert<MVector, Imath::V3d>( n->readable()[i] );
+						vertexNormalsArray[i++] = IECore::convert<MVector, Imath::V3d>( normal );
 					}
 				}
 				else

--- a/test/IECoreMaya/ParameterisedHolder.py
+++ b/test/IECoreMaya/ParameterisedHolder.py
@@ -282,11 +282,12 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 
 	def testMeshParameterIOProblem( self ) :
 
-		fnOP = IECoreMaya.FnOpHolder.create( "merge", "meshMerge", 1 )
+		fnOP = IECoreMaya.FnOpHolder.create( "merge", "meshMerge" )
 		op = fnOP.getOp()
 
 		mesh = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 2, 3, 4 ) ) )
-		op.parameters()["input"].setValue( mesh )
+		mesh[ "N" ] = IECoreScene.PrimitiveVariable( mesh[ "N" ].interpolation, mesh[ "N" ].expandedData() )
+		op.parameters()[ "input" ].setValue( mesh )
 		fnOP.setNodeValues()
 
 		cmds.file( rename = os.getcwd() + "/test/IECoreMaya/meshParameterIO.ma" )
@@ -300,8 +301,7 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		op = fnOP.getOp()
 
 		mesh2 = op.parameters()["input"].getValue()
-		self.failUnless( mesh2.arePrimitiveVariablesValid() )
-		del mesh2["N"]
+		self.assertTrue( mesh2.arePrimitiveVariablesValid() )
 		self.assertEqual( mesh2, mesh )
 
 	def testOpHolder( self ) :


### PR DESCRIPTION
### General Description ###
Fixes a bug in which indexed normals are not correctly added to maya meshes.
Maya expects fully expanded face varying normals when using the function
`MFnMesh::setFaceVertexNormals`.

### Related Issues ###
- Fixes a failing ParameterisedHolder unit test

### Checklist ###
- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
