### PR TITLE
Arnold CameraAlgo : Support animated projections

### DIFF
--- a/contrib/IECoreArnold/include/IECoreArnold/CameraAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/CameraAlgo.h
@@ -48,6 +48,7 @@ namespace CameraAlgo
 {
 
 IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace CameraAlgo
 


### PR DESCRIPTION
In #1107 we added the ability to interpolate camera parameters so we could load animated projections from `.scc` and `.abc` files. This takes advantage of that by adding support for animated projections when exporting cameras to Arnold. So for instance you can get motion blur from a crash zoom. I'll open an associated PR in Gaffer that should complete the puzzle.