### PR TITLE
Maya SceneShape VP2 optimizations 

### DIFF
--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -103,6 +103,16 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		using RenderItemUserDataPtr = std::shared_ptr<RenderItemUserData>;
 		using StyleMask = std::bitset<3>;
 
+		enum class RenderStyle
+		{
+			BoundingBox,
+			Wireframe,
+			Solid,
+			Textured
+		};
+
+		const std::vector<RenderStyle> &supportedRenderStyles();
+
 		struct Instance
 		{
 			Instance( const MMatrix &transformation, bool selected, bool componentMode, const MDagPath &path, bool visible )
@@ -137,6 +147,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		RenderItemUserDataPtr acquireUserData( int componentIndex );
 		void selectedComponentIndices( IndexMap &indexMap ) const;
+		MRenderItem *acquireRenderItem( MSubSceneContainer &container, const IECore::Object *object, const MString &name, RenderStyle style, bool &isNew );
 		void setBuffersForRenderItem( const IECoreScene::Primitive *primitive, MHWRender::MRenderItem *renderItem, bool wireframe, const MBoundingBox &bound );
 
 		void bufferEvictedCallback( const BufferPtr &buffer );

--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -125,7 +125,7 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		using Instances = std::vector<Instance>;
 
 		// Traverse the scene and create MRenderItems as necessary while collecting all matrices to be associated with them.
-		void visitSceneLocations( const IECoreScene::SceneInterface *sceneInterface, RenderItemMap &renderItems, MHWRender::MSubSceneContainer &container, const MMatrix &matrix, bool isRoot = false );
+		void visitSceneLocations( const IECoreScene::SceneInterface *sceneInterface, RenderItemMap &renderItems, MHWRender::MSubSceneContainer &container, const MMatrix &matrix, std::string relativeLocation, bool isRoot );
 
 		// Provide information about the instances that need drawing as
 		// SubSceneOverrides are responsible for drawing all instances of the
@@ -154,6 +154,8 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		MPlug m_shaderOutPlug;
 		bool m_instancedRendering;
 		IECoreScene::ConstSceneInterfacePtr m_sceneInterface;
+		IECoreScene::SceneInterface::Path m_rootPath;
+		std::string m_rootLocation;
 		bool m_geometryVisible;
 		bool m_objectOnly;
 

--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -147,7 +147,12 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 
 		RenderItemUserDataPtr acquireUserData( int componentIndex );
 		void selectedComponentIndices( IndexMap &indexMap ) const;
-		MRenderItem *acquireRenderItem( MSubSceneContainer &container, const IECore::Object *object, const MString &name, RenderStyle style, bool &isNew );
+		MRenderItem *acquireRenderItem(
+			MSubSceneContainer &container, const IECore::Object *object,
+			const Instance &instance, const std::string &relativeLocation,
+			const MBoundingBox &bound, const MString &name, RenderStyle style
+		);
+		void updateShaders( MRenderItem *renderItem, const Instance &instance, const std::string &relativeLocation, RenderStyle style );
 		void setBuffersForRenderItem( const IECoreScene::Primitive *primitive, MHWRender::MRenderItem *renderItem, bool wireframe, const MBoundingBox &bound );
 
 		void bufferEvictedCallback( const BufferPtr &buffer );

--- a/include/IECoreMaya/SceneShapeSubSceneOverride.h
+++ b/include/IECoreMaya/SceneShapeSubSceneOverride.h
@@ -49,6 +49,8 @@
 
 #include <bitset>
 #include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace IECoreMaya
 {
@@ -159,9 +161,9 @@ class IECOREMAYA_API SceneShapeSubSceneOverride : public MHWRender::MPxSubSceneO
 		IndexMap m_selectedComponents;
 		std::map<int, RenderItemUserDataPtr> m_userDataMap;
 		std::vector<BufferPtr> m_markedForDeletion;
-		using RenderItemNameSet = std::set<IECore::InternedString>;
-		std::map<Buffer*, RenderItemNameSet> m_bufferToRenderItems;
-		std::set<MHWRender::MRenderItem*> m_renderItemsToEnable;
+		using RenderItemNames = std::vector<MString>;
+		std::unordered_map<Buffer*, RenderItemNames> m_bufferToRenderItems;
+		std::unordered_set<MHWRender::MRenderItem*> m_renderItemsToEnable;
 
 		struct AllShaders;
 		using AllShadersPtr = std::shared_ptr<AllShaders>;

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1375,14 +1375,10 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 			continue;
 		}
 
-		const RenderItemNameSet &names = it->second;
-		for( const InternedString &itemName : names )
+		const RenderItemNames &names = it->second;
+		for( const auto &name : names )
 		{
-			MString name( itemName.c_str() );
-			if( container.find( name ) )
-			{
-				container.remove( name );
-			}
+			container.remove( name );
 	 	}
 	 	m_bufferToRenderItems.erase( b );
 	}
@@ -1749,11 +1745,11 @@ void SceneShapeSubSceneOverride::setBuffersForRenderItem( const Primitive *primi
 	auto it = m_bufferToRenderItems.find( buffer.get() );
 	if( it == m_bufferToRenderItems.end() )
 	{
-		m_bufferToRenderItems.emplace( buffer.get(), RenderItemNameSet{ renderItem->name().asChar() } );
+		m_bufferToRenderItems.emplace( buffer.get(), RenderItemNames{ renderItem->name() } );
 	}
 	else
 	{
-		it->second.emplace( renderItem->name().asChar() );
+		it->second.emplace_back( renderItem->name() );
 	}
 
 	MVertexBufferArray vertexBufferArray;
@@ -1798,11 +1794,11 @@ void SceneShapeSubSceneOverride::setBuffersForRenderItem( const Primitive *primi
 		it = m_bufferToRenderItems.find( buffer.get() );
 		if( it == m_bufferToRenderItems.end() )
 		{
-			m_bufferToRenderItems.emplace( buffer.get(), RenderItemNameSet{ renderItem->name().asChar() } );
+			m_bufferToRenderItems.emplace( buffer.get(), RenderItemNames{ renderItem->name() } );
 		}
 		else
 		{
-			it->second.emplace( renderItem->name().asChar() );
+			it->second.emplace_back( renderItem->name() );
 		}
 	}
 
@@ -1866,7 +1862,7 @@ void SceneShapeSubSceneOverride::bufferEvictedCallback( const BufferPtr &buffer 
 #if MAYA_API_VERSION > 201650
 bool SceneShapeSubSceneOverride::getInstancedSelectionPath( const MRenderItem &renderItem, const MIntersection &intersection, MDagPath &dagPath ) const
 {
-	auto it = m_renderItemNameToDagPath.find( std::string( renderItem.name().asChar() ) );
+	auto it = m_renderItemNameToDagPath.find( renderItem.name().asChar() );
 	if( it != m_renderItemNameToDagPath.end() )
 	{
 		dagPath.set( it->second );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1458,10 +1458,7 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	MRenderItem *renderItem = nullptr;
 	while( (renderItem = it->next()) != nullptr )
 	{
-		if( renderItem->isEnabled() )
-		{
-			renderItem->enable( false );
-		}
+		renderItem->enable( false );
 	}
 	it->destroy();
 

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1521,8 +1521,11 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	}
 
 	// Dispatch to children only if we need to draw them
-	/// \todo: we should be accounting for the tag filter when recursing to children
-	if( ( m_geometryVisible || m_drawChildBounds ) && !m_objectOnly )
+	if(
+		( m_geometryVisible || m_drawChildBounds ) &&
+		!m_objectOnly &&
+		( m_drawTagsFilter.empty() || sceneInterface->hasTag( m_drawTagsFilter, SceneInterface::DescendantTag | SceneInterface::LocalTag ) )
+	)
 	{
 		SceneInterface::NameList childNames;
 		sceneInterface->childNames( childNames );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1682,8 +1682,12 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 
 			// Before setting geometry, a shader has to be assigned so that the data requirements are clear.
 			std::string pathKey = instance.path.fullPathName().asChar();
-			/// \todo: we're inserting pathKey into the map regardless of whether it existed before
-			bool componentSelected = m_selectedComponents[pathKey].count( componentIndex ) > 0;
+			bool componentSelected = false;
+			auto selectionIt = m_selectedComponents.find( pathKey );
+			if( selectionIt != m_selectedComponents.end() )
+			{
+				componentSelected = selectionIt->second.count( componentIndex ) > 0;
+			}
 
 			MShaderInstance *shader = m_allShaders->getShader( style, instance.componentMode, instance.componentMode ? componentSelected : instance.selected );
 			if( renderItem->getShader() != shader )
@@ -1924,15 +1928,19 @@ void SceneShapeSubSceneOverride::selectedComponentIndices( SceneShapeSubSceneOve
 			continue;
 		}
 
+		std::string key = selectedPath.fullPathName().asChar();
+		auto it = indexMap.find( key );
+		if( it == indexMap.end() )
+		{
+			continue;
+		}
+
 		MIntArray componentIndices;
 		compFn.getElements( componentIndices );
 
-		std::string key = selectedPath.fullPathName().asChar();
 		for( size_t i = 0; i < componentIndices.length(); ++i )
 		{
-			/// \todo: this is inserting selected paths into the map regardless
-			/// of whether they match the dag paths of our node.
-			indexMap[key].insert( componentIndices[i] );
+			it->second.insert( componentIndices[i] );
 		}
 	}
 }

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -707,97 +707,6 @@ Cache &cache()
 // Misc Utilities
 ////////////////////////////////////////////////////////////////////////////////////////////
 
-enum class RenderStyle { BoundingBox, Wireframe, Solid, Textured };
-const std::vector<RenderStyle> &supportedRenderStyles()
-{
-	static std::vector<RenderStyle> g_supportedStyles = { RenderStyle::BoundingBox, RenderStyle::Wireframe, RenderStyle::Solid, RenderStyle::Textured };
-	return g_supportedStyles;
-}
-
-MRenderItem *acquireRenderItem( MSubSceneContainer &container, const IECore::Object *object, const MString &name, RenderStyle style, bool &isNew )
-{
-	MRenderItem *renderItem = container.find( name );
-	if( renderItem )
-	{
-		isNew = false; // this comes from the container and was assigned some geo before.
-		return renderItem;
-	}
-
-	// If the container does not have an appropriate MRenderItem yet, we'll construct an empty one.
-	isNew = true;
-
-	switch( style )
-	{
-	case RenderStyle::BoundingBox :
-	{
-		renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kLines);
-		renderItem->setDrawMode( MGeometry::kAll );
-		renderItem->castsShadows( false );
-		renderItem->receivesShadows( false );
-		renderItem->setExcludedFromPostEffects( true );
-		renderItem->depthPriority( MRenderItem::sActiveWireDepthPriority );
-		break;
-	}
-	case RenderStyle::Wireframe :
-	{
-		switch( static_cast<IECoreScene::TypeId>( object->typeId() ) )
-		{
-		case IECoreScene::TypeId::PointsPrimitiveTypeId :
-			renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kPoints );
-			break;
-		case IECoreScene::TypeId::CurvesPrimitiveTypeId :
-		case IECoreScene::TypeId::MeshPrimitiveTypeId :
-			renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kLines );
-			break;
-		default :
-			return nullptr;
-		}
-		renderItem->setDrawMode( MGeometry::kAll );
-		renderItem->castsShadows( false );
-		renderItem->receivesShadows( false );
-		renderItem->setExcludedFromPostEffects( true );
-		renderItem->depthPriority( MRenderItem::sActiveWireDepthPriority );
-		break;
-	}
-	case RenderStyle::Solid :
-	case RenderStyle::Textured :
-	{
-		switch( static_cast<IECoreScene::TypeId>( object->typeId() ) )
-		{
-			case IECoreScene::TypeId::PointsPrimitiveTypeId :
-			{
-				renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kPoints );
-				break;
-			}
-			case IECoreScene::TypeId::MeshPrimitiveTypeId :
-			{
-				renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kTriangles );
-				break;
-			}
-			case IECoreScene::TypeId::CurvesPrimitiveTypeId :
-			{
-				renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kLines );
-				break;
-			}
-		default :
-			break;
-
-		}
-
-		renderItem->setDrawMode( ( style == RenderStyle::Solid ) ? MGeometry::kShaded : MGeometry::kTextured );
-		renderItem->castsShadows( true );
-		renderItem->receivesShadows( true );
-		renderItem->setExcludedFromPostEffects( false );
-	}
-	default :
-		break;
-	}
-
-	container.add( renderItem );
-
-	return renderItem;
-}
-
 // For the given node return the out plug on the surface shader that is assigned
 MPlug getShaderOutPlug( const MObject &sceneShapeNode )
 {
@@ -1729,6 +1638,90 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	}
 }
 
+MRenderItem *SceneShapeSubSceneOverride::acquireRenderItem( MSubSceneContainer &container, const IECore::Object *object, const MString &name, RenderStyle style, bool &isNew )
+{
+	MRenderItem *renderItem = container.find( name );
+	if( renderItem )
+	{
+		isNew = false; // this comes from the container and was assigned some geo before.
+		return renderItem;
+	}
+
+	// If the container does not have an appropriate MRenderItem yet, we'll construct an empty one.
+	isNew = true;
+
+	switch( style )
+	{
+		case RenderStyle::BoundingBox :
+		{
+			renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kLines);
+			renderItem->setDrawMode( MGeometry::kAll );
+			renderItem->castsShadows( false );
+			renderItem->receivesShadows( false );
+			renderItem->setExcludedFromPostEffects( true );
+			renderItem->depthPriority( MRenderItem::sActiveWireDepthPriority );
+			break;
+		}
+		case RenderStyle::Wireframe :
+		{
+			switch( static_cast<IECoreScene::TypeId>( object->typeId() ) )
+			{
+				case IECoreScene::TypeId::PointsPrimitiveTypeId :
+					renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kPoints );
+					break;
+				case IECoreScene::TypeId::CurvesPrimitiveTypeId :
+				case IECoreScene::TypeId::MeshPrimitiveTypeId :
+					renderItem = MRenderItem::Create( name, MRenderItem::DecorationItem, MGeometry::kLines );
+					break;
+				default :
+					return nullptr;
+			}
+			renderItem->setDrawMode( MGeometry::kAll );
+			renderItem->castsShadows( false );
+			renderItem->receivesShadows( false );
+			renderItem->setExcludedFromPostEffects( true );
+			renderItem->depthPriority( MRenderItem::sActiveWireDepthPriority );
+			break;
+		}
+		case RenderStyle::Solid :
+		case RenderStyle::Textured :
+		{
+			switch( static_cast<IECoreScene::TypeId>( object->typeId() ) )
+			{
+				case IECoreScene::TypeId::PointsPrimitiveTypeId :
+				{
+					renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kPoints );
+					break;
+				}
+				case IECoreScene::TypeId::MeshPrimitiveTypeId :
+				{
+					renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kTriangles );
+					break;
+				}
+				case IECoreScene::TypeId::CurvesPrimitiveTypeId :
+				{
+					renderItem = MRenderItem::Create( name, MRenderItem::MaterialSceneItem, MGeometry::kLines );
+					break;
+				}
+				default :
+					break;
+
+			}
+
+			renderItem->setDrawMode( ( style == RenderStyle::Solid ) ? MGeometry::kShaded : MGeometry::kTextured );
+			renderItem->castsShadows( true );
+			renderItem->receivesShadows( true );
+			renderItem->setExcludedFromPostEffects( false );
+		}
+		default :
+			break;
+	}
+
+	container.add( renderItem );
+
+	return renderItem;
+}
+
 void SceneShapeSubSceneOverride::setBuffersForRenderItem( const Primitive *primitive, MRenderItem *renderItem, bool wireframe, const MBoundingBox &bound )
 {
 	CacheEntryPtr entry = cache().get( { MVertexBufferDescriptor(), primitive, nullptr, bound } );
@@ -1848,6 +1841,12 @@ SceneShapeSubSceneOverride::RenderItemUserDataPtr SceneShapeSubSceneOverride::ac
 void SceneShapeSubSceneOverride::bufferEvictedCallback( const BufferPtr &buffer )
 {
 	m_markedForDeletion.emplace_back( buffer ); // hold on to the resource just a little longer
+}
+
+const std::vector<SceneShapeSubSceneOverride::RenderStyle> &SceneShapeSubSceneOverride::supportedRenderStyles()
+{
+	static std::vector<RenderStyle> g_supportedStyles = { RenderStyle::BoundingBox, RenderStyle::Wireframe, RenderStyle::Solid, RenderStyle::Textured };
+	return g_supportedStyles;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1386,6 +1386,8 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 
 	// Create and enable MRenderItems while traversing the scene hierarchy
 	RenderItemMap renderItems;
+	/// \todo: SceneInterface structure is consistent over time. Consider separating the
+	/// traversal from the RenderItem accumulation to avoid unneeded IndexedIO per-draw
 	visitSceneLocations( m_sceneInterface.get(), renderItems, container, MMatrix(), "", true );
 
 	for( auto *item : m_renderItemsToEnable )

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1567,7 +1567,10 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			MRenderItem *renderItem = acquireRenderItem( container, IECore::NullObject::defaultNullObject(), itemName, RenderStyle::BoundingBox, isNew );
 
 			MShaderInstance *shader = m_allShaders->getShader( RenderStyle::BoundingBox, instance.componentMode, instance.selected );
-			renderItem->setShader( shader );
+			if( renderItem->getShader() != shader )
+			{
+				renderItem->setShader( shader );
+			}
 
 			if( isNew )
 			{
@@ -1690,7 +1693,10 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 			bool componentSelected = m_selectedComponents[pathKey].count( componentIndex ) > 0;
 
 			MShaderInstance *shader = m_allShaders->getShader( style, instance.componentMode, instance.componentMode ? componentSelected : instance.selected );
-			renderItem->setShader( shader );
+			if( renderItem->getShader() != shader )
+			{
+				renderItem->setShader( shader );
+			}
 
 			// Update the selection mask to enable marquee selection of components we explicitly disable
 			// wireframe selection in Solid mode, because otherwise we'd get double selections (the marquee

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1684,8 +1684,7 @@ void SceneShapeSubSceneOverride::updateShaders( MRenderItem *renderItem, const I
 		auto selectionIt = m_selectedComponents.find( instance.path.fullPathName().asChar() );
 		if( selectionIt != m_selectedComponents.end() )
 		{
-			/// \todo: stop using the SceneShapeInterface selectionIndex. It relies on a secondary IECoreGL render.
-			componentSelected = selectionIt->second.count( m_sceneShape->selectionIndex( relativeLocation ) ) > 0;
+			componentSelected = selectionIt->second.count( dynamic_cast<RenderItemUserData*>(renderItem->customData())->componentIndex ) > 0;
 		}
 
 		shader = m_allShaders->getShader( style, instance.componentMode, componentSelected );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1532,7 +1532,8 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 
 		for( const auto &childName : childNames )
 		{
-			visitSceneLocations( sceneInterface->child( childName ).get(), renderItems, container, accumulatedMatrix, false );
+			ConstSceneInterfacePtr child = sceneInterface->child( childName );
+			visitSceneLocations( child.get(), renderItems, container, accumulatedMatrix, false );
 		}
 	}
 


### PR DESCRIPTION
This improves performance of our VP2 drawing as tested on 2 production assets. The first is a digi-double with ~370k polys across 20 shapes. The second is a robot with ~300k polys across ~200 shapes.

Note all timings are taken on a cycle animation (either walk cycle or callisthenics test) after playing through once to get the filesystem IO out of the picture as much as possible. Also, they weren't measured too scientifically, just playing back and watching the FPS reported in the Viewport HUD.

| | Before | After |
:-: | :-: | :-: |
Human | 11 fps | 121 fps
Robot | 20 fps | 38 fps

A vtune profile taken after these changes shows Maya / GPU crosstalk as the primary bottleneck now, but I've also added a todo for the most prominent Cortex bit remaining. That'd take a big enough re-write of the traversal function that I wasn't sure I'd be able to get to it by weeks end, so thought it was worth putting this up now as I'm off work for the rest of April.

Its probably worth going through the code a commit at a time, as the logic of each changed is explained in each commit message, and the final diff is a bit much to look at in one go.