### PR TITLE
Nuke scene cache selection caching with motion blur

### DIFF
--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -545,7 +545,7 @@ Hash SceneCacheReader::selectionHash( bool force ) const
 {
 	if ( firstReader() != this )
 	{
-		return firstReader()->selectionHash(false);
+		return firstReader()->selectionHash(force);
 	}
 
 	if ( force || m_data->m_selectionHash == Hash() )


### PR DESCRIPTION
Fixes
---

- Nuke: SceneCacheReader: Fix selection caching for `Scene View` knob when using motion blur ( #1037 )

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
