### PR TITLE
FnSceneShape: maintain shader assignment during expansion / geo convert

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -444,15 +444,16 @@ if targetApp :
 	INSTALL_ARNOLDLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 	INSTALL_APPLESEEDLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 	INSTALL_ALEMBICLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_MAJOR_VERSION" )
+
 	# we don't want to build the renderman procedurals when we build apps, as otherwise they end
 	# up causing linking conflicts at rendertime. this is because the procedural would be linking to the
 	# boost version an app needs, whereas the other libraries are linking to the correct boost version for
-	# 3delight, so we just install the procedurals into /tmp where they can't do any harm.
-	INSTALL_RMANPROCEDURAL_NAME = "/tmp/unwantedRManProcedurals/$IECORE_NAME"
-	INSTALL_RMANDISPLAY_NAME = "/tmp/unwantedRManDisplays/$IECORE_NAME-$IECORE_MAJOR_VERSION"
-	INSTALL_ARNOLDPROCEDURAL_NAME = "/tmp/unwantedArnoldProcedurals/$IECORE_NAME-$IECORE_MAJOR_VERSION"
-	INSTALL_ARNOLDOUTPUTDRIVER_NAME = "/tmp/unwantedArnoldDrivers/$IECORE_NAME-$IECORE_MAJOR_VERSION"
-	INSTALL_APPLESEEDOUTPUTDRIVER_NAME = "/tmp/unwantedAppleseedDrivers/$IECORE_NAME-$IECORE_MAJOR_VERSION"
+	# 3delight, so we just install the procedurals into a temp directory where they can't do any harm.
+	INSTALL_RMANPROCEDURAL_NAME = os.path.join( "tmp", os.environ['USER'], "unwantedRManProcedurals/$IECORE_NAME" )
+	INSTALL_RMANDISPLAY_NAME = os.path.join( "tmp", os.environ['USER'], "unwantedRManDisplays/$IECORE_NAME-$IECORE_MAJOR_VERSION" )
+	INSTALL_ARNOLDPROCEDURAL_NAME = os.path.join( "tmp", os.environ['USER'], "unwantedArnoldProcedurals/$IECORE_NAME-$IECORE_MAJOR_VERSION" )
+	INSTALL_ARNOLDOUTPUTDRIVER_NAME = os.path.join( "tmp", os.environ['USER'], "unwantedArnoldDrivers/$IECORE_NAME-$IECORE_MAJOR_VERSION" )
+	INSTALL_APPLESEEDOUTPUTDRIVER_NAME = os.path.join( "tmp", os.environ['USER'], "unwantedAppleseedDrivers/$IECORE_NAME-$IECORE_MAJOR_VERSION" )
 else :
 	INSTALL_HEADER_DIR = os.path.join( basePrefix, "include" )
 	INSTALL_LIB_NAME = os.path.join( basePrefix, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_MAJOR_VERSION" )

--- a/python/IECoreMaya/FnSceneShape.py
+++ b/python/IECoreMaya/FnSceneShape.py
@@ -78,19 +78,19 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 	## Creates a new node under a transform of the specified name. Returns a function set instance operating on this new node.
 	@staticmethod
 	@IECoreMaya.UndoFlush()
-	def create( parentName, transformParent = None ) :
+	def create( parentName, transformParent = None, shadingEngine = None ) :
 		try:
 			parentNode = maya.cmds.createNode( "transform", name=parentName, skipSelect=True, parent = transformParent )
 		except:
 			# The parent name is supposed to be the children names in a sceneInterface, they could be numbers, maya doesn't like that. Use a prefix.
 			parentNode = maya.cmds.createNode( "transform", name="sceneShape_"+parentName, skipSelect=True, parent = transformParent )
 
-		return FnSceneShape.createShape( parentNode )
+		return FnSceneShape.createShape( parentNode, shadingEngine=shadingEngine )
 
 	## Create a scene shape under the given node. Returns a function set instance operating on this shape.
 	@staticmethod
 	@IECoreMaya.UndoFlush()
-	def createShape( parentNode ) :
+	def createShape( parentNode, shadingEngine = None ) :
 		parentShort = parentNode.rpartition( "|" )[-1]
 		numbersMatch = re.search( "[0-9]+$", parentShort )
 		if numbersMatch is not None :
@@ -100,12 +100,12 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 			shapeName = parentShort + "SceneShape"
 
 		dagMod = maya.OpenMaya.MDagModifier()
-		shapeNode = dagMod.createNode( "ieSceneShape", IECoreMaya.StringUtil.dependencyNodeFromString( parentNode ) )
+		shapeNode = dagMod.createNode( FnSceneShape._mayaNodeType(), IECoreMaya.StringUtil.dependencyNodeFromString( parentNode ) )
 		dagMod.renameNode( shapeNode, shapeName )
 		dagMod.doIt()
 
 		fnScS = FnSceneShape( shapeNode )
-		maya.cmds.sets( fnScS.fullPathName(), add="initialShadingGroup" )
+		maya.cmds.sets( fnScS.fullPathName(), edit=True, forceElement=shadingEngine or "initialShadingGroup" )
 
 		fnScS.findPlug( "objectOnly" ).setLocked( True )
 
@@ -239,15 +239,19 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		parentPath = dag.fullPathName()
 		childPath = parentPath + "|" + namespace + childName
 
+		# get parent shadingGroup
+		shadingGroups = maya.cmds.listConnections( self.fullPathName(), type='shadingEngine' ) or []
+		shadingGroup = shadingGroups[0] if shadingGroups else None
+
 		# Create (or retrieve) the child sceneShape
 		if maya.cmds.objExists(childPath):
 			shape = maya.cmds.listRelatives( childPath, fullPath=True, type="ieSceneShape" )
 			if shape:
 				fnChild = IECoreMaya.FnSceneShape( shape[0] )
 			else:
-				fnChild = IECoreMaya.FnSceneShape.createShape( childPath )
+				fnChild = IECoreMaya.FnSceneShape.createShape( childPath, shadingEngine=shadingGroup )
 		else:
-			fnChild = IECoreMaya.FnSceneShape.create( childName, transformParent = parentPath )
+			fnChild = IECoreMaya.FnSceneShape.create( childName, transformParent=parentPath, shadingEngine=shadingGroup )
 
 		fnChildTransform = maya.OpenMaya.MFnDagNode( fnChild.parent( 0 ) )
 
@@ -468,7 +472,7 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 			fnShape = maya.OpenMaya.MFnDagNode( shapeNode )
 
-			if shapeType == "mesh":
+			if shapeType != "locator":
 				maya.cmds.sets( pathToShape, add="initialShadingGroup" )
 
 		if shapeType == "mesh":
@@ -489,14 +493,17 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 
 		shapeName = IECoreMaya.FnDagNode.defaultShapeName( transformNode )
 
+		shapes = []
+
 		if shapeType == "nurbsCurve":
 			curvesPrimitive = self.sceneInterface().readObject( 0.0 )
 			numShapes = curvesPrimitive.numCurves()
 			for shapeId in range( numShapes ):
 				nameId = '' if numShapes == 1 else str( shapeId ) # Do not add number to the name if there's only one curve, for backward compatibility.
-				self.__findOrCreateShape( transformNode, shapeName + nameId, shapeType )
-		else:
-			self.__findOrCreateShape( transformNode, shapeName, shapeType )
+				shapes.append( self.__findOrCreateShape( transformNode, shapeName + nameId, shapeType ) )
+
+		shapes.append( self.__findOrCreateShape( transformNode, shapeName, shapeType ) )
+		return shapes
 
 	def __connectShape( self, pathToShape, plugStr, arrayIndex ):
 		fnShape = maya.OpenMaya.MFnDagNode( IECoreMaya.StringUtil.dagPathFromString( pathToShape ) )
@@ -590,6 +597,8 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 		if not scene or  not scene.hasObject():
 			return
 
+		shapeType, plugStr = self.__mayaCompatibleShapeAndPlug()
+
 		if not transformNode:
 			# No transform provided, use the transform of the reader
 			dag = maya.OpenMaya.MDagPath()
@@ -597,11 +606,19 @@ class FnSceneShape( maya.OpenMaya.MFnDagNode ) :
 			dag.pop()
 			transformNode = dag.fullPathName()
 
+		# get shadingGroup
+		shadingGroup = maya.cmds.listConnections( self.fullPathName(), type='shadingEngine' )[ 0 ]
+
 		# Turn myself into an intermediate object since the maya shape will take my place
 		self.findPlug( "intermediateObject" ).setBool( True )
 
-		self.__findOrCreateShapes( transformNode )
+		fnShapes = self.__findOrCreateShapes( transformNode )
 		self.__connectShapes( transformNode )
+
+		# apply parent shader
+		if shapeType != 'locator':
+			for shape in fnShapes:
+				maya.cmds.sets( shape.fullPathName(), edit=True, forceElement=shadingGroup )
 
 	## Creates a maya locator in the position and orientation of the scene path's transform.
 	# \param path Path to scene where the locator should be created

--- a/python/IECoreMaya/SceneShapeUI.py
+++ b/python/IECoreMaya/SceneShapeUI.py
@@ -51,7 +51,7 @@ def addDagMenuCallback( callback ) :
 
 ## Removes a callback previously added with addDagMenuCallback.
 def removeDagMenuCallback( callback ) :
-
+	IECore.warning("'SceneShapeUI.removeDagMenuCallback' has been deprecated. Menu callbacks cannot be removed anymore in the future.")
 	__dagMenuCallbacks.remove( callback )
 
 def _menuDefinition( callbackShape ) :


### PR DESCRIPTION
Features
---
- FnSceneShape: maintain shader assignment during expansion / geo convert
- FnSceneShape: added "child shape created" callback

Fixes
---
- IE Config: Fix tmp directory path not being writable

API - Deprecation Notice
---
- `SceneShapeUI.removeDagMenuCallback` deprecated. Menu callbacks cannot be removed anymore in the future.