### PR TITLE
ToHoudiniGeometryConverterBinding: setModelLock using the enum OP_LockTypes

### DIFF
--- a/src/IECoreHoudini/bindings/ToHoudinGeometryConverterBinding.cpp
+++ b/src/IECoreHoudini/bindings/ToHoudinGeometryConverterBinding.cpp
@@ -43,6 +43,7 @@
 #include "HOM/HOM_GUDetailHandle.h"
 #include "HOM/HOM_Geometry.h"
 #include "SOP/SOP_Node.h"
+#include "OP/OP_NodeFlags.h"
 
 using namespace boost::python;
 using namespace IECoreHoudini;
@@ -82,7 +83,7 @@ static bool convertToSop( ToHoudiniGeometryConverter &c, SOP_Node *sop, bool app
 
 	if ( convert( c, handle, append ) )
 	{
-		sop->setModelLock( true );
+		sop->setModelLock( OP_NodeFlags::OP_LockTypes::OP_HARD_LOCKED );
 		return true;
 	}
 


### PR DESCRIPTION
Fixes
---
- IECoreHoudini: `ToHoudiniGeometryConverter` bindings using `OP_LockTypes` for `setModelLock` to support Houdini 18.5x (#1098 )

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
