### PR TITLE
 StringAlgo : Add string substitution functionality

### DIFF
--- a/include/IECore/CompoundData.h
+++ b/include/IECore/CompoundData.h
@@ -57,9 +57,9 @@ class IECORE_API CompoundData : public CompoundDataBase
 		/// or doesn't match the type specified as the template argument, behavior
 		/// is defined by the throwExceptions parameter. When this parameter is true a descriptive
 		/// Exception is thrown, and when false 0 is returned.
-		template<typename T>
+		template<typename T = Data>
 		T *member( const InternedString &name, bool throwExceptions = false );
-		template<typename T>
+		template<typename T = Data>
 		const T *member( const InternedString &name, bool throwExceptions = false ) const;
 
 		/// A Convenience function to find a child Data object.
@@ -67,7 +67,7 @@ class IECORE_API CompoundData : public CompoundDataBase
 		/// with the type's object factory create method. If false, or the named child does not match the
 		/// type specified as the template argument, behavior is defined by the throwExceptions parameter.
 		/// When this parameter is true a descriptive Exception is thrown, and when false 0 is returned.
-		template<typename T>
+		template<typename T = Data>
 		T *member( const InternedString &name, bool throwExceptions, bool createIfMissing );
 };
 

--- a/include/IECore/InternedString.h
+++ b/include/IECore/InternedString.h
@@ -37,6 +37,8 @@
 
 #include "IECore/Export.h"
 
+#include "boost/utility/string_view.hpp"
+
 #include <string>
 
 /// May be used to detect the existence of the
@@ -61,6 +63,7 @@ class IECORE_API InternedString
 		inline InternedString( const InternedString &other );
 		inline InternedString( const char *value );
 		inline InternedString( const char *value, size_t length );
+		inline InternedString( const boost::string_view &value );
 		inline InternedString( int64_t number );
 
 		inline ~InternedString();

--- a/include/IECore/InternedString.inl
+++ b/include/IECore/InternedString.inl
@@ -63,6 +63,11 @@ inline InternedString::InternedString( const char *value, size_t length )
 {
 }
 
+inline InternedString::InternedString( const boost::string_view &value )
+	:	InternedString( value.data(), value.size() )
+{
+}
+
 inline InternedString::InternedString( int64_t number )
 	: m_value( numberString( number ).m_value )
 {

--- a/src/IECore/StringAlgo.cpp
+++ b/src/IECore/StringAlgo.cpp
@@ -237,8 +237,23 @@ struct CompoundDataVariableProvider : public StringAlgo::VariableProvider
 
 	int frame() const override
 	{
-		const IECore::IntData *d = m_variables->member<IECore::IntData>( "frame" );
-		return d ? d->readable() : 1;
+		const Data *d = m_variables->member( "frame" );
+		if( !d )
+		{
+			return 1;
+		}
+		switch( d->typeId() )
+		{
+			case IntDataTypeId :
+				return static_cast<const IntData *>( d )->readable();
+			case FloatDataTypeId :
+				return (int)round( static_cast<const FloatData *>( d )->readable() );
+			default :
+				throw IECore::Exception(
+					string( "Unexpected data type \"" ) + d->typeName() +
+					"\" for frame : expected IntData or FloatData"
+				);
+		}
 	}
 
 	const std::string &variable( const boost::string_view &name, bool &recurse ) const override

--- a/test/IECore/StringAlgoTest.py
+++ b/test/IECore/StringAlgoTest.py
@@ -271,5 +271,20 @@ class StringAlgoTest( unittest.TestCase ) :
 		self.assertEqual( IECore.StringAlgo.substitute( "${y}", v ), "yy" )
 		self.assertEqual( IECore.StringAlgo.substitute( "${recurse}", v ), "$norecurse" )
 
+	def testFrameSubstitutions( self ) :
+
+		self.assertEqual(
+			IECore.StringAlgo.substitute( "###", { "frame" : 1 } ),
+			"001"
+		)
+
+		self.assertEqual(
+			IECore.StringAlgo.substitute( "###", { "frame" : 2.1 } ),
+			"002"
+		)
+
+		with self.assertRaisesRegexp( IECore.Exception, "expected IntData or FloatData" ) :
+			IECore.StringAlgo.substitute( "###", { "frame" : "notAFrame" } )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This has been ported over from `Gaffer.Context`, with the variable source being generalised via the VariableProvider interface. My immediate motivation is to use a slightly funky VariableProvider to make a significant performance enhancement to the Spreadsheet in Gaffer. But I anticipate it having other uses where we want to present a familiar substitution syntax for users without the overhead of context creation to provide the variables.

