### PR TITLE
USDScene : Improve set handling

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -101,16 +101,14 @@ void convertPath( SceneInterface::Path& dst, const pxr::SdfPath& src)
 	SceneInterface::stringToPath(src.GetString(), dst);
 }
 
-void convertPath( pxr::SdfPath& dst, const SceneInterface::Path& src, bool relative = false)
+pxr::SdfPath toUSD( const SceneInterface::Path &path, const bool relative = false )
 {
-	std::string pathAsString;
-	SceneInterface::pathToString(src, pathAsString);
-	if ( relative )
+	pxr::SdfPath result = relative ? pxr::SdfPath::ReflexiveRelativePath() : pxr::SdfPath::AbsoluteRootPath();
+	for( const auto &name : path )
 	{
-		pathAsString.erase(0, 1);
+		result = result.AppendElementString( name.string() );
 	}
-
-	dst = pxr::SdfPath( pathAsString );
+	return result;
 }
 
 SceneInterface::Name convertAttributeName(const pxr::TfToken& attributeName)
@@ -766,9 +764,7 @@ void USDScene::writeSet( const Name &name, const IECore::PathMatcher &set )
 			continue;
 		}
 
-		pxr::SdfPath pxrPath;
-		convertPath( pxrPath, path, true );
-		targets.push_back( pxrPath );
+		targets.push_back( toUSD( path, /* relative = */ true ) );
 	}
 
 	collection.CreateIncludesRel().SetTargets( targets );

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -752,19 +752,7 @@ void USDScene::writeSet( const Name &name, const IECore::PathMatcher &set )
 	pxr::SdfPathVector targets;
 	for( PathMatcher::Iterator it = set.begin(); it != set.end(); ++it )
 	{
-		const SceneInterface::Path &path = *it;
-
-		if ( path.empty() )
-		{
-			IECore::msg(
-				IECore::MessageHandler::Error,
-				"USDScene::writeSet",
-				boost::str( boost::format( "Unable to add path '%2%' to  set: '%1%' at location: '%2%' " ) % name.string() % m_location->prim.GetPath().GetString() )
-			);
-			continue;
-		}
-
-		targets.push_back( toUSD( path, /* relative = */ true ) );
+		targets.push_back( toUSD( *it, /* relative = */ true ) );
 	}
 
 	collection.CreateIncludesRel().SetTargets( targets );

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -751,6 +751,7 @@ void USDScene::writeSet( const Name &name, const IECore::PathMatcher &set )
 {
 	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::ApplyCollection( m_location->prim, pxr::TfToken( name.string() ), pxr::UsdTokens->explicitOnly );
 
+	pxr::SdfPathVector targets;
 	for( PathMatcher::Iterator it = set.begin(); it != set.end(); ++it )
 	{
 		const SceneInterface::Path &path = *it;
@@ -767,9 +768,10 @@ void USDScene::writeSet( const Name &name, const IECore::PathMatcher &set )
 
 		pxr::SdfPath pxrPath;
 		convertPath( pxrPath, path, true );
-
-		collection.CreateIncludesRel().AddTarget( pxrPath );
+		targets.push_back( pxrPath );
 	}
+
+	collection.CreateIncludesRel().SetTargets( targets );
 }
 
 void USDScene::hashSet( const Name &name, IECore::MurmurHash &h ) const

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -762,11 +762,8 @@ void USDScene::hashSet( const Name &name, IECore::MurmurHash &h ) const
 {
 	SceneInterface::hashSet( name, h );
 
-	SceneInterface::Path path;
-	convertPath( path, m_location->prim.GetPath() );
-
 	h.append( m_root->fileName() );
-	h.append( &path[0], path.size() );
+	append( m_location->prim.GetPath(), h );
 	h.append( name );
 }
 

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -105,9 +105,6 @@ class USDScene : public IECoreScene::SceneInterface
 		void childNamesHash( double time, IECore::MurmurHash &h ) const;
 		void hierarchyHash( double time, IECore::MurmurHash &h ) const;
 
-		void recurseReadSet( const Path &prefix, const Name &name, IECore::PathMatcher &pathMatcher, bool includeDescendantSets ) const;
-		IECore::PathMatcherDataPtr readLocalSet( const Name &name ) const;
-
 		IOPtr m_root;
 		LocationPtr m_location;
 };

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1045,6 +1045,19 @@ class USDSceneTest( unittest.TestCase ) :
 		A3 = readRoot3.child('A')
 		self.assertEqual( A.hashSet("dummySetA"), A3.hashSet("dummySetA") )
 
+	def testSetsAtRoot( self ) :
+
+		fileName = os.path.join( self.temporaryDirectory(), "test.usda" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		child = root.createChild( "child" )
+		grandChild = child.createChild( "grandChild" )
+		root.writeSet( "test", IECore.PathMatcher( [ "/child/grandChild" ] ) )
+
+		del root, child, grandChild
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( root.readSet( "test" ), IECore.PathMatcher( [ "/child/grandChild" ] ) )
+
 	def testCameras( self ):
 
 		# Write a range of cameras from Cortex to USD

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -907,7 +907,7 @@ class USDSceneTest( unittest.TestCase ) :
 	def testSets( self ) :
 
 		# Based on IECoreScene/SceneCacheTest.py
-		# There is a difference in that we can't add the current location to a set written at the same location.
+		#
 		# A
 		#   B { 'don': ['/E'], 'john'; ['/F'] }
 		#      E
@@ -915,7 +915,7 @@ class USDSceneTest( unittest.TestCase ) :
 		#   C { 'don' : ['/O'] }
 		#      O
 		#   D { 'john' : ['/G] }
-		#      G {'matti' : ['/'] }  this will not get written - added here so we ensure the other set information is writen inspite of
+		#      G {'matti' : ['/'] }
 		# H
 		#    I
 		#       J
@@ -966,6 +966,7 @@ class USDSceneTest( unittest.TestCase ) :
 		D = A.child('D')
 		E = B.child('E')
 		F = B.child('F')
+		G = D.child('G')
 		H = readRoot.child('H')
 
 		self.assertEqual( set( B.childNames() ), set( ['E', 'F'] ) )
@@ -975,6 +976,7 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertEqual( set(B.readSet("john").paths() ), set(['/F'] ) )
 		self.assertEqual( set(C.readSet("don").paths() ), set(['/O'] ) )
 		self.assertEqual( set(D.readSet("john").paths() ), set(['/G'] ) )
+		self.assertEqual( set(G.readSet("matti").paths() ), set(['/'] ) )
 
 		self.assertEqual( set(E.readSet("don").paths() ), set([] ) )
 
@@ -989,6 +991,7 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertEqual( set( A.setNames() ), set( ['don', 'john', 'matti'] ) )
 		self.assertEqual( set( A.readSet( "don" ).paths() ), set( ['/B/E', '/C/O'] ) )
 		self.assertEqual( set( A.readSet( "john" ).paths() ), set( ['/B/F', '/D/G'] ) )
+		self.assertEqual( set( A.readSet( "matti" ).paths() ), set( ['/D/G'] ) )
 
 		self.assertEqual( set( H.readSet( "foo" ).paths() ), set( ['/I/J/K/L/M/N'] ) )
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1055,8 +1055,14 @@ class USDSceneTest( unittest.TestCase ) :
 
 		del root, child, grandChild
 
+		# We want to be able to read the set from the same place we wrote it. We can,
+		# but this relies on `includeDescendantSets = True` being the default.
 		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( root.readSet( "test" ), IECore.PathMatcher( [ "/child/grandChild" ] ) )
+		# In fact, due to a USD limitation we will have authored the set onto
+		# the child instead.
+		self.assertEqual( root.readSet( "test", includeDescendantSets = False ), IECore.PathMatcher() )
+		self.assertEqual( root.child( "child" ).readSet( "test", includeDescendantSets = False ), IECore.PathMatcher( [ "/grandChild" ] ) )
 
 	def testCameras( self ):
 


### PR DESCRIPTION
This makes substantial performance improvements to USDScene's `readSet()` and `writeSet()` implementations, and lifts a couple of restrictions regarding how they are used. This will provide the foundations for reimplementing the tags API using the same underlying UsdCollections that the sets API is using, providing us with a path forwards to eventually using the sets API directly in Gaffer.