### PR TITLE
USDScene : Warn for collection members not below the collection's prim

### DIFF
--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2040,5 +2040,21 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertSetNamesEqual( instancer.readTags( root.LocalTag ), [ "usd:pointInstancers" ] )
 		self.assertSetNamesEqual( instancer.readTags( root.DescendantTag ), [] )
 
+	def testNonSelfContainedCollection( self ) :
+
+		scene = IECoreScene.SceneInterface.create(
+			os.path.join( os.path.dirname( __file__ ), "data", "nonSelfContainedCollection.usda" ),
+			IECore.IndexedIO.OpenMode.Read
+		)
+		collections = scene.child( "collections" )
+
+		with IECore.CapturingMessageHandler() as mh :
+			self.assertEqual( collections.readSet( "elsewhere" ), IECore.PathMatcher() )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
+		self.assertEqual( mh.messages[0].context, "USDScene" )
+		self.assertEqual( mh.messages[0].message, 'Ignoring path "/sphere1" in collection "elsewhere" because it is not beneath the collection root "/collections"' )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/data/nonSelfContainedCollection.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/nonSelfContainedCollection.usda
@@ -1,0 +1,13 @@
+#usda 1.0
+
+def Sphere "sphere1"
+{
+}
+
+def "collections" (
+    prepend apiSchemas = ["CollectionAPI:elsewhere"]
+)
+{
+    uniform token collection:elsewhere:expansionRule = "explicitOnly"
+    prepend rel collection:elsewhere:includes = </sphere1>
+}


### PR DESCRIPTION
The SceneInterface `readSet()` and `writeSet()` methods deal exclusively in paths that are relative to the current location. But USD allows a collection to reference paths that are not parented beneath the prim holding the collection. We now detect this latter case in `readSet()` and emit a warning rather than adding the wrong path to the returned set.

It's yet to be seen whether this kind of collection is prevalent in the wild, and whether or not we will need to support them fully. This [usd-interest discussion](https://groups.google.com/u/2/g/usd-interest/c/O-cKw3yr-YY/m/MOiqWWbxAQAJ) implies that we are at least not alone, in that Katana has similar needs. If we do need to support these non-self-contained collections in the future, we have a couple of options :

- Omit the non-relative paths when reading the local set, but include them when calling `readSet( includeDescendantSets = true )` for a parent location. This would keep the relative-paths API we currently have.
- Change `readSet()` and `writeSet()` to deal only in absolute paths.

It seems that it would be premature to make a call on that just yet though.
