### PR TITLE
IECoreArnold::UniverseBlock : Set console verbosity before AiBegin

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
@@ -78,11 +78,19 @@ void loadMetadata( const std::string &pluginPaths )
 
 void begin()
 {
-	AiBegin();
 	// Default to logging errors / warnings only - we may not even be using this universe block to perform a render,
 	// we might just be loading some shader metadata or something, so we don't want to be dumping lots of
 	// unnecessary output
 	AiMsgSetConsoleFlags( AI_LOG_ERRORS | AI_LOG_WARNINGS );
+
+	AiBegin();
+
+#if ARNOLD_VERSION_NUM < 60004
+
+	// We set the console flags again, as older Arnold versions seem to update the flags during AiBegin.
+	AiMsgSetConsoleFlags( AI_LOG_ERRORS | AI_LOG_WARNINGS );
+
+#endif
 
 	const char *pluginPaths = getenv( "ARNOLD_PLUGIN_PATH" );
 	if( pluginPaths )


### PR DESCRIPTION
In Arnold 6.0.4.0 there is a good deal of INFO during AiBegin and users don't really need to see that until they start rendering.