### PR TITLE
DisplayDriverServer : Avoid hang when service not terminated

### DIFF
--- a/src/IECoreImage/DisplayDriverServer.cpp
+++ b/src/IECoreImage/DisplayDriverServer.cpp
@@ -151,6 +151,7 @@ DisplayDriverServer::DisplayDriverServer( int portNumber ) :
 
 DisplayDriverServer::~DisplayDriverServer()
 {
+	m_data->m_service.stop();
 }
 
 int DisplayDriverServer::portNumber()


### PR DESCRIPTION
This appears adequate to avoid the hangs that occur when an error leaves a DisplayDriverServer in an unexpected state.

We could try to be more selective about testing the state first, but I don't see any issue with stopping a service that may already be stopped.