### PR TITLE
IECoreArnold::ParameterAlgo : Prefer `std::unique_ptr`

### DIFF
--- a/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/ParameterAlgo.cpp
@@ -38,8 +38,6 @@
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "boost/interprocess/smart_ptr/unique_ptr.hpp"
-
 using namespace std;
 using namespace IECore;
 using namespace IECoreArnold;
@@ -51,7 +49,7 @@ using namespace IECoreArnold;
 namespace
 {
 
-typedef boost::interprocess::unique_ptr<AtArray, void (*)( AtArray *)> ArrayPtr;
+using ArrayPtr = std::unique_ptr<AtArray, void (*)( AtArray *)>;
 
 template<typename T>
 inline const T *dataCast( const char *name, const IECore::Data *data )


### PR DESCRIPTION
It isn't documented in the source, but I can only assume I used `boost::interprocess::unique_ptr` because C++11 wasn't available to us at the time.