### PR TITLE
IECoreGL::Shader : Support 3D samplers

### DIFF
--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -181,7 +181,7 @@ class Shader::Implementation : public IECore::RefCounted
 						}
 					}
 
-					if( p.type == GL_SAMPLER_2D )
+					if( p.type == GL_SAMPLER_2D || p.type == GL_SAMPLER_3D )
 					{
 						// we assign a specific texture unit to each individual
 						// sampler parameter - this makes it much easier to save


### PR DESCRIPTION
Simple fix allowing shaders built with IECoreGL::Shader to deal with 3D samplers the same way they deal with 2D samplers.