### PR TITLE
USDScene tag reading improvements

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -48,7 +48,7 @@ class USDScene : public IECoreScene::SceneInterface
 {
 	public:
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( USDScene, IECoreUSD::USDSceneTypeId, IECoreScene::SceneInterface )
-		USDScene( const std::string &path, IECore::IndexedIO::OpenMode &mode );
+		USDScene( const std::string &path, IECore::IndexedIO::OpenMode mode );
 
 		~USDScene() override;
 
@@ -92,11 +92,9 @@ class USDScene : public IECoreScene::SceneInterface
 
 	private:
 		IE_CORE_FORWARDDECLARE( IO );
-		IE_CORE_FORWARDDECLARE( Reader );
-		IE_CORE_FORWARDDECLARE( Writer );
 		IE_CORE_FORWARDDECLARE( Location );
 
-		USDScene( IOPtr root, LocationPtr location);
+		USDScene( IOPtr root, LocationPtr location );
 
 		void boundHash( double time, IECore::MurmurHash &h ) const;
 		void transformHash( double time, IECore::MurmurHash &h ) const;

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1917,7 +1917,7 @@ class USDSceneTest( unittest.TestCase ) :
 		#
 		# /a            tagOne             setOne : { /a, /a/b }
 		#   /b          tagTwo
-		# /c            			       setTwo : { /c/d }
+		# /c                               setTwo : { /c/d }
 		#   /d          tagOne, tagThree
 
 		fileName = os.path.join( self.temporaryDirectory(), "tagsAndSets.usda" )

--- a/include/IECore/InternedString.inl
+++ b/include/IECore/InternedString.inl
@@ -116,6 +116,11 @@ inline const char *InternedString::c_str() const
 	return m_value->c_str();
 }
 
+inline size_t tbb_hasher( const InternedString &s )
+{
+	return std::hash<std::string>()( s.string() );
+}
+
 } // namespace IECore
 
 namespace std

--- a/include/IECore/InternedString.inl
+++ b/include/IECore/InternedString.inl
@@ -116,6 +116,8 @@ inline const char *InternedString::c_str() const
 	return m_value->c_str();
 }
 
+#define IECORE_INTERNEDSTRING_WITH_TBB_HASHER
+
 inline size_t tbb_hasher( const InternedString &s )
 {
 	return std::hash<std::string>()( s.string() );


### PR DESCRIPTION
This rewrites USDScene's tag handling so that it maps to the exact same collections in USD as the sets API does. This gives us a path forward for transitioning from the tags API to the sets API in Gaffer. It also makes orders-of-magnitude performance improvements for both reading and writing tags. Finally, it adds support for auto-generating sets for cameras as required by Gaffer, and a set containing all UsdGeomPointInstancers to make it possible to target all instancers with a single filter in Gaffer.