### PR TITLE
StringAlgo : Provide support for ancient Boost 1.55.0

### DIFF
--- a/include/IECore/InternedString.h
+++ b/include/IECore/InternedString.h
@@ -37,7 +37,13 @@
 
 #include "IECore/Export.h"
 
+#include "boost/version.hpp"
+
+#if BOOST_VERSION > 105500
+
 #include "boost/utility/string_view.hpp"
+
+#endif
 
 #include <string>
 
@@ -63,7 +69,13 @@ class IECORE_API InternedString
 		inline InternedString( const InternedString &other );
 		inline InternedString( const char *value );
 		inline InternedString( const char *value, size_t length );
+
+#if BOOST_VERSION > 105500
+
 		inline InternedString( const boost::string_view &value );
+
+#endif
+
 		inline InternedString( int64_t number );
 
 		inline ~InternedString();

--- a/include/IECore/InternedString.inl
+++ b/include/IECore/InternedString.inl
@@ -63,10 +63,14 @@ inline InternedString::InternedString( const char *value, size_t length )
 {
 }
 
+#if BOOST_VERSION > 105500
+
 inline InternedString::InternedString( const boost::string_view &value )
 	:	InternedString( value.data(), value.size() )
 {
 }
+
+#endif
 
 inline InternedString::InternedString( int64_t number )
 	: m_value( numberString( number ).m_value )

--- a/include/IECore/StringAlgo.h
+++ b/include/IECore/StringAlgo.h
@@ -121,6 +121,8 @@ enum Substitutions
 	AllSubstitutions = FrameSubstitutions | VariableSubstitutions | EscapeSubstitutions | TildeSubstitutions
 };
 
+#if BOOST_VERSION > 105500
+
 /// Performs substitution on `input` using values from the `variables` object.
 IECORE_API std::string substitute( const std::string &input, const CompoundData *variables, unsigned substitutions = AllSubstitutions );
 
@@ -138,6 +140,8 @@ struct VariableProvider
 
 /// Performs substitutions on `input` using values provided by the `variableProvider` object.
 IECORE_API std::string substitute( const std::string &input, const VariableProvider &variableProvider, unsigned substitutions = AllSubstitutions );
+
+#endif
 
 /// Returns a bitmask of Substitutions values containing the
 /// sorts of substitutions contained in the string. If this returns

--- a/src/IECore/StringAlgo.cpp
+++ b/src/IECore/StringAlgo.cpp
@@ -42,7 +42,13 @@
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/lexical_cast.hpp"
 #include "boost/regex.hpp"
+#include "boost/version.hpp"
+
+#if BOOST_VERSION > 105500
+
 #include "boost/utility/string_view.hpp"
+
+#endif
 
 using namespace std;
 using namespace IECore;
@@ -98,6 +104,8 @@ bool matchInternal(
 		++matchPathBegin;
 	}
 }
+
+#if BOOST_VERSION > 105500
 
 inline void substituteInternal( const char *s, const StringAlgo::VariableProvider &variables, std::string &result, const int recursionDepth, unsigned substitutions )
 {
@@ -291,6 +299,8 @@ struct CompoundDataVariableProvider : public StringAlgo::VariableProvider
 
 };
 
+#endif
+
 } // namespace
 
 //////////////////////////////////////////////////////////////////////////
@@ -326,6 +336,7 @@ MatchPatternPath matchPatternPath( const std::string &patternPath, char separato
 	return result;
 }
 
+#if BOOST_VERSION > 105500
 
 std::string substitute( const std::string &s, const CompoundData *variables, unsigned substitutions )
 {
@@ -341,6 +352,8 @@ std::string substitute( const std::string &input, const VariableProvider &variab
 	substituteInternal( input.c_str(), variableProvider, result, 0, substitutions );
 	return result;
 }
+
+#endif
 
 unsigned substitutions( const std::string &input )
 {

--- a/src/IECorePython/StringAlgoBinding.cpp
+++ b/src/IECorePython/StringAlgoBinding.cpp
@@ -68,6 +68,8 @@ list matchPatternPath( const std::string &path, char separator )
 	return result;
 }
 
+#if BOOST_VERSION > 105500
+
 struct VariableProviderWrapper : StringAlgo::VariableProvider, wrapper<StringAlgo::VariableProvider>
 {
 
@@ -109,6 +111,8 @@ std::string substituteWrapper2( const std::string &input, const StringAlgo::Vari
 	return StringAlgo::substitute( input, variables, substitutions );
 }
 
+#endif
+
 } // namespace
 
 void IECorePython::bindStringAlgo()
@@ -132,10 +136,15 @@ void IECorePython::bindStringAlgo()
 		.value( "AllSubstitutions", StringAlgo::AllSubstitutions )
 	;
 
+#if BOOST_VERSION > 105500
+
 	class_<VariableProviderWrapper, boost::noncopyable>( "VariableProvider" );
 
 	def( "substitute", &substituteWrapper1, ( arg( "input" ), arg( "variables" ), arg( "substitutions" ) = StringAlgo::AllSubstitutions ) );
 	def( "substitute", &substituteWrapper2, ( arg( "input" ), arg( "variables" ), arg( "substitutions" ) = StringAlgo::AllSubstitutions ) );
+
+#endif
+
 	def( "substitutions", &StringAlgo::substitutions );
 	def( "hasSubstitutions", &StringAlgo::hasSubstitutions );
 


### PR DESCRIPTION
RV, and Autodesk product, is not yet shipping a version which is VFX Platform compliant, despite Autodesk being a leading member of VFX Platform and ASWF... There is apparently a beta version, but until then, we disable support for substitutions when building with very old boost libs.

I've left the tests enabled (and failing for those builds) as I wasn't sure if there is an appropriate way to disable them based on boost version from python.