### PR TITLE
USD displayColor support

### DIFF
--- a/contrib/IECoreUSD/include/IECoreUSD/DataAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/DataAlgo.h
@@ -67,13 +67,17 @@ template<typename T>
 typename USDTypeTraits<T>::CortexVectorDataType::Ptr fromUSD( const pxr::VtArray<T> &array );
 
 /// Converts USD `value` to Cortex Data, applying any additional
-/// geometric interpretation implied by `valueTypeName`. Returns nullptr
-/// if no appropriate conversion exists.
-IECOREUSD_API IECore::DataPtr fromUSD( const pxr::VtValue &value, const pxr::SdfValueTypeName &valueTypeName );
+/// geometric interpretation implied by `valueTypeName`. If
+/// `arrayAccepted` is false, then converts single element arrays
+/// to simple data and emits a warning and returns nullptr for
+/// all other arrays. Returns nullptr if no appropriate conversion
+/// exists.
+IECOREUSD_API IECore::DataPtr fromUSD( const pxr::VtValue &value, const pxr::SdfValueTypeName &valueTypeName, bool arrayAccepted = true );
 
 /// Converts the value of `attribute` at the specified time, using the attribute's
-/// type name to apply geometric interpretation.
-IECOREUSD_API IECore::DataPtr fromUSD( const pxr::UsdAttribute &attribute, pxr::UsdTimeCode time=pxr::UsdTimeCode::Default() );
+/// type name to apply geometric interpretation. The meaning of `arrayAccepted` is
+/// as above.
+IECOREUSD_API IECore::DataPtr fromUSD( const pxr::UsdAttribute &attribute, pxr::UsdTimeCode time=pxr::UsdTimeCode::Default(), bool arrayAccepted = true );
 
 /// From Cortex to USD
 /// ==================
@@ -84,8 +88,10 @@ template<typename T>
 typename CortexTypeTraits<T>::USDType toUSD( const T &value, typename std::enable_if<!std::is_void<typename CortexTypeTraits<T>::USDType>::value>::type *enabler = nullptr );
 
 /// Conversion of any supported data type to a generic VtValue.
-/// Returns an empty VtValue if no conversion is available.
-IECOREUSD_API pxr::VtValue toUSD( const IECore::Data *data );
+/// If `arrayRequired` is true, then even simple types will be converted to
+/// a VtArray containing a single element. Returns an empty VtValue
+/// if no conversion is available.
+IECOREUSD_API pxr::VtValue toUSD( const IECore::Data *data, bool arrayRequired = false );
 
 /// Returns the Sdf type for `data`. This augments the type of
 /// the VtValue returned by `toUSD( data )`. For example, `toUSD()`

--- a/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
@@ -54,8 +54,12 @@ namespace PrimitiveAlgo
 /// From Cortex to USD
 /// ==================
 
+/// Writes a PrimitiveVariable to a UsdGeomPrimvar.
+IECOREUSD_API void writePrimitiveVariable( const IECoreScene::PrimitiveVariable &primitiveVariable, pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time );
 /// Writes a PrimitiveVariable to USD, creating a primvar via `primvarsAPI`.
 IECOREUSD_API void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode time );
+/// As above, but redirects "Cs" to the "displayColor" of `gprim`.
+IECOREUSD_API void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomGprim &gprim, pxr::UsdTimeCode time );
 /// As above, but redirects "P", "N" etc to the relevant attributes of `pointBased`.
 IECOREUSD_API void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time );
 /// Equivalent to `DataAlgo::toUSD( primitiveVariable.expandedData() )`, but avoiding

--- a/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
@@ -60,7 +60,7 @@ IECOREUSD_API void writePrimitiveVariable( const std::string &name, const IECore
 IECOREUSD_API void writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time );
 /// Equivalent to `DataAlgo::toUSD( primitiveVariable.expandedData() )`, but avoiding
 /// the creation of the temporary expanded data.
-IECOREUSD_API pxr::VtValue toUSDExpanded( const IECoreScene::PrimitiveVariable &primitiveVariable );
+IECOREUSD_API pxr::VtValue toUSDExpanded( const IECoreScene::PrimitiveVariable &primitiveVariable, bool arrayRequired = false );
 /// Converts interpolation to USD.
 IECOREUSD_API pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation interpolation );
 

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -61,6 +61,27 @@ using namespace IECoreUSD;
 // Writing primitive variables
 //////////////////////////////////////////////////////////////////////////
 
+void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const IECoreScene::PrimitiveVariable &primitiveVariable, pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time )
+{
+	const pxr::TfToken usdInterpolation = toUSD( primitiveVariable.interpolation );
+	if( !usdInterpolation.IsEmpty() )
+	{
+		primVar.SetInterpolation( usdInterpolation );
+	}
+	else
+	{
+		IECore::msg( IECore::MessageHandler::Level::Warning, "IECoreUSD::PrimitiveAlgo", boost::format( "Invalid Interpolation for %1%" ) % primVar.GetPrimvarName() );
+	}
+
+	const pxr::VtValue value = DataAlgo::toUSD( primitiveVariable.data.get(), /* arrayRequired = */ primVar.GetAttr().GetTypeName().IsArray() );
+	primVar.Set( value, time );
+
+	if( primitiveVariable.indices )
+	{
+		primVar.SetIndices( DataAlgo::toUSD( primitiveVariable.indices.get() ).Get<pxr::VtIntArray>() );
+	}
+}
+
 void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode time )
 {
 	if( name == "uv" && runTimeCast<const V2fVectorData>( primitiveVariable.data ) )
@@ -69,23 +90,21 @@ void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, 
 		return;
 	}
 
-	const pxr::TfToken usdInterpolation = toUSD( primitiveVariable.interpolation );
-	if( usdInterpolation.IsEmpty() )
+	const pxr::SdfValueTypeName valueTypeName = DataAlgo::valueTypeName( primitiveVariable.data.get() );
+	pxr::UsdGeomPrimvar usdPrimVar = primvarsAPI.CreatePrimvar( pxr::TfToken( name ), valueTypeName );
+	writePrimitiveVariable( primitiveVariable, usdPrimVar, time );
+}
+
+void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primitiveVariable, const pxr::UsdGeomGprim &gPrim, pxr::UsdTimeCode time )
+{
+	if( name == "Cs" )
 	{
-		IECore::msg( IECore::MessageHandler::Level::Warning, "IECoreUSD::PrimitiveAlgo", boost::format( "Invalid Interpolation on %1%" ) % name );
+		UsdGeomPrimvar displayColorPrimvar = gPrim.GetDisplayColorPrimvar();
+		writePrimitiveVariable( primitiveVariable, displayColorPrimvar, time );
 		return;
 	}
 
-	const pxr::VtValue value = DataAlgo::toUSD( primitiveVariable.data.get() );
-	const pxr::SdfValueTypeName valueTypeName = DataAlgo::valueTypeName( primitiveVariable.data.get() );
-
-	pxr::UsdGeomPrimvar usdPrimVar = primvarsAPI.CreatePrimvar( pxr::TfToken( name ), valueTypeName, usdInterpolation );
-	usdPrimVar.Set( value, time );
-
-	if( primitiveVariable.indices )
-	{
-		usdPrimVar.SetIndices( DataAlgo::toUSD( primitiveVariable.indices.get() ).Get<pxr::VtIntArray>() );
-	}
+	writePrimitiveVariable( name, primitiveVariable, pxr::UsdGeomPrimvarsAPI( gPrim.GetPrim() ), time );
 }
 
 void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &value, pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode time )
@@ -111,7 +130,7 @@ void IECoreUSD::PrimitiveAlgo::writePrimitiveVariable( const std::string &name, 
 #endif
 	else
 	{
-		writePrimitiveVariable( name, value, pxr::UsdGeomPrimvarsAPI( pointBased.GetPrim() ), time );
+		writePrimitiveVariable( name, value, static_cast<pxr::UsdGeomGprim &>( pointBased ), time );
 	}
 }
 
@@ -182,7 +201,7 @@ pxr::TfToken IECoreUSD::PrimitiveAlgo::toUSD( IECoreScene::PrimitiveVariable::In
 namespace
 {
 
-void readPrimitiveVariable( const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time, IECoreScene::Primitive *primitive )
+void readPrimitiveVariable( const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode time, const std::string &name, IECoreScene::Primitive *primitive, bool constantAcceptsArray )
 {
 	IECoreScene::PrimitiveVariable::Interpolation interpolation = IECoreUSD::PrimitiveAlgo::fromUSD( primVar.GetInterpolation() );
 	if( interpolation == IECoreScene::PrimitiveVariable::Invalid )
@@ -197,7 +216,10 @@ void readPrimitiveVariable( const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode
 		return;
 	}
 
-	IECore::DataPtr data = DataAlgo::fromUSD( value, primVar.GetTypeName() );
+	IECore::DataPtr data = DataAlgo::fromUSD(
+		value, primVar.GetTypeName(),
+		/* arrayAccepted = */ interpolation != IECoreScene::PrimitiveVariable::Constant || constantAcceptsArray
+	);
 	if( !data )
 	{
 		IECore::msg( IECore::MessageHandler::Level::Warning, "IECoreUSD::PrimitiveAlgo", boost::format( "PrimVar: %1% type: %2% not supported - skipping" ) % primVar.GetName().GetString() % primVar.GetTypeName() );
@@ -212,7 +234,7 @@ void readPrimitiveVariable( const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode
 		indices = DataAlgo::fromUSD( srcIndices );
 	}
 
-	primitive->variables[primVar.GetPrimvarName().GetString()] = IECoreScene::PrimitiveVariable( interpolation, data, indices );
+	primitive->variables[name] = IECoreScene::PrimitiveVariable( interpolation, data, indices );
 }
 
 } // namespace
@@ -221,7 +243,14 @@ void IECoreUSD::PrimitiveAlgo::readPrimitiveVariables( const pxr::UsdGeomPrimvar
 {
 	for( const auto &primVar : primvarsAPI.GetPrimvars() )
 	{
-		readPrimitiveVariable( primVar, time, primitive );
+		string name = primVar.GetPrimvarName().GetString();
+		bool constantAcceptsArray = true;
+		if( name == "displayColor" )
+		{
+			name = "Cs";
+			constantAcceptsArray = false;
+		}
+		readPrimitiveVariable( primVar, time, name, primitive, constantAcceptsArray );
 	}
 
 	// USD uses "st" for the primary texture coordinates and we use "uv",

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -144,11 +144,11 @@ struct VtValueFromExpandedData
 
 } // namespace
 
-pxr::VtValue IECoreUSD::PrimitiveAlgo::toUSDExpanded( const IECoreScene::PrimitiveVariable &primitiveVariable )
+pxr::VtValue IECoreUSD::PrimitiveAlgo::toUSDExpanded( const IECoreScene::PrimitiveVariable &primitiveVariable, bool arrayRequired )
 {
 	if( !primitiveVariable.indices )
 	{
-		return DataAlgo::toUSD( primitiveVariable.data.get() );
+		return DataAlgo::toUSD( primitiveVariable.data.get(), arrayRequired );
 	}
 	else
 	{

--- a/contrib/IECoreUSD/src/IECoreUSD/SphereAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SphereAlgo.cpp
@@ -87,7 +87,7 @@ bool writeSphere( const IECoreScene::SpherePrimitive *sphere, const pxr::UsdStag
 	usdSphere.CreateRadiusAttr().Set( (double)sphere->radius(), time );
 	for( const auto &p : sphere->variables )
 	{
-		PrimitiveAlgo::writePrimitiveVariable( p.first, p.second, pxr::UsdGeomPrimvarsAPI( usdSphere.GetPrim() ), time );
+		PrimitiveAlgo::writePrimitiveVariable( p.first, p.second, usdSphere, time );
 	}
 
 	return true;


### PR DESCRIPTION
This adds support for USD's displayColor, by converting to "Cs" on reading and from "Cs" on writing. As [suggested in a previous review](https://github.com/ImageEngine/cortex/pull/1070#discussion_r482941065) I've also refactored the "constant arrays should be simple data" logic out into DataAlgo and PrimitiveAlgo so it can be shared with the points/curves widths code.