### PR TITLE
IE Build : Fix install prefix for releases

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -234,7 +234,7 @@ PYTHONPATH = string.join( [
 
 # get the installation locations right
 INSTALL_PREFIX = getOption( "INSTALL_PREFIX", os.path.expanduser( "~" ) )
-installPrefix = os.path.join( "$INSTALL_PREFIX", "apps", "cortex", "$IECORE_VERSION", platform )
+installPrefix = os.path.join( "$INSTALL_PREFIX", "apps", "cortex", "${IECORE_VERSION}", platform )
 
 # add the dev suffix to local builds
 if getOption( "RELEASE", "0" )!="1" :


### PR DESCRIPTION
This is required due to a change in the makeSymLink functions in the SConstruct .

Its not particularly ideal... but its good enough for IE and I don't know if anyone else is relying on the symlinks currently... What do you reckon @johnhaddon ? I suppose another option is to add an extra `$IECORE_VERSION` key to the `links` dict [here](https://github.com/ImageEngine/cortex/blob/master/SConstruct#L1503).