### PR TITLE
IECoreMaya : Updated LiveScene `scene:visible` logic

### DIFF
--- a/include/IECoreMaya/LiveScene.h
+++ b/include/IECoreMaya/LiveScene.h
@@ -77,7 +77,10 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		/// Returns the tokenized dag path this instance is referring to.
 		virtual void path( Path &p ) const;
 
-		// Returns the MDagPath object to the scene node
+		/// Name of maya attribute overriding `IECoreScene::SceneInterface::visibilityName`
+		static IECoreScene::SceneInterface::Name visibilityOverrideName;
+
+		/// Returns the MDagPath object to the scene node
 		MDagPath dagPath() const;
 
 		/*
@@ -187,6 +190,14 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		/// Currently raises an exception
 		virtual void hash( HashType hashType, double time, IECore::MurmurHash &h ) const;
 
+		/// Translates cortex attribute name to maya attribute name
+		/// Returns an empty string if there are no valid mappings
+		static Name toMayaAttributeName( const Name &name );
+
+		/// Translates maya attribute name to cortex attribute name
+		/// Returns an empty string if there are no valid mappings
+		static Name fromMayaAttributeName( const Name &name );
+
 		typedef boost::function<bool (const MDagPath &)> HasFn;
 		typedef boost::function<IECore::ConstObjectPtr (const MDagPath &)> ReadFn;
 		typedef boost::function<IECore::ConstObjectPtr (const MDagPath &, const Name &)> ReadAttrFn;
@@ -195,21 +206,21 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		typedef boost::function<void (const MDagPath &, NameList &)> NamesFn;
 		typedef boost::function<bool (const MDagPath &, const Name &)> MightHaveFn;
 
-		// Register callbacks for custom objects.
-		// The has function will be called during hasObject and it stops in the first one that returns true.
-		// The read method is called if the has method returns true, so it should return a valid Object pointer or raise an Exception.
+		/// Register callbacks for custom objects.
+		/// The has function will be called during hasObject and it stops in the first one that returns true.
+		/// The read method is called if the has method returns true, so it should return a valid Object pointer or raise an Exception.
 		static void registerCustomObject( HasFn hasFn, ReadFn readFn );
 
-		// Register callbacks for custom attributes.
-		// The names function will be called during attributeNames and hasAttribute.
-		// The readAttr method is called if the names method returns the expected attribute, so it should return a valid Object pointer or raise an Exception.
-		// If the mightHave function is specified, it will be called before names function for early out, to see if the names function can return the expected attribute.
+		/// Register callbacks for custom attributes.
+		/// The names function will be called during attributeNames and hasAttribute.
+		/// The readAttr method is called if the names method returns the expected attribute, so it should return a valid Object pointer or raise an Exception.
+		/// If the mightHave function is specified, it will be called before names function for early out, to see if the names function can return the expected attribute.
 		static void registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn );
 		static void registerCustomAttributes( NamesFn namesFn, ReadAttrFn readFn, MightHaveFn mightHaveFn);
 
-		// Register callbacks for nodes to define custom tags
-		// The functions will be called during hasTag and readTags.
-		// readTags will return the union of all custom ReadTagsFns.
+		/// Register callbacks for nodes to define custom tags
+		/// The functions will be called during hasTag and readTags.
+		/// readTags will return the union of all custom ReadTagsFns.
 		static void registerCustomTags( HasTagFn hasFn, ReadTagsFn readFn );
 
 	private :
@@ -248,7 +259,7 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 
 	protected:
 
-		// constructor for a specific dag path:
+		/// constructor for a specific dag path:
 		LiveScene( const MDagPath& p, bool isRoot = false );
 
 		MDagPath m_dagPath;
@@ -262,8 +273,6 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		static Mutex s_mutex;
 
 };
-
-IE_CORE_DECLAREPTR( LiveScene )
 
 } // namespace IECoreMaya
 

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -603,6 +603,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		self.__findOrCreateShapes( transformNode )
 		self.__connectShapes( transformNode )
 
+	## Creates a maya locator in the position and orientation of the scene path's transform.
+	# \param path Path to scene where the locator should be created
 	def createLocatorAtTransform( self, path ) :
 		node = self.fullPathName()
 		transform = maya.cmds.listRelatives( node, parent=True, f=True )[0]
@@ -617,6 +619,9 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 		return locator
 
+	## Creates a maya locator at the min, max, or center points of the scene path's bound.
+	# \param path Path to scene
+	# \param childPlugSuffixes List containing "Max", "Min", or "Center", the position where the locator should be created
 	def createLocatorAtPoints( self, path, childPlugSuffixes ) :
 		node = self.fullPathName()
 		transform = maya.cmds.listRelatives( node, parent=True, f=True )[0]
@@ -649,6 +654,9 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		cortexData = querySceneInterface.readAttribute( attributeName, time )
 		return FnSceneShape.__cortexToMayaDataTypeMap.get( cortexData.typeId() )
 
+	## Returns a list of attribute names which can be promoted to maya plugs.
+	# \param queryPath Path to the scene from which we want return attribute names. Defaults to root '/'
+	# \param blackListed List of attribute names which should not be included in the returned attribute names.
 	@IECoreMaya.UndoDisabled()
 	def promotableAttributeNames( self, queryPath='/', blackListed=None ):
 		if not blackListed:
@@ -672,6 +680,12 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		return promotableAttrs
 
 	@IECoreMaya.UndoFlush()
+	## Promotes an attribute from the sceneInterface onto a maya plug.
+	# \param attributeName Name of the attribute to promote
+	# \param queryPath Scene path from which to promote the attribute. Defaults to root ('/').
+	# \param mayaAttributeName Name of the maya plug onto which the attribute should be promoted. If not supplied,
+	#        defaults to the mapping specified in LiveScene
+	# \param keyable Should the maya plug be keyable. Defaults to keyable so that the value appears in the channel box.
 	def promoteAttribute( self, attributeName, queryPath='/', nodePath='', mayaAttributeName='', keyable=True ):
 		# Check the validity of the queryPath
 		queryScene = self.__sceneInterfaceFromQueryPath( queryPath )

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -660,9 +660,10 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 		attrNames = queryScene.attributeNames()
 
-		promotableAttrs = [ 'scene:visible' ] if 'scene:visible' in attrNames else []
+		promotableAttrs = list()
 		for attrName in attrNames:
-			if not attrName.startswith( 'user:' ) or attrName in blackListed:
+			mayaAttrName = str( IECoreMaya.LiveScene.toMayaAttributeName( attrName ) )
+			if not mayaAttrName or mayaAttrName in blackListed:
 				continue
 
 			if self.__cortexTypeToMayaType( queryScene, attrName ):
@@ -689,7 +690,6 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		attributePlugName = self.fullPathName() + '.attributes[{}].attributeValues[{}]'.format( queryPathIndex, queryAttributeIndex )
 
 		# Create the output plugs for the promoted attributes
-		# In the default case, we transform "user:" as "ieAttr_" and place the attribute on the parent transform
 		# This will effectively override the attribute when viewed from LiveScene
 		if nodePath:
 			if maya.cmds.objExists( nodePath ):
@@ -703,10 +703,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		node = IECoreMaya.StringUtil.dependencyNodeFromString( nodePath )
 
 		if not mayaAttributeName:
-			if attributeName == 'scene:visible':
-				mayaAttributeName = 'ieVisibility'
-			else:
-				mayaAttributeName = 'ieAttr_' + attributeName[5:].replace( ':', '__' )
+			mayaAttributeName = str( IECoreMaya.LiveScene.toMayaAttributeName( attributeName ) )
 
 		mayaAttributeType = self.__cortexTypeToMayaType( queryScene, attributeName )
 

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -135,8 +135,8 @@ def _menuDefinition( callbackShape ) :
 
 		if any( map( lambda x : x.canBeExpanded(), fnShapes ) ) :
 
-			expandDef.append( "/Expand One Level", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( __expandOnce, sceneShapes ) } )
-			expandDef.append( "/Recursive Expand", { "blindData" : { "maya" : { "radialPosition" : "N" } }, "command" : functools.partial( _expandAll, sceneShapes)})
+			expandDef.append( "/Expand One Level", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __expandOnce, sceneShapes ) } )
+			expandDef.append( "/Recursive Expand", { "blindData" : { "maya" : { "radialPosition" : "E" } }, "command" : functools.partial( _expandAll, sceneShapes)})
 
 			if len( sceneShapes ) == 1 and fnShapes[ 0 ].selectedComponentNames() :
 				expandDef.append( "/Expand to Selected Components", { "blindData" : { "maya" : { "radialPosition" : "S" } }, "command" : functools.partial( __expandToSelected, sceneShapes[ 0 ] ) } )
@@ -172,8 +172,8 @@ def _menuDefinition( callbackShape ) :
 			addTagSubMenuItems( expandTagDef, _expandAll)
 			addTagSubMenuItems( expandTagGeoDef, _expandAsGeometry)
 
-			expandDef.append( "/Expand by Tag...", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : expandTagDef } )
-			expandDef.append( "/Expand by Tag as Geo...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandTagGeoDef } )
+			expandDef.append( "/Expand by Tag...", { "blindData" : { "maya" : { "radialPosition" : "SE" } }, "subMenu" : expandTagDef } )
+			expandDef.append( "/Expand by Tag as Geo...", { "blindData" : { "maya" : { "radialPosition" : "SW" } }, "subMenu" : expandTagGeoDef } )
 
 		parentSceneShape = __parentSceneShape( sceneShapes )
 

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -1273,9 +1273,9 @@ void SceneShapeInterface::recurseBuildScene( IECoreGL::Renderer * renderer, cons
 		}
 	}
 
-	if ( subSceneInterface->hasAttribute( "scene:visible" ) )
+	if ( subSceneInterface->hasAttribute( SceneInterface::visibilityName ) )
 	{
-		if( ConstBoolDataPtr vis = runTimeCast<const BoolData>( subSceneInterface->readAttribute( "scene:visible", time ) ) )
+		if( ConstBoolDataPtr vis = runTimeCast<const BoolData>( subSceneInterface->readAttribute( SceneInterface::visibilityName, time ) ) )
 		{
 			if( !vis->readable() )
 			{

--- a/src/IECoreMaya/bindings/LiveSceneBinding.cpp
+++ b/src/IECoreMaya/bindings/LiveSceneBinding.cpp
@@ -206,5 +206,8 @@ void IECoreMaya::bindLiveScene()
 		.def( init<>() )
 		.def( "registerCustomTags", registerCustomTags, ( arg_( "hasFn" ), arg_( "readFn" ) ) ).staticmethod( "registerCustomTags" )
 		.def( "registerCustomAttributes", registerCustomAttributes, (  arg_( "namesFn" ), arg_( "readFn" ), arg_( "mightHaveFn" ) = object() ) ).staticmethod( "registerCustomAttributes" )
+		.def( "toMayaAttributeName", LiveScene::toMayaAttributeName ).staticmethod( "toMayaAttributeName" )
+		.def( "fromMayaAttributeName", LiveScene::fromMayaAttributeName ).staticmethod( "fromMayaAttributeName" )
+		.def_readonly("visibilityOverrideName", LiveScene::visibilityOverrideName )
 	;
 }

--- a/src/IECorePython/InternedStringBinding.cpp
+++ b/src/IECorePython/InternedStringBinding.cpp
@@ -93,6 +93,11 @@ static size_t hash( const InternedString &str )
 	return boost::hash<const char *>()( str.c_str() );
 }
 
+static size_t len( const InternedString &str )
+{
+	return str.string().length();
+}
+
 void bindInternedString()
 {
 
@@ -107,6 +112,7 @@ void bindInternedString()
 		.def( "numUniqueStrings", &InternedString::numUniqueStrings ).staticmethod( "numUniqueStrings" )
 		.def( "__repr__", &repr )
 		.def( "__hash__", &hash )
+		.def( "__len__", &len )
 	;
 	implicitly_convertible<InternedString, string>();
 

--- a/test/IECore/InternedStringTest.py
+++ b/test/IECore/InternedStringTest.py
@@ -90,6 +90,16 @@ class InternedStringTest( unittest.TestCase ) :
 
 		self.assertEqual( set(stringRange).difference(uniqueStringsSet), set() )
 
+	def testLength( self ):
+		emptyString = IECore.InternedString()
+		helloString = IECore.InternedString( 'Hello' )
+
+		self.assertEqual( len( emptyString ), 0 )
+		self.assertFalse( emptyString )
+
+		self.assertEqual( len( helloString ), 5 )
+		self.assertTrue( helloString )
+
 if __name__ == "__main__":
 	unittest.main()
 

--- a/test/IECoreMaya/FnSceneShapeTest.py
+++ b/test/IECoreMaya/FnSceneShapeTest.py
@@ -424,7 +424,7 @@ class FnSceneShapeTest( IECoreMaya.TestCase ) :
 
 		sceneShape = sceneShapeFn.fullPathName()
 		table = maya.cmds.listRelatives( sceneShape, parent=True )[0]
-		testVisibility = maya.cmds.getAttr( table + '.ieVisibility' )
+		testVisibility = maya.cmds.getAttr( table + '.' + str( IECoreMaya.LiveScene.visibilityOverrideName ) )
 		testBool = maya.cmds.getAttr( table + '.ieAttr_testBool' )
 		testShort = maya.cmds.getAttr( table + '.ieAttr_testShort' )
 		testInt = maya.cmds.getAttr( table + '.ieAttr_testInt' )

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -992,24 +992,24 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 		self.assertEqual( t2.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 
-		# test override of maya visibility with ieVisibility attribute
-		maya.cmds.addAttr( "t1", ln="ieVisibility", at="bool" )
+		# test override of maya visibility with visibilityOverrideName attribute
+		maya.cmds.addAttr( "t1", ln=IECoreMaya.LiveScene.visibilityOverrideName, at="bool" )
 		maya.cmds.setAttr( "t1.visibility", False )
 		maya.cmds.setAttr( "m1.visibility", False )
-		maya.cmds.setAttr( "t1.ieVisibility", True )
+		maya.cmds.setAttr( "t1." + IECoreMaya.LiveScene.visibilityOverrideName.value(), True )
 		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( True ) )
 
-		# shape ieVisibility should be ignored since we set the transform level to invisible
-		maya.cmds.addAttr( "m1", ln="ieVisibility", at="bool" )
+		# shape visibilityOverrideName should be ignored since we set the transform level to invisible
+		maya.cmds.addAttr( "m1", ln=IECoreMaya.LiveScene.visibilityOverrideName, at="bool" )
 		maya.cmds.setAttr( "t1.visibility", False )
-		maya.cmds.setAttr( "t1.ieVisibility", False )
-		maya.cmds.setAttr( "m1.ieVisibility", True )
+		maya.cmds.setAttr( "t1." + IECoreMaya.LiveScene.visibilityOverrideName.value(), False )
+		maya.cmds.setAttr( "m1." + IECoreMaya.LiveScene.visibilityOverrideName.value(), True )
 		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 
-		# shape ieVisibility should override the transform ieVisibility
+		# shape visibilityOverrideName should override the transform visibilityOverrideName
 		maya.cmds.setAttr( "t1.visibility", False )
-		maya.cmds.setAttr( "t1.ieVisibility", True )
-		maya.cmds.setAttr( "m1.ieVisibility", False )
+		maya.cmds.setAttr( "t1." + IECoreMaya.LiveScene.visibilityOverrideName.value(), True )
+		maya.cmds.setAttr( "m1." + IECoreMaya.LiveScene.visibilityOverrideName.value(), False )
 		self.assertEqual( t1.readAttribute( "scene:visible", 0 ), IECore.BoolData( False ) )
 
 	def testSceneShapeVisible( self ) :
@@ -1398,8 +1398,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 			maya.cmds.disconnectAttr( sourcePlug, destPlug )
 
 		maya.cmds.currentTime( str( time0 ) + 'sec' )
-		maya.cmds.setAttr( sceneTransform + '.ieVisibility' , False )
-		maya.cmds.setKeyframe( sceneTransform + '.ieVisibility' )
+		maya.cmds.setAttr( sceneTransform + '.' + str( IECoreMaya.LiveScene.visibilityOverrideName ), False )
+		maya.cmds.setKeyframe( sceneTransform + '.' + str( IECoreMaya.LiveScene.visibilityOverrideName ) )
 		maya.cmds.setAttr( sceneTransform + '.ieAttr_testBool' , False )
 		maya.cmds.setKeyframe( sceneTransform + '.ieAttr_testBool' )
 		maya.cmds.setAttr( sceneTransform + '.ieAttr_testShort', 20 )
@@ -1417,8 +1417,8 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		maya.cmds.setAttr( sceneTransform + '.ieAttr_testMatrixf', [ 240, 250, 260, 270, 280, 290, 300, 310, 320, 330, 340, 350, 360, 370, 380, 390 ], type='matrix' )
 
 		maya.cmds.currentTime( str( time1 ) + 'sec' )
-		maya.cmds.setAttr( sceneTransform + '.ieVisibility' , True )
-		maya.cmds.setKeyframe( sceneTransform + '.ieVisibility' )
+		maya.cmds.setAttr( sceneTransform + '.' + str( IECoreMaya.LiveScene.visibilityOverrideName ) , True )
+		maya.cmds.setKeyframe( sceneTransform + '.' + str( IECoreMaya.LiveScene.visibilityOverrideName ) )
 		maya.cmds.setAttr( sceneTransform + '.ieAttr_testBool' , True )
 		maya.cmds.setKeyframe( sceneTransform + '.ieAttr_testBool' )
 		maya.cmds.setAttr( sceneTransform + '.ieAttr_testShort', 2 )
@@ -1462,5 +1462,30 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		mat = imath.M44d( ( 240, 250, 260, 270 ), ( 280, 290, 300, 310 ), ( 320, 330, 340, 350 ), ( 360, 370, 380, 390 ) )
 		self.assertEqual( liveScene.readAttribute( 'user:testMatrixf', time1 ), IECore.M44dData( mat ) )
 
+	def testToFromMayaAttributeName( self ):
+		cortexUserAttr = 'user:attrName'
+		mayaUserAttr = 'ieAttr_attrName'
+		self.assertEqual( cortexUserAttr, IECoreMaya.LiveScene.fromMayaAttributeName( mayaUserAttr ) )
+		self.assertEqual( mayaUserAttr, IECoreMaya.LiveScene.toMayaAttributeName( cortexUserAttr ) )
+
+		cortexUserAttrWithNameSpace = 'user:ns:attrName'
+		mayaUserAttrWithNameSpace = 'ieAttr_ns__attrName'
+		self.assertEqual( cortexUserAttrWithNameSpace, IECoreMaya.LiveScene.fromMayaAttributeName( mayaUserAttrWithNameSpace ) )
+		self.assertEqual( mayaUserAttrWithNameSpace, IECoreMaya.LiveScene.toMayaAttributeName( cortexUserAttrWithNameSpace ) )
+
+		mayaVisibilityAttr = IECoreMaya.LiveScene.visibilityOverrideName
+		cortexVisibilityAttr = IECoreScene.SceneInterface.visibilityName
+		self.assertEqual( cortexVisibilityAttr, IECoreMaya.LiveScene.fromMayaAttributeName( mayaVisibilityAttr ) )
+		self.assertEqual( mayaVisibilityAttr, IECoreMaya.LiveScene.toMayaAttributeName( cortexVisibilityAttr ) )
+
+		cortexAttrWithoutMayaEquivalent = 'notForMaya:attrName'
+		mayaAttrWithoutCortexEquivalent = 'notForCortex'
+		self.assertFalse( IECoreMaya.LiveScene.fromMayaAttributeName( mayaAttrWithoutCortexEquivalent ) )
+		self.assertFalse( IECoreMaya.LiveScene.toMayaAttributeName( cortexAttrWithoutMayaEquivalent ) )
+
+	def testVisibilityOverrideName( self ) :
+		self.assertEqual( IECoreMaya.LiveScene.visibilityOverrideName, 'ieVisibility' )
+
 if __name__ == "__main__":
 	IECoreMaya.TestProgram( plugins = [ "ieCore" ] )
+


### PR DESCRIPTION
Fixes a bug in which a fully expanded SceneShape loses the ability to read the cached visibility value when expanded to leaf nodes.

- Added `IECoreMaya::LiveScene::toMayaAttributeName` and `IECoreMaya::LiveScene::fromMayaAttributeName` which map cortex attribute names to and from maya attribute names.

- Updated `IECoreMaya::LiveScene::readAttribute` such that maya shape nodes do not participate in visibility determination. Additionally, custom attribute readers are now able to produce the `scene:visible` attribute. 

- Added `__len__` to `IECore.InterneredString` in order to be able to find the length of an interned string in python and make use of python truth testing.

- Updated the position of expansion options in the SceneShape Dag Menu so that expand to geometry option are on the same side (the expand by tag options were flipped).

### Related Issues ###

- N/A

### Dependencies ###

- N/A

### Breaking Changes ###

- No API/ABI breaks

- Modified the current semantics of reading "scene:visible" attribute from LiveScene. However, I consider the previous logic to be a bug.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
- [X] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
