### PR TITLE
IE Build changes for newer Boost version

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -61,6 +61,7 @@ platform = IEEnv.platform()
 compiler = getOption( "COMPILER", None )
 compilerVersion = getOption( "COMPILER_VERSION", None )
 pythonVersion = getOption( "PYTHON_VERSION", None )
+sixVersion = getOption( "SIX_VERSION", "1.14.0" )
 targetApp = getOption( "APP", None )
 
 # get cortex config information from the registry. if we have setting specific to this platform then use them, otherwise
@@ -197,7 +198,8 @@ PYTHON_LINK_FLAGS = pythonReg["moduleLinkFlags"]
 if PYTHON_LINK_FLAGS=="" :
 	PYTHON_LINK_FLAGS = "-L" + pythonReg["location"] + "/" + compiler + "/" + compilerVersion + "/lib -lpython" + pythonVersion
 
-PYTHONPATH = "/software/apps/openexr/" + openEXRVersion + "/" + platform + "/" + compiler + "/" + compilerVersion + "/python/" + pythonVersion + "/boost/" + boostVersion + "/lib64/python" + pythonVersion + "/site-packages"
+PYTHONPATH  = "/software/apps/six/" + sixVersion
+PYTHONPATH += ":" + "/software/apps/openexr/" + openEXRVersion + "/" + platform + "/" + compiler + "/" + compilerVersion + "/python/" + pythonVersion + "/boost/" + boostVersion + "/lib64/python" + pythonVersion + "/site-packages"
 
 # get the installation locations right
 INSTALL_PREFIX = getOption( "INSTALL_PREFIX", os.path.expanduser( "~" ) )

--- a/config/ie/options
+++ b/config/ie/options
@@ -140,11 +140,6 @@ else :
 if not m :
 	raise RuntimeError( "Cannot determine compiler version (%s)" % compilerVersion )
 
-# figure out the suffix for boost libraries
-boostVersionSuffix = "-mt-" + boostVersion.replace( ".", "_" )
-while boostVersionSuffix.endswith( "_0" ) :
-	boostVersionSuffix = boostVersionSuffix[:-2]
-
 CXXFLAGS = [ "-pipe", "-Wall", "-pthread" ]
 
 LINKFLAGS = []
@@ -172,7 +167,26 @@ FREETYPE_INCLUDE_PATH = "/usr/include/freetype2"
 
 # figure out the boost lib suffix
 compilerVersionSplit = compilerVersion.split( "." )
-BOOST_LIB_SUFFIX = "-" + compiler + compilerVersionSplit[0] + compilerVersionSplit[1] + boostVersionSuffix
+boostCompilerSuffix = compiler + compilerVersionSplit[0]
+if distutils.version.LooseVersion( boostVersion ) < distutils.version.LooseVersion( "1.70.0" ) :
+	boostCompilerSuffix += compilerVersionSplit[1]
+
+boostArchSuffix = "x64"
+if distutils.version.LooseVersion( boostVersion ) < distutils.version.LooseVersion( "1.66.0" ) :
+	boostArchSuffix = ""
+
+boostVersionSuffix = boostVersion.replace( ".", "_" )
+while boostVersionSuffix.endswith( "_0" ) :
+	boostVersionSuffix = boostVersionSuffix[:-2]
+
+BOOST_LIB_SUFFIX = "-{compiler}-{optimization}-{arch}-{boostVersion}".format(
+	compiler = boostCompilerSuffix,
+	optimization = "mt",
+	arch = boostArchSuffix,
+	boostVersion = boostVersionSuffix,
+)
+# some parts are missing for some boost versions, so patch up the hyphens afterwards
+BOOST_LIB_SUFFIX = BOOST_LIB_SUFFIX.replace( "--", "-" )
 
 OPENEXR_LIB_SUFFIX = "-" + openEXRVersion
 


### PR DESCRIPTION
I still need to run the unittests after rebuilding the OpenEXR python bindings with newer boosts, but this does compile with the boost flavours we need in production today.

| Boost | GCC | Python | Why | Compiles | Tests pass |
| -- | --  | -- | -- | -- | -- |
| 1.58 | 4.8.3 | 2.7 | Rv 7.2 | x | x |
| 1.61 | 4.8.3 | 2.7 | VFX 2017, Nuke 11 | x | x |
| 1.61 | 6.3.1 | 2.7 | VFX 2018, Houdini 18, Maya 2019 |x | x |
| 1.66 | 6.3.1 | 2.7 | VFX 2019 | x | - |
| 1.70 | 6.3.1 | 2.7 | Transition to VFX 2020 | - | - |
| 1.70 | 6.3.1 | 3.7 | VFX 2020 | x | - |

I also included the six path fix that'd I'd previously put into #1058. I'll rebase that on top of this once merged.