### PR TITLE
MurmurHash : Add accessors for internal values

### DIFF
--- a/include/IECore/MurmurHash.h
+++ b/include/IECore/MurmurHash.h
@@ -72,6 +72,9 @@ class IECORE_API MurmurHash
 		MurmurHash();
 		MurmurHash( const MurmurHash &other );
 
+		// Construct directly from known internal values
+		MurmurHash( uint64_t h1, uint64_t h2 );
+
 		inline MurmurHash &append( char data );
 		inline MurmurHash &append( unsigned char data );
 		inline MurmurHash &append( short data );
@@ -154,6 +157,10 @@ class IECORE_API MurmurHash
 		inline bool operator < ( const MurmurHash &other ) const;
 
 		std::string toString() const;
+
+		// Access internal storage for special cases
+		inline uint64_t h1() const;
+		inline uint64_t h2() const;
 
 	private :
 

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -592,6 +592,16 @@ inline bool MurmurHash::operator < ( const MurmurHash &other ) const
 	return m_h1 < other.m_h1 || ( m_h1 == other.m_h1 && m_h2 < other.m_h2 );
 }
 
+inline uint64_t MurmurHash::h1() const
+{
+	return m_h1;
+}
+
+inline uint64_t MurmurHash::h2() const
+{
+	return m_h2;
+}
+
 /// Implementation of tbb_hasher for MurmurHash, allowing MurmurHash to be used
 /// as a key in tbb::concurrent_hash_map.
 inline size_t tbb_hasher( const MurmurHash &h )

--- a/src/IECore/MurmurHash.cpp
+++ b/src/IECore/MurmurHash.cpp
@@ -49,6 +49,11 @@ MurmurHash::MurmurHash( const MurmurHash &other )
 {
 }
 
+MurmurHash::MurmurHash( uint64_t h1, uint64_t h2 )
+	:	m_h1( h1 ), m_h2( h2 )
+{
+}
+
 std::string MurmurHash::toString() const
 {
 	std::stringstream s;

--- a/src/IECorePython/MurmurHashBinding.cpp
+++ b/src/IECorePython/MurmurHashBinding.cpp
@@ -76,6 +76,7 @@ void bindMurmurHash()
 	class_<MurmurHash>( "MurmurHash" )
 		.def( init<>() )
 		.def( init<const MurmurHash &>() )
+		.def( init<uint64_t, uint64_t>() )
 		.def( "append", (MurmurHash &(MurmurHash::*)( float ))&MurmurHash::append, return_self<>() )
 		.def( "append", (MurmurHash &(MurmurHash::*)( double ))&MurmurHash::append, return_self<>() )
 		.def( "append", &appendInt, return_self<>() )
@@ -143,6 +144,8 @@ void bindMurmurHash()
 		.def( "__repr__", &repr )
 		.def( "__str__", &MurmurHash::toString )
 		.def( "toString", &MurmurHash::toString )
+		.def( "h1", &MurmurHash::h1 )
+		.def( "h2", &MurmurHash::h2 )
 	;
 
 }

--- a/test/IECore/MurmurHashTest.py
+++ b/test/IECore/MurmurHashTest.py
@@ -218,6 +218,21 @@ class MurmurHashTest( unittest.TestCase ) :
 
 		self.assertNotEqual( h1, h2 )
 
+	def testDataAccess( self ) :
+
+		# Test accessors for the internal data ( it's not usually necessary to access
+		# these directly, but it can be useful in special cases )
+
+		for t in [ "the quick", 101, IECore.FloatVectorData( [1, 2, 3] ) ]:
+
+			h = IECore.MurmurHash()
+			h.append( t )
+			self.assertEqual( str( h ), "{:016x}{:016x}".format( h.h1(), h.h2() ) )
+
+			h2 = IECore.MurmurHash( h.h1(), h.h2() )
+			self.assertEqual( h, h2 )
+
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
As discussed, these accessors make it possible to do tricks like using sums of hashes to create order independent hashes.

I haven't actually fully validated this yet in the context I'm planning on using it in ( encountered a weird issue, but I don't think it's related to this at all ).  This PR seems pretty simple.

I was wondering whether the annoying "include the Changelog updates in every single commit thing" is supposed to happen in Cortex now too, but I looked at other commits and didn't see it, so I haven't done it here.