### PR TITLE
IECoreMaya : FromMayaMeshConverter, respect "uv" parameter with multiple uvs

### DIFF
--- a/src/IECoreMaya/FromMayaMeshConverter.cpp
+++ b/src/IECoreMaya/FromMayaMeshConverter.cpp
@@ -619,20 +619,19 @@ IECoreScene::PrimitivePtr FromMayaMeshConverter::doPrimitiveConversion( MFnMesh 
 
 	if( uvParameter()->getTypedValue() && currentUVSet.length() )
 	{
-		result->variables["uv"] = uvs( currentUVSet, verticesPerFaceData->readable() );
-	}
-
-	MStringArray uvSets;
-	fnMesh.getUVSetNames( uvSets );
-	for( unsigned int i=0; i<uvSets.length(); i++ )
-	{
-		if( uvSets[i] == currentUVSet )
+		MStringArray uvSets;
+		fnMesh.getUVSetNames( uvSets );
+		for( unsigned int i = 0; i < uvSets.length(); i++ )
 		{
-			// we've already converted these UVs above
-			continue;
+			if( uvSets[i] == currentUVSet )
+			{
+				result->variables["uv"] = uvs( currentUVSet, verticesPerFaceData->readable() );
+			}
+			else
+			{
+				result->variables[uvSets[i].asChar()] = uvs( uvSets[i], verticesPerFaceData->readable() );
+			}
 		}
-
-		result->variables[ uvSets[i].asChar() ] = uvs( uvSets[i], verticesPerFaceData->readable() );
 	}
 
 	bool convertColors = colorsParameter()->getTypedValue();

--- a/test/IECoreMaya/FromMayaMeshConverterTest.py
+++ b/test/IECoreMaya/FromMayaMeshConverterTest.py
@@ -292,20 +292,27 @@ class FromMayaMeshConverterTest( IECoreMaya.TestCase ) :
 		converter = IECoreMaya.FromMayaShapeConverter.create( plane, IECoreScene.MeshPrimitive.staticTypeId() )
 		m = converter.convert()
 
-		self.assert_( "uv" in m )
+		self.assertIn( "uv", m )
 		# map1 is the default set
-		self.assert_( "map1" not in m )
+		self.assertNotIn( "map1", m )
 
 		maya.cmds.polyUVSet( plane, copy=True, uvSet="map1", newUVSet="map2" )
 
 		m = converter.convert()
 
-		self.assert_( "uv" in m )
-		self.assert_( "map1" not in m )
-		self.assert_( "map2" in m )
+		self.assertIn( "uv", m )
+		self.assertNotIn( "map1", m )
+		self.assertIn( "map2",  m )
 
 		self.assertEqual( m["uv"].data.getInterpretation(), IECore.GeometricData.Interpretation.UV )
 		self.assertEqual( m["map2"].data.getInterpretation(), IECore.GeometricData.Interpretation.UV )
+
+		# Test that all uvs are ignored when the uv parameter is False
+		converter["uv"].setTypedValue( False )
+		m = converter.convert()
+		self.assertNotIn( "uv", m )
+		self.assertNotIn( "map1", m )
+		self.assertNotIn( "map2", m )
 
 	def testManyUVConversionsFromPlug( self ) :
 


### PR DESCRIPTION
The "uv" parameter tells the converter whether or not to copy the maya uv sets to primitive variables on the converted MeshPrimitive. This commit fixes a bug where the converter copies extra uvs set when the maya mesh has multiple uvs and the "uv" parameter is set to False.

 - IECoreMaya : Bug fix for FromMayaMeshConverter when the maya mesh has multiple uv sets.

### Related Issues ###

- N/A

### Dependencies ###

- N/A

### Breaking Changes ###

- N/A

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
