### PR TITLE
Houdini transform pc

### DIFF
--- a/include/IECoreHoudini/SOP_SceneCacheSource.h
+++ b/include/IECoreHoudini/SOP_SceneCacheSource.h
@@ -117,6 +117,8 @@ class IECOREHOUDINI_API SOP_SceneCacheSource : public SceneCacheNode<SOP_Node>
 			ReturnType operator()( const T *data ) const;
 		};
 
+		IECore::ConstObjectPtr buildTransformPointCloud( const IECoreScene::SceneInterface *scene,const Imath::M44d &transform,const double time, Parameters &params,const bool hasObject );
+
 };
 
 } // namespace IECoreHoudini

--- a/include/IECoreHoudini/SceneCacheNode.h
+++ b/include/IECoreHoudini/SceneCacheNode.h
@@ -105,7 +105,8 @@ class IECOREHOUDINI_API SceneCacheNode : public BaseType
 			Cortex,
 			Houdini,
 			BoundingBox,
-			PointCloud
+			PointCloud,
+			TransformPointCloud
 		};
 
 		/// convenience methods for the common parameters;

--- a/include/IECoreHoudini/ToHoudiniNumericAttribConverter.h
+++ b/include/IECoreHoudini/ToHoudiniNumericAttribConverter.h
@@ -103,6 +103,7 @@ typedef ToHoudiniNumericVectorAttribConverter<IECore::V2iVectorData> ToHoudiniV2
 typedef ToHoudiniNumericVectorAttribConverter<IECore::V3iVectorData> ToHoudiniV3iVectorAttribConverter;
 typedef ToHoudiniNumericVectorAttribConverter<IECore::M33fVectorData> ToHoudiniM33fVectorAttribConverter;
 typedef ToHoudiniNumericVectorAttribConverter<IECore::M44fVectorData> ToHoudiniM44fVectorAttribConverter;
+typedef ToHoudiniNumericVectorAttribConverter<IECore::M44dVectorData> ToHoudiniM44dVectorAttribConverter;
 
 typedef ToHoudiniNumericDetailAttribConverter<IECore::FloatData> ToHoudiniFloatDetailAttribConverter;
 typedef ToHoudiniNumericDetailAttribConverter<IECore::V2fData> ToHoudiniV2fDetailAttribConverter;
@@ -113,6 +114,7 @@ typedef ToHoudiniNumericDetailAttribConverter<IECore::V2iData> ToHoudiniV2iDetai
 typedef ToHoudiniNumericDetailAttribConverter<IECore::V3iData> ToHoudiniV3iDetailAttribConverter;
 typedef ToHoudiniNumericDetailAttribConverter<IECore::M33fData> ToHoudiniM33fDetailAttribConverter;
 typedef ToHoudiniNumericDetailAttribConverter<IECore::M44fData> ToHoudiniM44fDetailAttribConverter;
+typedef ToHoudiniNumericDetailAttribConverter<IECore::M44dData> ToHoudiniM44dDetailAttribConverter;
 
 } // namespace IECoreHoudini
 

--- a/include/IECoreHoudini/TypeIds.h
+++ b/include/IECoreHoudini/TypeIds.h
@@ -85,6 +85,8 @@ namespace IECoreHoudini
 		ToHoudiniM44fDetailAttribConverterTypeId = 111038,
 		ToHoudiniM33fVectorAttribConverterTypeId = 111039,
 		ToHoudiniM44fVectorAttribConverterTypeId = 111040,
+		ToHoudiniM44dDetailAttribConverterTypeId = 111041,
+		ToHoudiniM44dVectorAttribConverterTypeId = 111042,
 		// remember to update TypeIdBinding.cpp
 		LastTypeId = 111999,
 	};

--- a/include/IECoreHoudini/TypeTraits.h
+++ b/include/IECoreHoudini/TypeTraits.h
@@ -68,6 +68,7 @@ template<> struct IsVectorAttribFloatTypedData< IECore::V3fVectorData > : public
 template<> struct IsVectorAttribFloatTypedData< IECore::Color3fVectorData > : public boost::true_type {};
 template<> struct IsVectorAttribFloatTypedData< IECore::M33fVectorData > : public boost::true_type {};
 template<> struct IsVectorAttribFloatTypedData< IECore::M44fVectorData > : public boost::true_type {};
+template<> struct IsVectorAttribFloatTypedData< IECore::M44dVectorData > : public boost::true_type {};
 
 /// IsVectorAttribIntTypedData
 template<typename T> struct IsVectorAttribIntTypedData : public boost::false_type {};

--- a/src/IECoreHoudini/SOP_SceneCacheSource.cpp
+++ b/src/IECoreHoudini/SOP_SceneCacheSource.cpp
@@ -50,6 +50,8 @@
 #include "IECore/DespatchTypedData.h"
 #include "IECore/TypeTraits.h"
 
+#include "OpenEXR/ImathMatrixAlgo.h"
+
 #include "GA/GA_Names.h"
 #include "OP/OP_NodeInfoParms.h"
 #include "PRM/PRM_ChoiceList.h"
@@ -63,6 +65,7 @@ using namespace IECoreScene;
 using namespace IECoreHoudini;
 
 static InternedString pName( "P" );
+static InternedString mRefName( "user:Mref" );
 
 const char *SOP_SceneCacheSource::typeName = "ieSceneCacheSource";
 
@@ -305,6 +308,66 @@ OP_ERROR SOP_SceneCacheSource::cookMySop( OP_Context &context )
 	return error();
 }
 
+ConstObjectPtr SOP_SceneCacheSource::buildTransformPointCloud( const IECoreScene::SceneInterface *scene,const Imath::M44d &transform,const double time, Parameters &params,const bool hasObject )
+{
+	params.hasAnimatedTopology = false;
+	params.hasAnimatedPrimVars = true;
+	params.animatedPrimVars.clear();
+	Imath::V3f p(0);
+	std::vector<Imath::V3f> point( 1, p );
+	PointsPrimitivePtr points = new PointsPrimitive( new V3fVectorData( point ) );
+
+	// has object
+	std::vector<int> hasObjects( 1, hasObject );
+	points->variables["hasobject"] = PrimitiveVariable( PrimitiveVariable::Vertex, new IntVectorData( hasObjects ) );
+
+	// transform matrix
+	std::vector<Imath::M44d> transformMatrix( 1, transform );
+	points->variables["transform"] = PrimitiveVariable( PrimitiveVariable::Vertex, new M44dVectorData( transformMatrix ) );
+
+	Imath::V3d scale;
+	extractScaling( transform, scale, false );
+	float uniformScale = ( fabs( scale.x ) + fabs( scale.y ) + fabs( scale.z ) ) / 3.0f;
+	std::vector<float> pscale( 1, uniformScale );
+	points->variables["pscale"] = PrimitiveVariable( PrimitiveVariable::Vertex, new FloatVectorData( pscale ) );
+
+	std::vector<Imath::V3f> scales( 1, scale / uniformScale );
+	points->variables["scale"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( scales ) );
+
+	Imath::M44d rotationMatrix = transform;
+	removeScalingAndShear( rotationMatrix, false );
+	std::vector<Imath::Quatf> orientation( 1, extractQuat( rotationMatrix ) );
+	points->variables["orient"] = PrimitiveVariable( PrimitiveVariable::Vertex, new QuatfVectorData( orientation ) );
+
+	if ( scene->hasAttribute( mRefName ) )
+	{
+		if ( IECore::ConstObjectPtr mRefAttr = scene->readAttribute( mRefName, time ) )
+		{
+			const IECore::M44dData* mRef = IECore::runTimeCast<const IECore::M44dData >( mRefAttr.get() );
+			if ( mRef )
+			{
+				// mref transform
+				const Imath::M44d &refTransform = mRef->readable();
+				std::vector<Imath::M44d> mRefMatrix( 1, refTransform );
+				points->variables["resttransform"] = PrimitiveVariable( PrimitiveVariable::Vertex, new M44dVectorData( mRefMatrix ) );
+
+				// rest position
+				std::vector<Imath::V3f> rest( 1, refTransform.translation() );
+				points->variables["restposition"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( rest ) );
+				params.animatedPrimVars.push_back( "resttransform" );
+				params.animatedPrimVars.push_back( "restposition" );
+			}
+		}
+	}
+	params.animatedPrimVars.push_back( "P" );
+	params.animatedPrimVars.push_back( "transform" );
+	params.animatedPrimVars.push_back( "pscale" );
+	params.animatedPrimVars.push_back( "scale" );
+	params.animatedPrimVars.push_back( "orient" );
+
+	return points;
+
+}
 void SOP_SceneCacheSource::loadObjects( const IECoreScene::SceneInterface *scene, Imath::M44d transform, double time, Space space, Parameters &params, size_t rootSize, std::string currentPath )
 {
 	UT_Interrupt *progress = UTgetInterrupt();
@@ -350,7 +413,7 @@ void SOP_SceneCacheSource::loadObjects( const IECoreScene::SceneInterface *scene
 	if ( UT_String( currentPath ).multiMatch( params.shapeFilter ) && tagged( scene, params.tagFilter ) )
 	{
 
-		if ( params.inheritedVisibility && scene->hasObject() )
+		if ( params.inheritedVisibility )
 		{
 			Imath::M44d currentTransform;
 			if ( space == Local )
@@ -361,73 +424,86 @@ void SOP_SceneCacheSource::loadObjects( const IECoreScene::SceneInterface *scene
 			{
 				currentTransform = transform;
 			}
-
 			ConstObjectPtr object = 0;
-			if ( params.geometryType == BoundingBox )
+			if ( scene->hasObject() )
 			{
-				Imath::Box3d bound = scene->readBound( time );
-				object = MeshPrimitive::createBox( Imath::Box3f( bound.min, bound.max ) );
-
-				params.hasAnimatedTopology = false;
-				params.hasAnimatedPrimVars = true;
-				params.animatedPrimVars.clear();
-				params.animatedPrimVars.push_back( "P" );
-			}
-			else if ( params.geometryType == PointCloud )
-			{
-				std::vector<Imath::V3f> point( 1, scene->readBound( time ).center() );
-				PointsPrimitivePtr points = new PointsPrimitive( new V3fVectorData( point ) );
-				std::vector<Imath::V3f> basis1( 1, Imath::V3f( currentTransform[0][0], currentTransform[0][1], currentTransform[0][2] ) );
-				std::vector<Imath::V3f> basis2( 1, Imath::V3f( currentTransform[1][0], currentTransform[1][1], currentTransform[1][2] ) );
-				std::vector<Imath::V3f> basis3( 1, Imath::V3f( currentTransform[2][0], currentTransform[2][1], currentTransform[2][2] ) );
-				points->variables["basis1"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis1 ) );
-				points->variables["basis2"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis2 ) );
-				points->variables["basis3"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis3 ) );
-
-				params.hasAnimatedTopology = false;
-				params.hasAnimatedPrimVars = true;
-				params.animatedPrimVars.clear();
-				params.animatedPrimVars.push_back( "P" );
-				params.animatedPrimVars.push_back( "basis1" );
-				params.animatedPrimVars.push_back( "basis2" );
-				params.animatedPrimVars.push_back( "basis3" );
-
-				object = points;
-			}
-			else
-			{
-				object = scene->readObject( time );
-
-				params.hasAnimatedTopology = scene->hasAttribute( SceneCache::animatedObjectTopologyAttribute );
-				params.hasAnimatedPrimVars = scene->hasAttribute( SceneCache::animatedObjectPrimVarsAttribute );
-				if ( params.hasAnimatedPrimVars )
+				if ( params.geometryType == BoundingBox )
 				{
-					const ConstObjectPtr animatedPrimVarObj = scene->readAttribute( SceneCache::animatedObjectPrimVarsAttribute, 0 );
-					const InternedStringVectorData *animatedPrimVarData = IECore::runTimeCast<const InternedStringVectorData>( animatedPrimVarObj.get() );
-					if ( animatedPrimVarData )
+					Imath::Box3d bound = scene->readBound( time );
+					object = MeshPrimitive::createBox( Imath::Box3f( bound.min, bound.max ) );
+
+					params.hasAnimatedTopology = false;
+					params.hasAnimatedPrimVars = true;
+					params.animatedPrimVars.clear();
+					params.animatedPrimVars.push_back( "P" );
+				}
+				else if ( params.geometryType == PointCloud )
+				{
+					std::vector<Imath::V3f> point( 1, scene->readBound( time ).center() );
+					PointsPrimitivePtr points = new PointsPrimitive( new V3fVectorData( point ) );
+					std::vector<Imath::V3f> basis1( 1, Imath::V3f( currentTransform[0][0], currentTransform[0][1], currentTransform[0][2] ) );
+					std::vector<Imath::V3f> basis2( 1, Imath::V3f( currentTransform[1][0], currentTransform[1][1], currentTransform[1][2] ) );
+					std::vector<Imath::V3f> basis3( 1, Imath::V3f( currentTransform[2][0], currentTransform[2][1], currentTransform[2][2] ) );
+					points->variables["basis1"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis1 ) );
+					points->variables["basis2"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis2 ) );
+					points->variables["basis3"] = PrimitiveVariable( PrimitiveVariable::Vertex, new V3fVectorData( basis3 ) );
+
+					params.hasAnimatedTopology = false;
+					params.hasAnimatedPrimVars = true;
+					params.animatedPrimVars.clear();
+					params.animatedPrimVars.push_back( "P" );
+					params.animatedPrimVars.push_back( "basis1" );
+					params.animatedPrimVars.push_back( "basis2" );
+					params.animatedPrimVars.push_back( "basis3" );
+
+					object = points;
+				}
+				else if( params.geometryType == TransformPointCloud )
+				{
+					object = buildTransformPointCloud( scene, currentTransform, time, params, true );
+				}
+				else
+				{
+					object = scene->readObject( time );
+
+					params.hasAnimatedTopology = scene->hasAttribute( SceneCache::animatedObjectTopologyAttribute );
+					params.hasAnimatedPrimVars = scene->hasAttribute( SceneCache::animatedObjectPrimVarsAttribute );
+					if ( params.hasAnimatedPrimVars )
 					{
-						const std::vector<InternedString> &values = animatedPrimVarData->readable();
-						params.animatedPrimVars.clear();
-						params.animatedPrimVars.resize( values.size() );
-						std::copy( values.begin(), values.end(), params.animatedPrimVars.begin() );
+						const ConstObjectPtr animatedPrimVarObj = scene->readAttribute( SceneCache::animatedObjectPrimVarsAttribute, 0 );
+						const InternedStringVectorData *animatedPrimVarData = IECore::runTimeCast<const InternedStringVectorData>( animatedPrimVarObj.get() );
+						if ( animatedPrimVarData )
+						{
+							const std::vector<InternedString> &values = animatedPrimVarData->readable();
+							params.animatedPrimVars.clear();
+							params.animatedPrimVars.resize( values.size() );
+							std::copy( values.begin(), values.end(), params.animatedPrimVars.begin() );
+						}
 					}
+
+				}
+			}
+			else if( params.geometryType == TransformPointCloud )
+			{
+				object = buildTransformPointCloud( scene, currentTransform, time, params, false );
+			}
+
+			if ( object )
+			{
+				// modify the object if necessary
+				object = modifyObject( object.get(), params );
+
+				// transform the object unless its an identity
+				if ( currentTransform != Imath::M44d() )
+				{
+					object = transformObject( object.get(), currentTransform, params );
 				}
 
-			}
-
-			// modify the object if necessary
-			object = modifyObject( object.get(), params );
-
-			// transform the object unless its an identity
-			if ( currentTransform != Imath::M44d() )
-			{
-				object = transformObject( object.get(), currentTransform, params );
-			}
-
-			// convert the object to Houdini
-			if ( !convertObject( object.get(), name, scene, params ) )
-			{
-				addWarning( SOP_MESSAGE, ( "Could not convert " + currentPath + " to Houdini" ).c_str() );
+				// convert the object to Houdini
+				if ( !convertObject( object.get(), name, scene, params ) )
+				{
+					addWarning( SOP_MESSAGE, ( "Could not convert " + currentPath + " to Houdini" ).c_str() );
+				}
 			}
 		}
 	}

--- a/src/IECoreHoudini/SceneCacheNode.cpp
+++ b/src/IECoreHoudini/SceneCacheNode.cpp
@@ -132,6 +132,7 @@ static PRM_Name geometryTypes[] = {
 	PRM_Name( "1", "Houdini Geometry" ),
 	PRM_Name( "2", "Bounding Boxes" ),
 	PRM_Name( "3", "Point Cloud" ),
+	PRM_Name( "4", "Transform Point Cloud" ),
 	PRM_Name( 0 ) // sentinal
 };
 

--- a/src/IECoreHoudini/ToHoudiniNumericAttribConverter.cpp
+++ b/src/IECoreHoudini/ToHoudiniNumericAttribConverter.cpp
@@ -48,6 +48,7 @@ IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniV2iVectorAttribConver
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniV3iVectorAttribConverter, ToHoudiniV3iVectorAttribConverterTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM33fVectorAttribConverter, ToHoudiniM33fVectorAttribConverterTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM44fVectorAttribConverter, ToHoudiniM44fVectorAttribConverterTypeId )
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM44dVectorAttribConverter, ToHoudiniM44dVectorAttribConverterTypeId )
 
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniFloatDetailAttribConverter, ToHoudiniFloatDetailAttribConverterTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniV2fDetailAttribConverter, ToHoudiniV2fDetailAttribConverterTypeId )
@@ -58,6 +59,7 @@ IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniV2iDetailAttribConver
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniV3iDetailAttribConverter, ToHoudiniV3iDetailAttribConverterTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM33fDetailAttribConverter, ToHoudiniM33fDetailAttribConverterTypeId )
 IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM44fDetailAttribConverter, ToHoudiniM44fDetailAttribConverterTypeId )
+IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( ToHoudiniM44dDetailAttribConverter, ToHoudiniM44dDetailAttribConverterTypeId )
 
 // Explicit instantiations for numeric vector classes
 template class ToHoudiniNumericVectorAttribConverter<IECore::FloatVectorData>;
@@ -69,6 +71,7 @@ template class ToHoudiniNumericVectorAttribConverter<IECore::V2iVectorData>;
 template class ToHoudiniNumericVectorAttribConverter<IECore::V3iVectorData>;
 template class ToHoudiniNumericVectorAttribConverter<IECore::M33fVectorData>;
 template class ToHoudiniNumericVectorAttribConverter<IECore::M44fVectorData>;
+template class ToHoudiniNumericVectorAttribConverter<IECore::M44dVectorData>;
 
 // Explicit instantiations for numeric detail classes
 template class ToHoudiniNumericDetailAttribConverter<IECore::FloatData>;
@@ -80,5 +83,6 @@ template class ToHoudiniNumericDetailAttribConverter<IECore::V2iData>;
 template class ToHoudiniNumericDetailAttribConverter<IECore::V3iData>;
 template class ToHoudiniNumericDetailAttribConverter<IECore::M33fData>;
 template class ToHoudiniNumericDetailAttribConverter<IECore::M44fData>;
+template class ToHoudiniNumericDetailAttribConverter<IECore::M44dData>;
 
 } // namespace IECoreHoudini

--- a/src/IECoreHoudini/bindings/SceneCacheNodeBinding.cpp
+++ b/src/IECoreHoudini/bindings/SceneCacheNodeBinding.cpp
@@ -152,6 +152,7 @@ void IECoreHoudini::bindSceneCacheNode()
 		.value( "Houdini", SceneCacheNode<OP_Node>::Houdini )
 		.value( "BoundingBox", SceneCacheNode<OP_Node>::BoundingBox )
 		.value( "PointCloud", SceneCacheNode<OP_Node>::PointCloud )
+		.value( "TransformPointCloud", SceneCacheNode<OP_Node>::TransformPointCloud )
 	;
 
 	enum_<OBJ_SceneCacheTransform::Hierarchy>( "Hierarchy" )

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -3324,9 +3324,9 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 			bPoint = prims[1].vertices()[0].point()
 			cPoint = prims[2].vertices()[0].point()
 
-			aWorld = scene.readTransformAsMatrix( time ) * a.readTransformAsMatrix( time )
-			bWorld = aWorld * b.readTransformAsMatrix( time )
-			cWorld = bWorld * c.readTransformAsMatrix( time )
+			aWorld = a.readTransformAsMatrix( time ) * scene.readTransformAsMatrix( time )
+			bWorld = b.readTransformAsMatrix( time ) * aWorld
+			cWorld = c.readTransformAsMatrix( time ) * bWorld
 
 			self.assertTrue( imath.V3d( list(aPoint.position()) ).equalWithAbsError( aWorld.multVecMatrix( a.readBound( time ).center() ), 1e-6 ) )
 			self.assertTrue( imath.V3d( list(bPoint.position()) ).equalWithAbsError( bWorld.multVecMatrix( b.readBound( time ).center() ), 1e-6 ) )

--- a/test/IECoreHoudini/SceneCacheTest.py
+++ b/test/IECoreHoudini/SceneCacheTest.py
@@ -126,30 +126,33 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		rop.parmTuple( "f" ).deleteAllKeyframes()
 		return rop
 
-	def writeSCC( self, rotation=imath.V3d( 0, 0, 0 ), time=0 ) :
+	def writeSCC( self, rotation=imath.V3d( 0, 0, 0 ), time=0, includeMesh=True ) :
 
 		scene = IECoreScene.SceneCache( self._testFile, IECore.IndexedIO.OpenMode.Write )
 
 		sc = scene.createChild( str( 1 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
-		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6 ) )
-		sc.writeObject( mesh, time )
+		if includeMesh:
+			mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+			mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ) ] * 6 ) )
+			sc.writeObject( mesh, time )
 		matrix = imath.M44d().translate( imath.V3d( 1, 0, 0 ) )
 		matrix = matrix.rotate( rotation )
 		sc.writeTransform( IECore.M44dData( matrix ), time )
 
 		sc = sc.createChild( str( 2 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
-		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 1, 0 ) ] * 6 ) )
-		sc.writeObject( mesh, time )
+		if includeMesh:
+			mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+			mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 1, 0 ) ] * 6 ) )
+			sc.writeObject( mesh, time )
 		matrix = imath.M44d().translate( imath.V3d( 2, 0, 0 ) )
 		matrix = matrix.rotate( rotation )
 		sc.writeTransform( IECore.M44dData( matrix ), time )
 
 		sc = sc.createChild( str( 3 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
-		mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 0, 1 ) ] * 6 ) )
-		sc.writeObject( mesh, time )
+		if includeMesh:
+			mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+			mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( 0, 0, 1 ) ] * 6 ) )
+			sc.writeObject( mesh, time )
 		matrix = imath.M44d().translate( imath.V3d( 3, 0, 0 ) )
 		matrix = matrix.rotate( rotation )
 		sc.writeTransform( IECore.M44dData( matrix ), time )
@@ -1717,32 +1720,48 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		testNode( self.geometry() )
 		testNode( self.sopXform() )
 
-	def writeAnimSCC( self, rotate = False ) :
+	def writeAnimSCC( self, rotate = False, scale=False, includeMesh=True, writeMRef=False ) :
 
-		scene = self.writeSCC()
+		scene = self.writeSCC( includeMesh=includeMesh )
 		sc1 = scene.child( str( 1 ) )
 		sc2 = sc1.child( str( 2 ) )
 		sc3 = sc2.child( str( 3 ) )
-		mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
+		if includeMesh:
+			mesh = IECoreScene.MeshPrimitive.createBox(imath.Box3f(imath.V3f(0),imath.V3f(1)))
 
 		for time in [ 0.5, 1, 1.5, 2, 5, 10 ] :
 
 			matrix = imath.M44d().translate( imath.V3d( 1, time, 0 ) )
 			if rotate :
 				matrix.rotate( imath.V3d( time, 0, 0 ) )
+			if scale :
+				matrix.scale( imath.V3d( time, 1, 1 ) )
 			sc1.writeTransform( IECore.M44dData( matrix ), time )
+			if writeMRef:
+				sc1.writeAttribute( "user:Mref", IECore.M44dData( matrix ), time )
+			if not includeMesh:
+				sc1.writeBound( imath.Box3d( imath.V3d(0), imath.V3d(0) ), time )
 
-			mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( time, 1, 0 ) ] * 6 ) )
-			sc2.writeObject( mesh, time )
+			if includeMesh:
+				mesh["Cs"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.V3fVectorData( [ imath.V3f( time, 1, 0 ) ] * 6 ) )
+				sc2.writeObject( mesh, time )
 			matrix = imath.M44d().translate( imath.V3d( 2, time, 0 ) )
 			if rotate :
 				matrix.rotate( imath.V3d( time, 0, 0 ) )
+			if not includeMesh:
+				sc2.writeBound( imath.Box3d( imath.V3d(0), imath.V3d(0) ), time )
 			sc2.writeTransform( IECore.M44dData( matrix ), time )
+			if writeMRef:
+				sc2.writeAttribute( "user:Mref", IECore.M44dData( matrix ), time )
 
 			matrix = imath.M44d().translate( imath.V3d( 3, time, 0 ) )
 			if rotate :
 				matrix.rotate( imath.V3d( time, 0, 0 ) )
+			if not includeMesh:
+				sc3.writeBound( imath.Box3d( imath.V3d(0), imath.V3d(0) ), time )
 			sc3.writeTransform( IECore.M44dData( matrix ), time )
+			if writeMRef:
+				sc3.writeAttribute( "user:Mref", IECore.M44dData( matrix ), time )
 
 		return scene
 
@@ -3305,6 +3324,7 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		self.writeAnimSCC( rotate = True )
 
 		scene = IECoreScene.SharedSceneInterfaces.get( self._testFile )
+
 		a = scene.child( "1" )
 		b = a.child( "2" )
 		c = b.child( "3" )
@@ -3343,6 +3363,91 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 			self.assertTrue( imath.V3d( list(cPoint.attribValue( "basis1" )) ).equalWithAbsError( imath.V3d( cWorld[0][0], cWorld[0][1], cWorld[0][2] ), 1e-6 ) )
 			self.assertTrue( imath.V3d( list(cPoint.attribValue( "basis2" )) ).equalWithAbsError( imath.V3d( cWorld[1][0], cWorld[1][1], cWorld[1][2] ), 1e-6 ) )
 			self.assertTrue( imath.V3d( list(cPoint.attribValue( "basis3" )) ).equalWithAbsError( imath.V3d( cWorld[2][0], cWorld[2][1], cWorld[2][2] ), 1e-6 ) )
+
+		# re-write with rotation and no geo to prove transform point cloud basis vectors and transforms are accurate
+		self.writeAnimSCC( rotate=True, scale=True, includeMesh=False, writeMRef=True )
+		scene = IECoreScene.SharedSceneInterfaces.get( self._testFile )
+		a = scene.child( "1" )
+		b = a.child( "2" )
+		c = b.child( "3" )
+
+		node.parm( "reload" ).pressButton()
+		node.parm( "geometryType" ).set( IECoreHoudini.SceneCacheNode.GeometryType.TransformPointCloud )
+		for time in times :
+			hou.setTime( time - spf )
+			prims = node.geometry().prims()
+			self.assertEqual( len(prims), 4 )
+			nameAttr = node.geometry().findPrimAttrib( "name" )
+			self.assertEqual( nameAttr.strings(), tuple( [ '/', '/1', '/1/2', '/1/2/3' ] ) )
+			for name in nameAttr.strings() :
+				self.assertEqual( len([ x for x in prims if x.attribValue( "name" ) == name ]), 1 )
+
+			aPoint = prims[1].vertices()[0].point()
+			bPoint = prims[2].vertices()[0].point()
+			cPoint = prims[3].vertices()[0].point()
+
+			aWorld = a.readTransformAsMatrix( time ) * scene.readTransformAsMatrix( time )
+			bWorld = b.readTransformAsMatrix( time ) * aWorld
+			cWorld = c.readTransformAsMatrix( time ) * bWorld
+
+			data = {
+				aPoint : ( aWorld, prims[1], a ),
+				bPoint : ( bWorld, prims[2], b ),
+				cPoint : ( cWorld, prims[3], c ),
+			}
+
+			for point, ( transform, prim, location ) in data.items():
+				self.assertTrue( imath.V3d( list(point.position() ) ).equalWithAbsError( transform.multVecMatrix( imath.V3f(0) ), 1e-6 ) )
+
+				self.assertTrue( imath.M44d( *list(point.attribValue( "transform" )) ).equalWithAbsError( transform, 1e-6 ) )
+
+				s = imath.V3d()
+				transform.extractScaling( s )
+				pscale = ( abs( s.x ) + abs( s.y ) + abs( s.z ) ) / 3.0
+				self.assertTrue( abs( pscale - point.attribValue( "pscale" ) ) < 1e-6 )
+				self.assertTrue(
+					imath.V3d( list(point.attribValue( "scale" ) ) ).equalWithAbsError(
+						s / pscale,
+						1e-6
+					)
+				)
+
+				rotationMatrix = imath.M44d( transform )
+				rotationMatrix.removeScalingAndShear()
+				q = imath.Quatf( imath.M44f( rotationMatrix ) )
+				sceneOrientation = imath.V4f( q.v().x, q.v().y, q.v().z, q.r() )
+				houdiniOrientation = imath.V4f( *list(point.attribValue( "orient" )) )
+				for i in range( 4 ):
+					# sign may flip so we use abs for both
+					self.assertTrue( abs( sceneOrientation[i] ) - abs( houdiniOrientation[i] ) < 1e-6 )
+
+				# check rest transform and rest position
+				restTransform = location.readAttribute( "user:Mref", time ).value
+				self.assertTrue( imath.M44d( *list(point.attribValue( "resttransform" )) ).equalWithAbsError( restTransform, 1e-6 ) )
+				self.assertTrue( imath.V3d( list(point.attribValue( "restposition" ) ) ).equalWithAbsError( restTransform.multVecMatrix( imath.V3f(0) ), 1e-6 ) )
+
+				# no transform
+				self.assertTrue( point.attribValue( "hasobject" ) == 0 )
+
+		# write with shape
+		self.writeAnimSCC( rotate=True, scale=True, writeMRef=True )
+		scene = IECoreScene.SharedSceneInterfaces.get( self._testFile )
+		a = scene.child( "1" )
+		b = a.child( "2" )
+		c = b.child( "3" )
+
+		node.parm( "reload" ).pressButton()
+		node.parm( "geometryType" ).set( IECoreHoudini.SceneCacheNode.GeometryType.TransformPointCloud )
+		for time in times :
+			hou.setTime( time - spf )
+			prims = node.geometry().prims()
+
+			aPoint = prims[1].vertices()[0].point()
+			bPoint = prims[2].vertices()[0].point()
+			cPoint = prims[3].vertices()[0].point()
+
+			for point in ( aPoint, bPoint, cPoint ):
+				self.assertTrue( point.attribValue( "hasobject" ) == 1 )
 
 	def testNonExistantAttributes( self ) :
 
@@ -3556,6 +3661,6 @@ class TestSceneCache( IECoreHoudini.TestCase ) :
 		writer.parm( "rootObject" ).set( geo.path() )
 
 		self.assertRaises( hou.OperationFailed , functools.partial( writer.render, [1,1] ) )
-
+		
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add support for loading transform only scene cache in Houdini

IECoreHoudini::SOP_SceneCacheSource : Add support for transform only scene cache (#1053):
  - `P`: transform matrix translation
  - `transform`: transform matrix
  -  `orient`: orientation quaternion of the transform matrix
  - `pscale`: uniform scale of the transform matrix
  - `scale`: scaling of the transform matrix
  - `resttransform`: `Mref` matrix
  - `restposition`: `Mref` matrix's translation
  - `hasshape`: flag if the location has a shape or if it's transform only.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
