### PR TITLE
SConstruct: Added possibility of controlling boost python suffix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -161,6 +161,13 @@ o.Add(
 	"-${BOOST_MAJOR_VERSION}_${BOOST_MINOR_VERSION}_${BOOST_PATCH_VERSION}",
 )
 
+o.Add(
+	"BOOST_PYTHON_LIB_SUFFIX",
+	"The suffix appended to the names of the python boost libraries. "
+	"You can modify this so that the correct python library name is used, "
+	"likely related to the specific python version.",
+)
+
 # OpenEXR options
 
 o.Add(
@@ -1424,12 +1431,15 @@ else :
 
 pythonEnv.Append( CPPFLAGS = "-DBOOST_PYTHON_MAX_ARITY=20" )
 
-boostPythonLibSuffix = ""
-if ( int( env["BOOST_MAJOR_VERSION"] ), int( env["BOOST_MINOR_VERSION"] ) ) >= ( 1, 67 ) :
-	boostPythonLibSuffix = pythonEnv["PYTHON_VERSION"].replace( ".", "" )
+# if BOOST_PYTHON_LIB_SUFFIX is provided, use it
+boostPythonLibSuffix = pythonEnv.get( "BOOST_PYTHON_LIB_SUFFIX", None )
+if boostPythonLibSuffix is None :
+	boostPythonLibSuffix = pythonEnv["BOOST_LIB_SUFFIX"]
+	if ( int( env["BOOST_MAJOR_VERSION"] ), int( env["BOOST_MINOR_VERSION"] ) ) >= ( 1, 67 ) :
+		boostPythonLibSuffix = pythonEnv["PYTHON_VERSION"].replace( ".", "" ) + boostPythonLibSuffix
 
 pythonEnv.Append( LIBS = [
-		"boost_python" + boostPythonLibSuffix + pythonEnv["BOOST_LIB_SUFFIX"],
+		"boost_python" + boostPythonLibSuffix,
 	]
 )
 

--- a/config/ie/options
+++ b/config/ie/options
@@ -180,6 +180,9 @@ TBB_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "tbb", tbbVersion )
 BOOST_INCLUDE_PATH = os.path.join( "/software/tools/include", platform, "boost", boostVersion )
 BOOST_LIB_PATH = os.path.join( "/software", "tools", "lib", platform, compiler, compilerVersion )
 BOOST_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "boost", boostVersion, { "compiler" : compiler, "compilerVersion" : compilerVersion } )
+BOOST_PYTHON_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix(
+	"boost_python", boostVersion, { "compiler" : compiler, "compilerVersion" : compilerVersion, "pythonVersion" : pythonVersion }
+)
 
 OPENEXR_INCLUDE_PATH = "/software/tools/include/" + platform + "/OpenEXR/" + openEXRVersion
 OPENEXR_LIB_PATH = os.path.join( "/software", "tools", "lib", platform, compiler, compilerVersion )


### PR DESCRIPTION
IE/options make use of it so we can support python 3/boost 1.66.

We could hard-code an extra rule where the current one for boost > 1.67 is processed.
However, it seems like it's better to offer different facilities more control over how boost libraries may be named.

The current PR keeps it backward compatible, but allows for the customization.

