### PR TITLE
Rv support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1285,11 +1285,11 @@ if doConfigure :
 			"boost_iostreams" + env["BOOST_LIB_SUFFIX"],
 			"boost_date_time" + env["BOOST_LIB_SUFFIX"],
 			"boost_thread" + env["BOOST_LIB_SUFFIX"],
-			"boost_wave" + env["BOOST_LIB_SUFFIX"],
 			"boost_timer" + env["BOOST_LIB_SUFFIX"],
 			"boost_chrono" + env["BOOST_LIB_SUFFIX"]
 		]
 	)
+
 	if int( env["BOOST_MINOR_VERSION"] ) >=35 :
 		env.Append( LIBS = [ "boost_system" + env["BOOST_LIB_SUFFIX"] ] )
 
@@ -2122,6 +2122,11 @@ if env["WITH_GL"] and doConfigure :
 	if not c.CheckLibWithHeader( env.subst( "GLEW$GLEW_LIB_SUFFIX" ), "GL/glew.h", "CXX" ) :
 
 		sys.stderr.write( "WARNING : GLEW library not found, not building IECoreGL - check GLEW_INCLUDE_PATH and GLEW_LIB_PATH.\n" )
+		c.Finish()
+
+	elif not c.CheckLibWithHeader( env.subst( "boost_wave" + env["BOOST_LIB_SUFFIX"] ), "boost/wave.hpp", "CXX" ) :
+
+		sys.stderr.write( "WARNING : boost_wave library not found, not building IECoreGL - check BOOST_INCLUDE_PATH and BOOST_LIB_PATH.\n" )
 		c.Finish()
 
 	else :

--- a/config/ie/options
+++ b/config/ie/options
@@ -400,6 +400,24 @@ if targetApp=="houdini" :
 	else:
 		WITH_GL = False
 
+if targetApp=="rv" :
+
+	rvVersion = targetAppVersion
+	rvReg = IEEnv.registry["apps"]["rv"][rvVersion][platform]
+	rvRoot = rvReg["location"]
+	rvIncludes = os.path.join( rvRoot, "include" )
+	rvLibs = os.path.join( rvRoot, "lib" )
+
+	if distutils.version.LooseVersion(rvVersion) >= distutils.version.LooseVersion("7.8.0"):
+		BOOST_INCLUDE_PATH = rvIncludes
+		BOOST_LIB_PATH = rvLibs
+		BOOST_LIB_SUFFIX = rvReg.get( "boostLibSuffix", BOOST_LIB_SUFFIX )
+
+		# NOTE: At the moment RV doesn't provide OIIO headers, so we rely on
+		# the default `OIIO_INCLUDE_PATH` value.
+		OIIO_LIB_PATH = rvLibs
+		OIIO_LIB_SUFFIX = rvReg.get( "OpenImageIOLibSuffix", OIIO_LIB_SUFFIX )
+
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )
 

--- a/include/IECoreImage/OpenImageIOAlgo.h
+++ b/include/IECoreImage/OpenImageIOAlgo.h
@@ -42,10 +42,11 @@
 
 #include "IECore/GeometricTypedData.h"
 
-#include "OpenImageIO/color.h"
 #include "OpenImageIO/imageio.h"
 #include "OpenImageIO/paramlist.h"
 #include "OpenImageIO/typedesc.h"
+
+#include "OpenImageIO/color.h"
 
 namespace IECoreImage
 {

--- a/src/IECoreImage/ColorAlgo.cpp
+++ b/src/IECoreImage/ColorAlgo.cpp
@@ -76,6 +76,7 @@ struct ColorTransformer
 		);
 
 		// convert in-place
+#if OIIO_VERSION > 10800
 		bool status = ImageBufAlgo::colorconvert(
 			/* dst */ buffer, /* src */ buffer,
 			/* from */ m_inputSpace, /* to */ m_outputSpace,
@@ -85,6 +86,22 @@ struct ColorTransformer
 			/* colorconfig */ OpenImageIOAlgo::colorConfig(),
 			/* roi */ roi
 		);
+#elif OIIO_VERSION > 10701 
+		bool status = ImageBufAlgo::colorconvert(
+			/* dst */ buffer, /* src */ buffer,
+			/* from */ m_inputSpace, /* to */ m_outputSpace,
+			/* unpremult */ false,
+			/* colorconfig */ OpenImageIOAlgo::colorConfig(),
+			/* roi */ roi
+		);
+#else
+		bool status = ImageBufAlgo::colorconvert(
+			/* dst */ buffer, /* src */ buffer,
+			/* from */ m_inputSpace, /* to */ m_outputSpace,
+			/* unpremult */ false,
+			/* roi */ roi
+		);
+#endif
 
 		if( !status )
 		{

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -46,7 +46,10 @@
 
 #include "OpenImageIO/imagecache.h"
 #include "OpenImageIO/imageio.h"
+
+#if OIIO_VERSION > 10700
 #include "OpenImageIO/deepdata.h"
+#endif
 
 #include "boost/tokenizer.hpp"
 
@@ -76,7 +79,7 @@ ImageInputPtr openImageInput( const std::string &fileName )
 	return ImageInput::open( fileName );
 }
 
-#else
+#elif OIIO_VERSION > 10603
 
 using ImageInputPtr = unique_ptr<ImageInput, decltype(&ImageInput::destroy)>;
 ImageInputPtr createImageInput( const std::string &fileName )
@@ -87,6 +90,19 @@ ImageInputPtr createImageInput( const std::string &fileName )
 ImageInputPtr openImageInput( const std::string &fileName )
 {
 	return ImageInputPtr( ImageInput::open( fileName ), &ImageInput::destroy );
+}
+
+#else
+
+using ImageInputPtr = unique_ptr<ImageInput>;
+ImageInputPtr createImageInput( const std::string &fileName )
+{
+	return ImageInputPtr( ImageInput::create( fileName ) );
+}
+
+ImageInputPtr openImageInput( const std::string &fileName )
+{
+	return ImageInputPtr( ImageInput::open( fileName ) );
 }
 
 #endif

--- a/src/IECoreImage/ImageWriter.cpp
+++ b/src/IECoreImage/ImageWriter.cpp
@@ -83,12 +83,20 @@ ImageOutputPtr createImageOutput( const std::string &fileName )
 	return ImageOutput::create( fileName );
 }
 
-#else
+#elif OIIO_VERSION > 10603
 
 using ImageOutputPtr = unique_ptr<ImageOutput, decltype(&ImageOutput::destroy)>;
 ImageOutputPtr createImageOutput( const std::string &fileName )
 {
 	return ImageOutputPtr( ImageOutput::create( fileName ), &ImageOutput::destroy );
+}
+
+#else
+
+using ImageOutputPtr = unique_ptr<ImageOutput>;
+ImageOutputPtr createImageOutput( const std::string &fileName )
+{
+	return ImageOutputPtr( ImageOutput::create( fileName ) );
 }
 
 #endif

--- a/src/IECoreImage/OpenImageIOAlgo.cpp
+++ b/src/IECoreImage/OpenImageIOAlgo.cpp
@@ -325,10 +325,12 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 			type = TypeDesc( TypeDesc::FLOAT, TypeDesc::VEC2, TypeDesc::NOXFORM, 2 );
 			data = static_cast<const Box2fData *>( d )->baseReadable();
 			break;
+#if OIIO_VERSION > 10606
 		case M33fDataTypeId :
 			type = TypeDesc( TypeDesc::FLOAT, TypeDesc::MATRIX33 );
 			data = static_cast<const M33fData *>( d )->baseReadable();
 			break;
+#endif
 		case M44fDataTypeId :
 			type = TypeDesc( TypeDesc::FLOAT, TypeDesc::MATRIX44 );
 			data = static_cast<const M44fData *>( d )->baseReadable();
@@ -345,10 +347,12 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 			type = TypeDesc( TypeDesc::DOUBLE, TypeDesc::VEC2, TypeDesc::NOXFORM, 2 );
 			data = static_cast<const Box2dData *>( d )->baseReadable();
 			break;
+#if OIIO_VERSION > 10606
 		case M33dDataTypeId :
 			type = TypeDesc( TypeDesc::DOUBLE, TypeDesc::MATRIX33 );
 			data = static_cast<const M33dData *>( d )->baseReadable();
 			break;
+#endif
 		case M44dDataTypeId :
 			type = TypeDesc( TypeDesc::DOUBLE, TypeDesc::MATRIX44 );
 			data = static_cast<const M44dData *>( d )->baseReadable();
@@ -716,10 +720,12 @@ IECore::DataPtr data( const OIIO::ParamValue &value )
 				{
 					return new V3fData( Imath::V3f( typedData[0], typedData[1], typedData[2] ) );
 				}
+#if OIIO_VERSION > 10606
 				case TypeDesc::MATRIX33 :
 				{
 					return new M33fData( Imath::M33f( typedData[0], typedData[1], typedData[2], typedData[3], typedData[4], typedData[5], typedData[6], typedData[7], typedData[8] ) );
 				}
+#endif
 				case TypeDesc::MATRIX44 :
 				{
 					return new M44fData( Imath::M44f( typedData[0], typedData[1], typedData[2], typedData[3], typedData[4], typedData[5], typedData[6], typedData[7], typedData[8], typedData[9], typedData[10], typedData[11], typedData[12], typedData[13], typedData[14], typedData[15] ) );
@@ -771,10 +777,12 @@ IECore::DataPtr data( const OIIO::ParamValue &value )
 				{
 					return new V3dData( Imath::V3d( typedData[0], typedData[1], typedData[2] ) );
 				}
+#if OIIO_VERSION > 10606
 				case TypeDesc::MATRIX33 :
 				{
 					return new M33dData( Imath::M33d( typedData[0], typedData[1], typedData[2], typedData[3], typedData[4], typedData[5], typedData[6], typedData[7], typedData[8] ) );
 				}
+#endif
 				case TypeDesc::MATRIX44 :
 				{
 					return new M44dData( Imath::M44d( typedData[0], typedData[1], typedData[2], typedData[3], typedData[4], typedData[5], typedData[6], typedData[7], typedData[8], typedData[9], typedData[10], typedData[11], typedData[12], typedData[13], typedData[14], typedData[15] ) );


### PR DESCRIPTION
This PR is meant to lower the OIIO requirement to 1.5.x, and allow building without `libboost_wave` and the boost test framwefork. Both set of changes involve reduced functionality, in particular shader preprocessing is not supported when building without libboost_wave.

Using our internal boost build causes a "double free" crash in RV
because our lib suffix doesn't match the libs provided by RV.
The same goes for OpenImageIO because our build links to the same
internal boost version.

Even though RV's boost is incomplete and OpenImageIO is several
versions behind respect to ours, it's more convenient and probably more
robust in the long run to use those instead of re-building them
ourselves to match.

NOTE: At the moment RV doesn't provide OIIO headers, so we rely on
the default `OIIO_INCLUDE_PATH` value.

- IECoreImage: allow building with OpenImageIO 1.5.x
- Disable IECoreGL when building without Boost Wave
- Tests : skip some tests on missing boost_test libs
- Build : use provided libraries for RV >= 7.8.0 build

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable. (NOTE: not sure if this applies.)
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary. (NOTE: I only ran the `test` target, do I need to run other DCC tests too?)
- [ ] My code follows the Cortex project's prevailing coding style and conventions. (NOTE: I tried but I'm not sure it really checks out.)
- [x] ~If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.~
