### PR TITLE
CI : Include GafferHQ/dependencies in uploaded packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,8 +137,7 @@ jobs:
       # containing the hash of the archive, for use in the cache key
       # below.
       run: |
-        echo CORTEX_DEPENDENCIES_HASH=`python config/installDependencies.py --archiveURL ${{ matrix.dependenciesURL }} --dependenciesDir ./dependencies --outputFormat "{archiveDigest}"` >> $GITHUB_ENV
-        echo CORTEX_DEPENDENCIES_DIR=./dependencies >> $GITHUB_ENV
+        echo CORTEX_DEPENDENCIES_HASH=`python config/installDependencies.py --archiveURL ${{ matrix.dependenciesURL }} --dependenciesDir ${{ env.CORTEX_BUILD_NAME }} --outputFormat "{archiveDigest}"` >> $GITHUB_ENV
       shell: bash
 
     - name: Install renderers

--- a/.github/workflows/main/options.posix
+++ b/.github/workflows/main/options.posix
@@ -1,7 +1,7 @@
 import os
 import platform
 
-deps = os.environ.get( "CORTEX_DEPENDENCIES_DIR" )
+deps = os.environ.get( "CORTEX_BUILD_NAME" )
 includes = os.path.join( deps, "include" )
 libs = os.path.join( deps, "lib" )
 

--- a/.github/workflows/main/options.windows
+++ b/.github/workflows/main/options.windows
@@ -1,6 +1,6 @@
 import os
 
-deps = os.environ.get( "CORTEX_DEPENDENCIES_DIR" )
+deps = os.environ.get( "CORTEX_BUILD_NAME" )
 includes = os.path.join( deps, "include" )
 libs = os.path.join( deps, "lib" )
 


### PR DESCRIPTION
This makes them usable on their own, and will allow us to build Gaffer
with fresh Cortex builds without a complete (and very slow) release
cycle for GafferHQ/dependencies itself.

This is a somewhat odd workflow, given that GafferHQ/dependencies
includes Cortex originally, and also includes many packages not needed by Cortex.
Other possibilities considered include :

- Omitting Cortex from GafferHQ/dependencies and doing a merge of a
  Cortex package (excluding dependencies) and a dependencies package at
  build time in GafferHQ/gaffer. This would be a little cleaner
  conceptually, but has several downsides :
  - More confusing for newcomers. It is very nice to be able to point
    people to a single precompiled package containing everything Gaffer
	needs.
  - Danger of mismatched builds, using a Cortex built against the wrong
    GafferHQ/dependencies.
  - GafferHQ/dependencies is incomplete for Gaffer and overkill for
    Cortex.
- Creating separate Cortex dependencies builds, with only stuff needed
  for Cortex. Building Cortex with those and then feeding them into a
  separate GafferHQ/dependencies project which adds everything else.
  This is conceptually cleaner, but a lot more management overhead.
- Improving turnaround for GafferHQ/dependencies. There is definitely
  scope for this with some sort of caching system, but not in the time
  available.
- Moving Cortex into Gaffer. This probably makes a lot of sense
  everywhere except Image Engine. I briefly investigated doing this via
  Git submodules but again it is more complex than the solution used
  here.
