### PR TITLE
IECoreMaya : Updated headers to support maya 2020.

### DIFF
--- a/include/IECoreMaya/DrawableHolderUI.h
+++ b/include/IECoreMaya/DrawableHolderUI.h
@@ -35,6 +35,9 @@
 #ifndef IECOREMAYA_DRAWABLEHOLDERUI_H
 #define IECOREMAYA_DRAWABLEHOLDERUI_H
 
+#include "maya/MDrawInfo.h"
+#include "maya/MDrawRequestQueue.h"
+#include "maya/MSelectInfo.h"
 #include "maya/MPxSurfaceShapeUI.h"
 
 #include "IECoreMaya/DisplayStyle.h"

--- a/include/IECoreMaya/ParameterisedHolder.h
+++ b/include/IECoreMaya/ParameterisedHolder.h
@@ -51,6 +51,7 @@ class MPxImagePlane;
 
 #include "IECore/Parameterised.h"
 
+#include "IECoreMaya/Export.h"
 #include "IECoreMaya/ParameterisedHolderInterface.h"
 #include "IECoreMaya/MStringLess.h"
 #include "IECoreMaya/PostLoadCallback.h"
@@ -88,9 +89,9 @@ class IECOREMAYA_API ParameterisedHolder : public BaseType, public Parameterised
 		static MTypeId id;
 		static MString typeName;
 
-		virtual void postConstructor();
-		virtual MStatus setDependentsDirty( const MPlug &plug, MPlugArray &plugArray );
-		virtual MStatus shouldSave( const MPlug &plug, bool &isSaving );
+		void postConstructor() override;
+		MStatus setDependentsDirty( const MPlug &plug, MPlugArray &plugArray ) override;
+		MStatus shouldSave( const MPlug &plug, bool &isSaving ) override;
 
 		//! @name ParameterisedHolderInterface implementation
 		/////////////////////////////////////////////////////////////////////////////////////////

--- a/src/IECoreMaya/ParameterisedHolder.cpp
+++ b/src/IECoreMaya/ParameterisedHolder.cpp
@@ -36,6 +36,8 @@
 #include "boost/format.hpp"
 #include "boost/tokenizer.hpp"
 
+#include "IECoreMaya/Export.h"
+IECORE_PUSH_DEFAULT_VISIBILITY
 #include "maya/MPxNode.h"
 #include "maya/MPxLocatorNode.h"
 #include "maya/MPxDeformerNode.h"
@@ -44,6 +46,8 @@
 #include "maya/MPxSurfaceShape.h"
 #include "maya/MPxComponentShape.h"
 #include "maya/MPxImagePlane.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
 #include "maya/MFnTypedAttribute.h"
 #include "maya/MFnNumericAttribute.h"
 #include "maya/MFnDependencyNode.h"

--- a/src/IECoreMaya/SceneShapeUI.cpp
+++ b/src/IECoreMaya/SceneShapeUI.cpp
@@ -39,8 +39,11 @@
 
 #include "maya/MTypes.h"
 #include "maya/MGlobal.h"
-#include "maya/MDrawData.h"
 #include "maya/MDagPath.h"
+#include "maya/MDrawData.h"
+#include "maya/MDrawInfo.h"
+#include "maya/MDrawRequestQueue.h"
+#include "maya/MSelectInfo.h"
 #include "maya/MSelectionList.h"
 #include "maya/MSelectionMask.h"
 #include "maya/MMaterial.h"


### PR DESCRIPTION
In maya 2019, maya proxy classes were manually exporting their symbols. In maya 2020, this is no longer the case. Since we compile with -fvisibility=hidden, all maya symbols become hidden. This is problematic for template classes like `ParameterisedHolder` which inherit from a hidden proxy class. The derived class will not export its symbols on GCC
6.3.1 unless the templated base class also exports its symbols. Curiously, this does not seem to be an issue if you derived directly from a class with hidden visibility. I assume this is somehow related to possibility of template specialization.

We work around this in `ParameterisedHolder` by using the macros `IECORE_PUSH_DEFAULT_VISIBILITY` and `IECORE_POP_DEFAULT_VISIBILITY` to manually export the needed maya proxy classes.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
