### PR TITLE
Actions : Update to checkout@v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Setup python (Windows)
       # Revert to Python 2.7 on Windows, for running


### PR DESCRIPTION
This is said to fix "reference is not a tree" errors when retrying a workflow :

https://github.com/actions/checkout/issues/23#issuecomment-572688577
