### PR TITLE
USD Primitive conversion improvements

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.cpp
@@ -189,6 +189,8 @@ static const std::map<pxr::TfType, IECore::DataPtr (*)( const pxr::VtValue &, Ge
 
 	// Quaternions
 
+	{ TfType::Find<GfQuath>(), &dataFromValue<GfQuath> },
+	{ TfType::Find<VtArray<GfQuath>>(), &dataFromArray<GfQuath> },
 	{ TfType::Find<GfQuatf>(), &dataFromValue<GfQuatf> },
 	{ TfType::Find<VtArray<GfQuatf>>(), &dataFromArray<GfQuatf> },
 	{ TfType::Find<GfQuatd>(), &dataFromValue<GfQuatd> },

--- a/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.inl
+++ b/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.inl
@@ -80,6 +80,12 @@ typename USDTypeTraits<T>::CortexType fromUSDInternal( const T &value, typename 
 	return reinterpret_cast<const CortexType &>( value );
 }
 
+inline Imath::Quatf fromUSDInternal( const pxr::GfQuath &src )
+{
+	const auto &v = src.GetImaginary();
+	return Imath::Quatf( src.GetReal(), Imath::V3f( v[0], v[1], v[2] ) );
+}
+
 inline Imath::Quatf fromUSDInternal( const pxr::GfQuatf &src )
 {
 	const auto &v = src.GetImaginary();

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -217,6 +217,31 @@ void IECoreUSD::PrimitiveAlgo::readPrimitiveVariables( const pxr::UsdGeomPointBa
 #endif
 }
 
+bool IECoreUSD::PrimitiveAlgo::primitiveVariablesMightBeTimeVarying( const pxr::UsdGeomPrimvarsAPI &primvarsAPI )
+{
+	for( const auto &primVar : primvarsAPI.GetPrimvars() )
+	{
+		if( primVar.ValueMightBeTimeVarying() )
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool IECoreUSD::PrimitiveAlgo::primitiveVariablesMightBeTimeVarying( const pxr::UsdGeomPointBased &pointBased )
+{
+	return
+		pointBased.GetPointsAttr().ValueMightBeTimeVarying() ||
+		pointBased.GetNormalsAttr().ValueMightBeTimeVarying() ||
+		pointBased.GetVelocitiesAttr().ValueMightBeTimeVarying() ||
+#if USD_VERSION >= 1911
+		pointBased.GetAccelerationsAttr().ValueMightBeTimeVarying() ||
+#endif
+		primitiveVariablesMightBeTimeVarying( pxr::UsdGeomPrimvarsAPI( pointBased.GetPrim() ) );
+	;
+}
+
 IECoreScene::PrimitiveVariable::Interpolation IECoreUSD::PrimitiveAlgo::fromUSD( pxr::TfToken interpolationToken )
 {
 	if( interpolationToken == pxr::UsdGeomTokens->varying )

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -38,6 +38,11 @@
 
 #include "IECore/MessageHandler.h"
 
+/// \todo Use the standard PXR_VERSION instead. We can't do that until
+/// everyone is using USD 19.11 though, because prior to that PXR_VERSION
+/// was malformed (octal, and not comparable in any way).
+#define USD_VERSION ( PXR_MAJOR_VERSION * 10000 + PXR_MINOR_VERSION * 100 + PXR_PATCH_VERSION )
+
 using namespace IECore;
 using namespace IECoreUSD;
 
@@ -86,10 +91,12 @@ void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, 
 	{
 		pointBased.CreateVelocitiesAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
 	}
+#if USD_VERSION >= 1911
 	else if( name == "acceleration" )
 	{
 		pointBased.CreateAccelerationsAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
 	}
+#endif
 	else
 	{
 		writePrimitiveVariable( name, value, pxr::UsdGeomPrimvarsAPI( pointBased.GetPrim() ), time );
@@ -202,10 +209,12 @@ void IECoreUSD::PrimitiveAlgo::readPrimitiveVariables( const pxr::UsdGeomPointBa
 		primitive->variables["velocity"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, v );
 	}
 
+#if USD_VERSION >= 1911
 	if( auto a = boost::static_pointer_cast<V3fVectorData>( DataAlgo::fromUSD( pointBased.GetAccelerationsAttr(), time ) ) )
 	{
 		primitive->variables["acceleration"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, a );
 	}
+#endif
 }
 
 IECoreScene::PrimitiveVariable::Interpolation IECoreUSD::PrimitiveAlgo::fromUSD( pxr::TfToken interpolationToken )

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -127,7 +127,7 @@ struct VtValueFromExpandedData
 		array.reserve( indices->readable().size() );
 		for( const auto &e : PrimitiveVariable::IndexedView<T>( data->readable(), &indices->readable() ) )
 		{
-			array.push_back( DataAlgo::toUSD( e ) );
+			array.push_back( DataAlgo::toUSD( static_cast<const T &>( e ) ) );
 		}
 		return VtValue( array );
 	}

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -1,0 +1,115 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "PrimitiveAlgo.h"
+
+#include "DataAlgo.h"
+
+#include "IECore/MessageHandler.h"
+
+using namespace IECore;
+
+//////////////////////////////////////////////////////////////////////////
+// Writing primitive variables
+//////////////////////////////////////////////////////////////////////////
+
+void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode time )
+{
+	if( name == "uv" && runTimeCast<const V2fVectorData>( primitiveVariable.data ) )
+	{
+		writePrimitiveVariable( "st", primitiveVariable, primvarsAPI, time );
+		return;
+	}
+
+	const pxr::TfToken usdInterpolation = toUSD( primitiveVariable.interpolation );
+	if( usdInterpolation.IsEmpty() )
+	{
+		IECore::msg( IECore::MessageHandler::Level::Warning, "IECoreUSD::PrimitiveAlgo", boost::format( "Invalid Interpolation on %1%" ) % name );
+		return;
+	}
+
+	const pxr::VtValue value = DataAlgo::toUSD( primitiveVariable.data.get() );
+	const pxr::SdfValueTypeName valueTypeName = DataAlgo::valueTypeName( primitiveVariable.data.get() );
+
+	pxr::UsdGeomPrimvar usdPrimVar = primvarsAPI.CreatePrimvar( pxr::TfToken( name ), valueTypeName, usdInterpolation );
+	usdPrimVar.Set( value, time );
+
+	if( primitiveVariable.indices )
+	{
+		usdPrimVar.SetIndices( DataAlgo::toUSD( primitiveVariable.indices.get() ).Get<pxr::VtIntArray>() );
+	}
+}
+
+void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &value, const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time )
+{
+	if( name == "P" )
+	{
+		pointBased.CreatePointsAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
+	}
+	else if( name == "N" )
+	{
+		pointBased.CreateNormalsAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
+	}
+	else if( name == "velocity" )
+	{
+		pointBased.CreateVelocitiesAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
+	}
+	else if( name == "acceleration" )
+	{
+		pointBased.CreateAccelerationsAttr().Set( DataAlgo::toUSD( value.data.get() ), time );
+	}
+	else
+	{
+		writePrimitiveVariable( name, value, pxr::UsdGeomPrimvarsAPI( pointBased.GetPrim() ), time );
+	}
+}
+
+pxr::TfToken IECoreUSD::PrimitiveAlgo::toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation )
+{
+	switch( interpolation )
+	{
+		case IECoreScene::PrimitiveVariable::Constant :
+			return pxr::UsdGeomTokens->constant;
+		case IECoreScene::PrimitiveVariable::Uniform :
+			return pxr::UsdGeomTokens->uniform;
+		case IECoreScene::PrimitiveVariable::Vertex :
+			return pxr::UsdGeomTokens->vertex;
+		case IECoreScene::PrimitiveVariable::Varying :
+			return pxr::UsdGeomTokens->varying;
+		case IECoreScene::PrimitiveVariable::FaceVarying :
+			return pxr::UsdGeomTokens->faceVarying;
+		default :
+			return pxr::TfToken();
+	}
+}

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
@@ -1,0 +1,65 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2020, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREUSD_PRIMITIVEALGO_H
+#define IECOREUSD_PRIMITIVEALGO_H
+
+#include "IECoreScene/PrimitiveVariable.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/usd/usdGeom/pointBased.h"
+#include "pxr/usd/usdGeom/primvarsAPI.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
+namespace IECoreUSD
+{
+
+namespace PrimitiveAlgo
+{
+
+/// From Cortex to USD
+/// ==================
+
+/// Writes a PrimitiveVariable to USD, creating a primvar via `primvarsAPI`.
+void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode time );
+/// As above, but redirects "P", "N" etc to the relevant attributes of `pointBased`.
+void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time );
+/// Converts interpolation to USD.
+pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation );
+
+} // namespace PrimitiveAlgo
+
+} // namespace IECoreUSD
+
+#endif // IECOREUSD_PRIMITIVEALGO_H

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
@@ -35,6 +35,7 @@
 #ifndef IECOREUSD_PRIMITIVEALGO_H
 #define IECOREUSD_PRIMITIVEALGO_H
 
+#include "IECoreScene/Primitive.h"
 #include "IECoreScene/PrimitiveVariable.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
@@ -57,6 +58,16 @@ void writePrimitiveVariable( const std::string &name, const IECoreScene::Primiti
 void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time );
 /// Converts interpolation to USD.
 pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation );
+
+/// From USD to Cortex
+/// ==================
+
+/// Reads all primvars from `primvarsAPI`, adding them to `primitive`.
+void readPrimitiveVariables( const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive );
+/// As above, but also reads "P", "N" etc from `pointBased`.
+void readPrimitiveVariables( const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive );
+/// Converts interpolation from USD.
+IECoreScene::PrimitiveVariable::Interpolation fromUSD( pxr::TfToken interpolationToken );
 
 } // namespace PrimitiveAlgo
 

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
@@ -56,6 +56,9 @@ namespace PrimitiveAlgo
 void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode time );
 /// As above, but redirects "P", "N" etc to the relevant attributes of `pointBased`.
 void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time );
+/// Equivalent to `DataAlgo::toUSD( primitiveVariable.expandedData() )`, but avoiding
+/// the creation of the temporary expanded data.
+pxr::VtValue toUSDExpanded( const IECoreScene::PrimitiveVariable &primitiveVariable );
 /// Converts interpolation to USD.
 pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation );
 

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.h
@@ -66,6 +66,11 @@ pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation 
 void readPrimitiveVariables( const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive );
 /// As above, but also reads "P", "N" etc from `pointBased`.
 void readPrimitiveVariables( const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive );
+/// Returns true if any of the primitive variables might be animated.
+bool primitiveVariablesMightBeTimeVarying( const pxr::UsdGeomPrimvarsAPI &primvarsAPI );
+/// Returns true if any of the primitive variables might be animated, including the
+/// "P", "N" etc that `readPrimitiveVariables()` creates.
+bool primitiveVariablesMightBeTimeVarying( const pxr::UsdGeomPointBased &pointBased );
 /// Converts interpolation from USD.
 IECoreScene::PrimitiveVariable::Interpolation fromUSD( pxr::TfToken interpolationToken );
 

--- a/contrib/IECoreUSD/src/IECoreUSD/TypeTraits.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/TypeTraits.h
@@ -118,6 +118,10 @@ IECOREUSD_TYPETRAITS_SPECIALISATION( IECore::InternedString, pxr::TfToken, false
 // Only specialising CortexTypeTraits, because we can't map `USDTypeTraits<GfVec3f>`
 // to both `Imath::Vec3f` and `Imath::Color3f`.
 IECOREUSD_CORTEXTYPETRAITS_SPECIALISATION( Imath::Color3f, pxr::GfVec3f, true )
+// Only specialising USDTypeTraits, because we can't map `Quatf` to both
+// `GfQuath` and `GfQuatf`.
+/// \todo Should we convert to `Imath::Quat<half>` in Cortex instead?
+IECOREUSD_USDTYPETRAITS_SPECIALISATION( Imath::Quatf, pxr::GfQuath, false, IECore::TypedData )
 
 } // namespace IECoreUSD
 

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -438,7 +438,7 @@ void convertPrimitive( pxr::UsdGeomPoints usdPoints, const IECoreScene::PointsPr
 			}
 			else
 			{
-				widthsAttr.Set( DataAlgo::toUSD( p.second.data.get() ), timeCode );
+				widthsAttr.Set( PrimitiveAlgo::toUSDExpanded( p.second ), timeCode );
 			}
 			usdPoints.SetWidthsInterpolation( PrimitiveAlgo::toUSD( p.second.interpolation ) );
 		}
@@ -503,7 +503,7 @@ void convertPrimitive( pxr::UsdGeomBasisCurves usdCurves, const IECoreScene::Cur
 			}
 			else
 			{
-				widthsAttr.Set( DataAlgo::toUSD( p.second.data.get() ), timeCode );
+				widthsAttr.Set( PrimitiveAlgo::toUSDExpanded( p.second ), timeCode );
 			}
 			usdCurves.SetWidthsInterpolation( PrimitiveAlgo::toUSD( p.second.interpolation ) );
 		}

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -79,6 +79,11 @@ using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreUSD;
 
+/// \todo Use the standard PXR_VERSION instead. We can't do that until
+/// everyone is using USD 19.11 though, because prior to that PXR_VERSION
+/// was malformed (octal, and not comparable in any way).
+#define USD_VERSION ( PXR_MAJOR_VERSION * 10000 + PXR_MINOR_VERSION * 100 + PXR_PATCH_VERSION )
+
 namespace
 {
 
@@ -162,10 +167,12 @@ IECoreScene::PointsPrimitivePtr convertPrimitive( pxr::UsdGeomPointInstancer poi
 		newPoints->variables["velocity"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, velocityData );
 	}
 
+#if USD_VERSION >= 1911
 	if( auto accelerationData = DataAlgo::fromUSD( pointInstancer.GetAccelerationsAttr(), time ) )
 	{
 		newPoints->variables["acceleration"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, accelerationData );
 	}
+#endif
 
 	if( auto angularVelocityData = DataAlgo::fromUSD( pointInstancer.GetAngularVelocitiesAttr(), time ) )
 	{
@@ -429,7 +436,7 @@ void convertPrimitive( pxr::UsdGeomPoints usdPoints, const IECoreScene::PointsPr
 			if( p.second.interpolation == PrimitiveVariable::Constant && floatData )
 			{
 				// USD requires an array even for constant data.
-				widthsAttr.Set( pxr::VtArray<float>( { floatData->readable() } ), timeCode );
+				widthsAttr.Set( pxr::VtArray<float>( 1, floatData->readable() ), timeCode );
 			}
 			else
 			{
@@ -494,7 +501,7 @@ void convertPrimitive( pxr::UsdGeomBasisCurves usdCurves, const IECoreScene::Cur
 			if( p.second.interpolation == PrimitiveVariable::Constant && floatData )
 			{
 				// USD requires an array even for constant data.
-				widthsAttr.Set( pxr::VtArray<float>( { floatData->readable() } ), timeCode );
+				widthsAttr.Set( pxr::VtArray<float>( 1, floatData->readable() ), timeCode );
 			}
 			else
 			{

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -206,6 +206,7 @@ class USDSceneTest( unittest.TestCase ) :
 		cubeMesh = cube.readObject( 0.0 )
 
 		self.assertTrue( isinstance( cubeMesh, IECoreScene.MeshPrimitive ) )
+		self.assertEqual( set( cubeMesh.keys() ), { "P", "uv", "displayColor" } )
 		self.assertIsInstance( cubeMesh["P"].data, IECore.V3fVectorData )
 		self.assertEqual( cubeMesh["P"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1379,5 +1379,41 @@ class USDSceneTest( unittest.TestCase ) :
 		curves2 = root.child( "test" ).readObject( 0.0 )
 		self.assertEqual( curves2, curves )
 
+	def testCurveBasisAndWrap( self ) :
+
+		fileName = os.path.join( self.temporaryDirectory(), "curvesBasisAndWrap.usda" )
+
+		for basis in [
+			IECore.CubicBasisf.linear(),
+			IECore.CubicBasisf.bezier(),
+			IECore.CubicBasisf.bSpline(),
+			IECore.CubicBasisf.catmullRom()
+		] :
+
+			for periodic in ( True, False ) :
+
+				curves = IECoreScene.CurvesPrimitive(
+					IECore.IntVectorData( [ 4 ] ),
+					basis,
+					periodic,
+					IECore.V3fVectorData(
+						[ imath.V3f( x, 0, 0 ) for x in range( 0, 4 ) ]
+					)
+				)
+
+				root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+				root.createChild( "test" ).writeObject( curves, 0 )
+				del root
+
+				# Read back and check we end up where we started
+
+				root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+				curves2 = root.child( "test" ).readObject( 0.0 )
+
+				self.assertEqual( curves2.basis(), curves.basis() )
+
+				self.assertEqual( curves2, curves )
+				del root
+
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -46,6 +46,9 @@ import IECoreUSD
 import pxr.Usd
 import pxr.UsdGeom
 
+if pxr.Usd.GetVersion() < ( 0, 19, 3 ) :
+	pxr.Usd.Attribute.HasAuthoredValue = pxr.Usd.Attribute.HasAuthoredValueOpinion
+
 class USDSceneTest( unittest.TestCase ) :
 
 	def setUp( self ) :
@@ -1231,13 +1234,15 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertFalse( primvarsAPI.GetPrimvar( "P" ) )
 		self.assertFalse( primvarsAPI.GetPrimvar( "N" ) )
 		self.assertFalse( primvarsAPI.GetPrimvar( "velocity" ) )
-		self.assertFalse( primvarsAPI.GetPrimvar( "acceleration" ) )
+		if pxr.Usd.GetVersion() >= ( 0, 19, 11 ) :
+			self.assertFalse( primvarsAPI.GetPrimvar( "acceleration" ) )
 
 		usdMesh = pxr.UsdGeom.Mesh( stage.GetPrimAtPath( "/test" ) )
 		self.assertTrue( usdMesh.GetPointsAttr().HasAuthoredValue() )
 		self.assertTrue( usdMesh.GetNormalsAttr().HasAuthoredValue() )
 		self.assertTrue( usdMesh.GetVelocitiesAttr().HasAuthoredValue() )
-		self.assertTrue( usdMesh.GetAccelerationsAttr().HasAuthoredValue() )
+		if pxr.Usd.GetVersion() >= ( 0, 19, 11 ) :
+			self.assertTrue( usdMesh.GetAccelerationsAttr().HasAuthoredValue() )
 
 		# And that we can load them back in successfully.
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -225,6 +225,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 		points = child.readObject( 0.0 )
 		self.assertTrue( isinstance( points, IECoreScene.PointsPrimitive ) )
+		self.assertEqual( points.numPoints, 4 )
 		self.assertIsInstance( points["P"].data, IECore.V3fVectorData )
 		self.assertEqual( points["P"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
 
@@ -1237,6 +1238,12 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertTrue( usdMesh.GetNormalsAttr().HasAuthoredValue() )
 		self.assertTrue( usdMesh.GetVelocitiesAttr().HasAuthoredValue() )
 		self.assertTrue( usdMesh.GetAccelerationsAttr().HasAuthoredValue() )
+
+		# And that we can load them back in successfully.
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		mesh2 = root.child( "test" ).readObject( 0.0 )
+		self.assertEqual( mesh2, mesh )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This builds on #1068, adding :

- A new PrimitiveAlgo namespace with utilities for reading and writing primitive variables.
- Consistent support for normal, velocity, acceleration, id, normal and width primitive variables.
- Read/write of curves basis/wrap/type.
- Support for missing USDGeomPointInstancer attributes, and loading using names that match the defaults for a GafferScene::Instancer.

Only the commits from 762661c onwards are unique to this PR - the rest are also in #1068. I just wanted to get a PR up now in the hope that #1068 is now merge-ready, and I might benefit from an overnight review from the west coast.

The eagle-eyed will notice that I haven't updated the `isTimeVarying()` functions in USDScene.cpp to match the newly supported attributes. I've just realised this myself, and also noticed that they're not even consistent with the code we had before. My next step was going to be to refactor all the object conversion code out into an ObjectAlgo namespace. Ideally from my point of view we could merge this PR anyway, and then I'll make the fixes for `isTimeVarying()` as part of that.