### PR TITLE
IECoreMaya SceneShape VP2 : Enable marquee selection for components

### DIFF
--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -124,11 +124,12 @@ class IECOREMAYA_API SceneShapeInterface: public MPxComponentShape
 		/// Returns the sceneInterface for this node. Needs to be implemented by derived classes.
 		virtual IECoreScene::ConstSceneInterfacePtr getSceneInterface();
 
+		/// \todo: Move this IECoreGL functionality to SceneShapeUI. It should not be used by clients of the node, nor VP2 codepaths.
 		/// Returns the GL Scene representing the sceneInterface for the preview plug values ( objectOnly, drawGeometry, drawLocators, drawChildBounds )
 		IECoreGL::ConstScenePtr glScene();
-
 		/// Returns GL Group matching the given path name.
 		IECoreGL::GroupPtr glGroup( const IECore::InternedString &name );
+
 		/// Returns the internal index stored for the given path
 		int selectionIndex( const IECore::InternedString &name );
 		/// Returns the path name for the given index

--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -138,11 +138,6 @@ class IECOREMAYA_API SceneShapeInterface: public MPxComponentShape
 		const std::vector< IECore::InternedString > & componentNames() const;
 		/// Return the value of the time plug for the SceneShape.
 		double time() const;
-		/// Build data-structure to map from group names to component indices. If
-		/// rendering is done through a different mechanism than glScene(), for
-		/// example by using VP2, this needs to be called whenever the scene updates
-		/// to keep the map in sync. Return value indicates success.
-		bool buildComponentIndexMap();
 
 	protected :
 

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1558,6 +1558,9 @@ void SceneShapeInterface::setDirty()
 
 IECoreGL::GroupPtr SceneShapeInterface::glGroup( const IECore::InternedString &name )
 {
+	// make sure the gl scene's been built, as this keeps m_nameToGroupMap up to date
+	const_cast<SceneShapeInterface*>( this )->glScene();
+
 	NameToGroupMap::const_iterator elementIt = m_nameToGroupMap.find( name );
 	if( elementIt != m_nameToGroupMap.end() )
 	{
@@ -1571,6 +1574,9 @@ IECoreGL::GroupPtr SceneShapeInterface::glGroup( const IECore::InternedString &n
 
 int SceneShapeInterface::selectionIndex( const IECore::InternedString &name )
 {
+	// make sure the gl scene's been built, as this keeps m_indexToNameMap up to date
+	const_cast<SceneShapeInterface*>( this )->glScene();
+
 	NameToGroupMap::const_iterator elementIt = m_nameToGroupMap.find( name );
 	if( elementIt != m_nameToGroupMap.end() )
 	{

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1495,33 +1495,6 @@ void SceneShapeInterface::registerGroup( const std::string &name, IECoreGL::Grou
 		}
 }
 
-bool SceneShapeInterface::buildComponentIndexMap()
-{
-	ConstSceneInterfacePtr sceneInterface = getSceneInterface();
-	if( !sceneInterface )
-	{
-		return false;
-	}
-
-	IECoreGL::RendererPtr renderer = new IECoreGL::Renderer();
-	renderer->setOption( "gl:mode", new StringData( "deferred" ) );
-
-	renderer->worldBegin();
-	{
-		buildScene( renderer, sceneInterface );
-	}
-	renderer->worldEnd();
-
-	// Update component name to group map
-	m_nameToGroupMap.clear();
-	m_indexToNameMap.clear();
-	IECoreGL::ConstStatePtr defaultState = IECoreGL::State::defaultState();
-	buildGroups( defaultState->get<const IECoreGL::NameStateComponent>(), renderer->scene()->root() );
-	createInstances();
-
-	return true;
-}
-
 void SceneShapeInterface::buildGroups( IECoreGL::ConstNameStateComponentPtr nameState, IECoreGL::GroupPtr group )
 {
 	assert( nameState );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1402,8 +1402,6 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 		// All data in the container is invalid now and we can safely clear it
 		container.clear();
 		m_sceneInterface = tmpSceneInterface;
-		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
-		m_sceneShape->buildComponentIndexMap();
 	}
 
 	// STYLE
@@ -1426,8 +1424,6 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	if( tmpObjectOnly != m_objectOnly )
 	{
 		m_objectOnly = tmpObjectOnly;
-		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
-		m_sceneShape->buildComponentIndexMap();
 	}
 
 	// TAGS
@@ -1437,8 +1433,6 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	if( tmpTagsFilter.asChar() != m_drawTagsFilter )
 	{
 		m_drawTagsFilter = tmpTagsFilter.asChar();
-		/// \todo: stop using the SceneShapeInterface component map. It relies on a secondary IECoreGL render.
-		m_sceneShape->buildComponentIndexMap();
 	}
 
 	// COMPONENT SELECTION

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1692,6 +1692,19 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			MShaderInstance *shader = m_allShaders->getShader( style, instance.componentMode, instance.componentMode ? componentSelected : instance.selected );
 			renderItem->setShader( shader );
 
+			// Update the selection mask to enable marquee selection of components we explicitly disable
+			// wireframe selection in Solid mode, because otherwise we'd get double selections (the marquee
+			// overlaps both the mesh and the wireframe). Note we're still allowing bounding box selection
+			// so double selection is still possible, and this breaks toggle selection mode.
+			if( style == RenderStyle::Wireframe && m_styleMask.test( (int)RenderStyle::Solid ) )
+			{
+				renderItem->setSelectionMask( MSelectionMask::kSelectMeshes );
+			}
+			else
+			{
+				renderItem->setSelectionMask( instance.componentMode ? MSelectionMask::kSelectMeshFaces : MSelectionMask::kSelectMeshes );
+			}
+
 			// set the geometry on the render item if it's a new one.
 			if( isNew )
 			{


### PR DESCRIPTION
This fixes marquee component selection in VP2, with one odd caveat. Marquee selection in toggle mode (holding shift) does not work if you have child bounds drawing and geometry drawing both enabled, and the marquee hits both the child bounding box and the actual geometry. In this case we get a double selection reported as we have two active `SceneShapeSubSceneOverride::ComponentConverter`s and toggling flips the state twice, so we end up with the same selection we started with.

I'm waiting for feedback from Autodesk on how to compress/condense the selection results, but I think its worth releasing this in the mean time, as marquee component selection is needed in production and childBounds are rarely used.