### PR TITLE
testCore: boost unique names for unit tests

### DIFF
--- a/test/IECore/DataConversionTest.h
+++ b/test/IECore/DataConversionTest.h
@@ -47,6 +47,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/random.hpp"
 #include "boost/test/floating_point_comparison.hpp"
+#include <boost/bind.hpp>
 
 #include <cassert>
 
@@ -92,50 +93,25 @@ struct DataConversionTestSuite : public boost::unit_test::test_suite
 	{
 		static boost::shared_ptr<DataConversionTest> instance( new DataConversionTest() );
 
-		testSignedScaled( instance );
-	}
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<char, short>, instance) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<char, int>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<char, long>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<char, float>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<char, double>, instance ) ) );
 
-	void testSignedScaled( boost::shared_ptr<DataConversionTest> instance )
-	{
-		void (DataConversionTest::*fn)() = 0;
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<short, int>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<short, long>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<short, float>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<short, double>, instance ) ) );
 
-		// "To" types have greater range/precision, so that we can accurately verify roundtrip. If we didn't do this
-		/// we'd lose information on the way through.
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<int, long>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<int, float>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<int, double>, instance ) ) );
 
-		fn = &DataConversionTest::testSignedScaled<char, short>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<char, int>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<char, long>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<char, float>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<char, double>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<long, float>, instance ) ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<long, double>, instance ) ) );
 
-		fn = &DataConversionTest::testSignedScaled<short, int>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<short, long>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<short, float>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<short, double>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-
-		fn = &DataConversionTest::testSignedScaled<int, long>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<int, float>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<int, double>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-
-		fn = &DataConversionTest::testSignedScaled<long, float>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-		fn = &DataConversionTest::testSignedScaled<long, double>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-
-		fn = &DataConversionTest::testSignedScaled<float, double>;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
+		add( BOOST_TEST_CASE( boost::bind( &DataConversionTest::testSignedScaled<float, double>, instance ) ) );
 	}
 
 };

--- a/test/IECore/DataConvertTest.h
+++ b/test/IECore/DataConvertTest.h
@@ -45,6 +45,7 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/test/floating_point_comparison.hpp"
+#include <boost/bind.hpp>
 
 #include <cassert>
 
@@ -106,32 +107,13 @@ struct DataConvertTestSuite : public boost::unit_test::test_suite
 
 	DataConvertTestSuite() : boost::unit_test::test_suite( "DataConvertTestSuite" )
 	{
-		static boost::shared_ptr<DataConvertTest> instance( new DataConvertTest() );
+		boost::shared_ptr<DataConvertTest> instance( new DataConvertTest() );
 
-		testVectorData( instance );
-		testSimpleData( instance );
-	}
+		add(BOOST_TEST_CASE(boost::bind(&DataConvertTest::testVectorData<UIntVectorData, FloatVectorData>, instance)));
+		add(BOOST_TEST_CASE(boost::bind(&DataConvertTest::testVectorData<ShortVectorData, DoubleVectorData>, instance)));
 
-	void testVectorData( boost::shared_ptr<DataConvertTest> instance )
-	{
-		void (DataConvertTest::*fn)() = 0;
-
-		fn = &DataConvertTest::testVectorData< UIntVectorData, FloatVectorData >;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-
-		fn = &DataConvertTest::testVectorData< ShortVectorData, DoubleVectorData >;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-	}
-
-	void testSimpleData( boost::shared_ptr<DataConvertTest> instance )
-	{
-		void (DataConvertTest::*fn)() = 0;
-
-		fn = &DataConvertTest::testSimpleData< UIntData, FloatData >;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
-
-		fn = &DataConvertTest::testSimpleData< ShortData, DoubleData >;
-		add( BOOST_CLASS_TEST_CASE( fn, instance ) );
+		add(BOOST_TEST_CASE(boost::bind(&DataConvertTest::testSimpleData<UIntData, FloatData>, instance)));
+		add(BOOST_TEST_CASE(boost::bind(&DataConvertTest::testSimpleData<ShortData, DoubleData>, instance)));
 	}
 
 };

--- a/test/IECore/InterpolatorTest.h
+++ b/test/IECore/InterpolatorTest.h
@@ -50,6 +50,7 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/test/floating_point_comparison.hpp"
+#include <boost/mpl/list.hpp>
 
 namespace IECore
 {
@@ -96,68 +97,55 @@ class MatrixCubicInterpolatorTest
 };
 
 
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_LinearInterpolator, T)
+{
+	static boost::shared_ptr<LinearInterpolatorTest<T> > instance(new LinearInterpolatorTest<T>());
+	instance->testSimple();
+	instance->testTyped();
+	instance->testVector();
+}
 
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_CubicInterpolator, T)
+{
+	static boost::shared_ptr<CubicInterpolatorTest<T> > instance(new CubicInterpolatorTest<T>());
+	instance->testSimple();
+	instance->testTyped();
+	instance->testVector();
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_MatrixLinearInterpolator, T)
+{
+	static boost::shared_ptr<MatrixLinearInterpolatorTest<T> > instance(new MatrixLinearInterpolatorTest<T>());
+	instance->testSimple();
+	instance->testTyped();
+	instance->testVector();
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_MatrixCubicInterpolator, T)
+{
+	static boost::shared_ptr<MatrixCubicInterpolatorTest<T> > instance(new MatrixCubicInterpolatorTest<T>());
+	instance->testSimple();
+	instance->testTyped();
+	instance->testVector();
+}
 
 struct InterpolatorTestSuite : public boost::unit_test::test_suite
 {
 
 	InterpolatorTestSuite() : boost::unit_test::test_suite("InterpolatorTestSuite")
 	{
-		addLinearTest<float>();
-		addLinearTest<double>();
-		addLinearTest<Imath::V3f>();
-		addLinearTest<Imath::V3d>();
+		typedef boost::mpl::list<float,double> test_types_simple;
+		typedef boost::mpl::list<Imath::V3f,Imath::V3d> test_types_imath;
 
-		addLinearMatrixTest<float>();
-		addLinearMatrixTest<double>();
+		add( BOOST_TEST_CASE_TEMPLATE( test_LinearInterpolator, test_types_simple ) );
+		add( BOOST_TEST_CASE_TEMPLATE( test_LinearInterpolator, test_types_imath ) );
 
-		addCubicTest<float>();
-		addCubicTest<double>();
-		addCubicTest<Imath::V3f>();
-		addCubicTest<Imath::V3d>();
+		add( BOOST_TEST_CASE_TEMPLATE( test_MatrixLinearInterpolator, test_types_simple ) );
 
-		addCubicMatrixTest<float>();
-		addCubicMatrixTest<double>();
-	}
+		add( BOOST_TEST_CASE_TEMPLATE( test_CubicInterpolator, test_types_simple ) );
+		add( BOOST_TEST_CASE_TEMPLATE( test_CubicInterpolator, test_types_imath ) );
 
-	template<typename T>
-	void addLinearTest()
-	{
-		static boost::shared_ptr<LinearInterpolatorTest<T> > instance(new LinearInterpolatorTest<T>());
-
-		add( BOOST_CLASS_TEST_CASE( &LinearInterpolatorTest<T>::testSimple, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &LinearInterpolatorTest<T>::testTyped, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &LinearInterpolatorTest<T>::testVector, instance ) );
-	}
-
-	template<typename T>
-	void addCubicTest()
-	{
-		static boost::shared_ptr<CubicInterpolatorTest<T> > instance(new CubicInterpolatorTest<T>());
-
-		add( BOOST_CLASS_TEST_CASE( &CubicInterpolatorTest<T>::testSimple, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &CubicInterpolatorTest<T>::testTyped, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &CubicInterpolatorTest<T>::testVector, instance ) );
-	}
-
-	template<typename T>
-	void addLinearMatrixTest()
-	{
-		static boost::shared_ptr<MatrixLinearInterpolatorTest<T> > instance(new MatrixLinearInterpolatorTest<T>());
-
-		add( BOOST_CLASS_TEST_CASE( &MatrixLinearInterpolatorTest<T>::testSimple, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &MatrixLinearInterpolatorTest<T>::testTyped, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &MatrixLinearInterpolatorTest<T>::testVector, instance ) );
-	}
-
-	template<typename T>
-	void addCubicMatrixTest()
-	{
-		static boost::shared_ptr<MatrixCubicInterpolatorTest<T> > instance(new MatrixCubicInterpolatorTest<T>());
-
-		add( BOOST_CLASS_TEST_CASE( &MatrixCubicInterpolatorTest<T>::testSimple, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &MatrixCubicInterpolatorTest<T>::testTyped, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &MatrixCubicInterpolatorTest<T>::testVector, instance ) );
+		add( BOOST_TEST_CASE_TEMPLATE( test_MatrixCubicInterpolator, test_types_simple ) );
 	}
 };
 }

--- a/test/IECore/KDTreeTest.cpp
+++ b/test/IECore/KDTreeTest.cpp
@@ -39,8 +39,7 @@ namespace IECore
 
 void addKDTreeTest(boost::unit_test::test_suite* test)
 {
-	test->add( new KDTreeTestSuite<10>() );
-	test->add( new KDTreeTestSuite<1500>() );
+	test->add( new KDTreeTestSuite() );
 }
 
 }

--- a/test/IECore/KDTreeTest.h
+++ b/test/IECore/KDTreeTest.h
@@ -50,6 +50,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include <algorithm>
 #include <iostream>
+#include <boost/mpl/list.hpp>
 
 namespace IECore
 {
@@ -85,26 +86,31 @@ class KDTreeTest
 
 };
 
-template<unsigned int N>
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_10, T)
+{
+	static boost::shared_ptr<KDTreeTest<T> > instance(new KDTreeTest<T>(10));
+	instance->testNearestNeighour();
+	instance->testNearestNeighours();
+	instance->testNearestNNeighours();
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_150, T)
+{
+	static boost::shared_ptr<KDTreeTest<T> > instance(new KDTreeTest<T>(150));
+	instance->testNearestNeighour();
+	instance->testNearestNeighours();
+	instance->testNearestNNeighours();
+}
+
 struct KDTreeTestSuite : public boost::unit_test::test_suite
 {
 
 	KDTreeTestSuite() : boost::unit_test::test_suite("KDTreeTestSuite")
 	{
-		addTest<Imath::V3f>();
-		addTest<Imath::V3d>();
-		addTest<Imath::V2f>();
-		addTest<Imath::V2d>();
-	}
+		typedef boost::mpl::list<Imath::V3f,Imath::V3d,Imath::V2f,Imath::V2d> test_types;
+		add( BOOST_TEST_CASE_TEMPLATE( test_10, test_types ) );
+		add( BOOST_TEST_CASE_TEMPLATE( test_150, test_types ) );
 
-	template<typename T>
-	void addTest()
-	{
-		static boost::shared_ptr<KDTreeTest<T> > instance(new KDTreeTest<T>(N));
-
-		add( BOOST_CLASS_TEST_CASE( &KDTreeTest<T>::testNearestNeighour, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &KDTreeTest<T>::testNearestNeighours, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &KDTreeTest<T>::testNearestNNeighours, instance ) );
 	}
 };
 

--- a/test/IECore/LevenbergMarquardtTest.cpp
+++ b/test/IECore/LevenbergMarquardtTest.cpp
@@ -41,8 +41,7 @@ namespace IECore
 
 void addLevenbergMarquardtTest( boost::unit_test::test_suite* test )
 {
-	test->add( new LevenbergMarquardtTestSuite<float>() );
-	test->add( new LevenbergMarquardtTestSuite<double>() );
+	test->add( new LevenbergMarquardtTestSuite() );
 }
 
 }

--- a/test/IECore/LevenbergMarquardtTest.h
+++ b/test/IECore/LevenbergMarquardtTest.h
@@ -50,6 +50,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include <algorithm>
 #include <iostream>
+#include <boost/mpl/list.hpp>
 
 namespace IECore
 {
@@ -83,30 +84,31 @@ class LevenbergMarquardtTestPolynomialFit
 		void test();
 };
 
-template<typename T>
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_Simple, T)
+{
+	static boost::shared_ptr< LevenbergMarquardtTestSimple<T> > instance( new LevenbergMarquardtTestSimple<T>() );
+	instance->test();
+}
+
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_CurveFit, T)
+{
+	static boost::shared_ptr< LevenbergMarquardtTestPolynomialFit<T> > instance( new LevenbergMarquardtTestPolynomialFit<T>() );
+	instance->template test<1>();
+	instance->template test<2>();
+	instance->template test<3>();
+	instance->template test<4>();
+}
+
 struct LevenbergMarquardtTestSuite : public boost::unit_test::test_suite
 {
 
 	LevenbergMarquardtTestSuite() : boost::unit_test::test_suite( "LevenbergMarquardtTestSuite" )
 	{
-		addSimple();
-		addCurveFit();
+		typedef boost::mpl::list<float,double> type_list;
+		add( BOOST_TEST_CASE_TEMPLATE(test_Simple, type_list) );
+		add( BOOST_TEST_CASE_TEMPLATE(test_CurveFit, type_list) );
 	}
 
-	void addSimple()
-	{
-		static boost::shared_ptr< LevenbergMarquardtTestSimple<T> > instance( new LevenbergMarquardtTestSimple<T>() );
-		add( BOOST_CLASS_TEST_CASE( &LevenbergMarquardtTestSimple<T>::test, instance ) );
-	}
-
-	void addCurveFit()
-	{
-		static boost::shared_ptr< LevenbergMarquardtTestPolynomialFit<T> > instance( new LevenbergMarquardtTestPolynomialFit<T>() );
-		add( BOOST_CLASS_TEST_CASE( &LevenbergMarquardtTestPolynomialFit<T>::template test<1>, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &LevenbergMarquardtTestPolynomialFit<T>::template test<2>, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &LevenbergMarquardtTestPolynomialFit<T>::template test<3>, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &LevenbergMarquardtTestPolynomialFit<T>::template test<4>, instance ) );
-	}
 };
 
 }

--- a/test/IECore/TypedDataTest.cpp
+++ b/test/IECore/TypedDataTest.cpp
@@ -39,11 +39,7 @@ namespace IECore
 
 void addTypedDataTest(boost::unit_test::test_suite* test)
 {
-	test->add( new TypedDataTestSuite<0>() );
-	test->add( new TypedDataTestSuite<1>() );
-	test->add( new TypedDataTestSuite<10>() );
-	test->add( new TypedDataTestSuite<100>() );
-	test->add( new TypedDataTestSuite<1000000>() );
+	test->add( new TypedDataTestSuite() );
 }
 
 }

--- a/test/IECore/TypedDataTest.h
+++ b/test/IECore/TypedDataTest.h
@@ -47,6 +47,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include <iostream>
 #include <vector>
+#include <boost/mpl/list.hpp>
 
 namespace IECore
 {
@@ -95,45 +96,37 @@ class SimpleTypedDataTest
 
 };
 
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_VectorTypedData, T)
+{
+	auto values = std::vector<int>{0, 1, 10, 100, 1000000};
+	for (auto v : values) {
+		static boost::shared_ptr<VectorTypedDataTest<T> > instance(new VectorTypedDataTest<T>(v));
+		instance->testSize();
+		instance->testRead();
+		instance->testWrite();
+		instance->testAssign();
+	}
+}
 
-template<unsigned int N>
+BOOST_TEST_CASE_TEMPLATE_FUNCTION(test_SimpleTypedData, T)
+{
+	static boost::shared_ptr<SimpleTypedDataTest<T> > instance(new SimpleTypedDataTest<T>());
+	instance->testRead();
+	instance->testWrite();
+	instance->testAssign();
+	instance->testIsEqualTo();
+}
+
 struct TypedDataTestSuite : public boost::unit_test::test_suite
 {
 
 	TypedDataTestSuite() : boost::unit_test::test_suite("TypedDataTestSuite")
 	{
-		addVectorTypedDataTest<std::vector<float> >();
-		addVectorTypedDataTest<std::vector<int> >();
-		addVectorTypedDataTest<std::vector<double> >();
+		typedef boost::mpl::list<std::vector<float>,std::vector<int>,std::vector<double>> type_list;
+		add( BOOST_TEST_CASE_TEMPLATE(test_VectorTypedData, type_list) );
 
-		addSimpleTypedDataTest<float>();
-		addSimpleTypedDataTest<double>();
-		addSimpleTypedDataTest<int>();
-		addSimpleTypedDataTest<unsigned int>();
-		addSimpleTypedDataTest<char>();
-		addSimpleTypedDataTest<unsigned char>();
-	}
-
-	template<typename T>
-	void addVectorTypedDataTest()
-	{
-		static boost::shared_ptr<VectorTypedDataTest<T> > instance(new VectorTypedDataTest<T>(N));
-
-		add( BOOST_CLASS_TEST_CASE( &VectorTypedDataTest<T>::testSize, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &VectorTypedDataTest<T>::testRead, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &VectorTypedDataTest<T>::testWrite, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &VectorTypedDataTest<T>::testAssign, instance ) );
-	}
-
-	template<typename T>
-	void addSimpleTypedDataTest()
-	{
-		static boost::shared_ptr<SimpleTypedDataTest<T> > instance(new SimpleTypedDataTest<T>());
-
-		add( BOOST_CLASS_TEST_CASE( &SimpleTypedDataTest<T>::testRead, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &SimpleTypedDataTest<T>::testWrite, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &SimpleTypedDataTest<T>::testAssign, instance ) );
-		add( BOOST_CLASS_TEST_CASE( &SimpleTypedDataTest<T>::testIsEqualTo, instance ) );
+		typedef boost::mpl::list<float,double,int,unsigned int, char, unsigned char> type_list2;
+		add( BOOST_TEST_CASE_TEMPLATE(test_SimpleTypedData, type_list2));
 	}
 };
 


### PR DESCRIPTION
Since version 1.67 of Boost the test utit names should be unique when registered to the test suite. See [1.67 release logs](https://www.boost.org/doc/libs/1_67_0/libs/test/doc/html/boost_test/change_log.html) for more details.

- testCore: fix test unit name registered multiple times

### Related Issues ###

- shortly discussed in #1054

### Dependencies ###

- none

### Breaking Changes ###

- tested only in boost 1.72, but I expect it to work 1.67 and newer 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
