### PR TITLE
IECoreUSD : Add `SceneAlgo::sceneFromStage`

### DIFF
--- a/contrib/IECoreUSD/include/IECoreUSD/SceneAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/SceneAlgo.h
@@ -41,6 +41,7 @@
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usd/stage.h"
+#include "pxr/usd/usd/stageCache.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreUSD
@@ -51,6 +52,13 @@ namespace SceneAlgo
 
 /// Wrap a UsdStage into a Cortex SceneInterface
 IECOREUSD_API IECoreScene::SceneInterfacePtr sceneFromStage( const pxr::UsdStageRefPtr &stage );
+
+// \todo: remove this and make it part of the normal SceneInterface factory
+IECOREUSD_API IECoreScene::SceneInterfacePtr getScene( int stageId );
+
+IECOREUSD_API int cacheStage( const pxr::UsdStageRefPtr &stage );
+IECOREUSD_API int getStageId( const pxr::UsdStageRefPtr &stage );
+IECOREUSD_API bool eraseStage( int stageId );
 
 } // namespace SceneAlgo
 

--- a/contrib/IECoreUSD/include/IECoreUSD/SceneAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/SceneAlgo.h
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2017, Image Engine Design. All rights reserved.
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -32,20 +32,28 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
+#ifndef IECOREUSD_SCENEALGO_H
+#define IECOREUSD_SCENEALGO_H
 
-#include "IECoreUSD/SceneAlgo.h"
+#include "IECoreUSD/Export.h"
 
-using namespace boost::python;
-using namespace IECoreUSD;
+#include "IECoreScene/SceneInterface.h"
 
-BOOST_PYTHON_MODULE( _IECoreUSD )
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/usd/usd/stage.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
+namespace IECoreUSD
 {
-	{
-		object module( borrowed( PyImport_AddModule( "IECoreUSD.SceneAlgo" ) ) );
-		scope().attr( "SceneAlgo" ) = module;
-		scope moduleScope( module );
 
-		def( "sceneFromStage", &SceneAlgo::sceneFromStage );
-	}
-}
+namespace SceneAlgo
+{
+
+/// Wrap a UsdStage into a Cortex SceneInterface
+IECOREUSD_API IECoreScene::SceneInterfacePtr sceneFromStage( const pxr::UsdStageRefPtr &stage );
+
+} // namespace SceneAlgo
+
+} // namespace IECoreUSD
+
+#endif // IECOREUSD_SCENEALGO_H

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneAlgo.cpp
@@ -45,3 +45,34 @@ SceneInterfacePtr IECoreUSD::SceneAlgo::sceneFromStage( const pxr::UsdStageRefPt
 {
 	return new USDScene( stage );
 }
+
+namespace
+{
+
+UsdStageCache &stageCache()
+{
+	static UsdStageCache *g_stageCache = new UsdStageCache;
+	return *g_stageCache;
+}
+
+} // namespace
+
+SceneInterfacePtr IECoreUSD::SceneAlgo::getScene( int stageId )
+{
+	return new USDScene( ::stageCache().Find( UsdStageCache::Id::FromLongInt( stageId ) ) );
+}
+
+int IECoreUSD::SceneAlgo::cacheStage( const UsdStageRefPtr &stage )
+{
+	return ::stageCache().Insert( stage ).ToLongInt();
+}
+
+int IECoreUSD::SceneAlgo::getStageId( const UsdStageRefPtr &stage )
+{
+	return ::stageCache().GetId( stage ).ToLongInt();
+}
+
+bool IECoreUSD::SceneAlgo::eraseStage( int stageId )
+{
+	return ::stageCache().Erase( UsdStageCache::Id::FromLongInt( stageId ) );
+}

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneAlgo.cpp
@@ -1,6 +1,6 @@
 //////////////////////////////////////////////////////////////////////////
 //
-//  Copyright (c) 2017, Image Engine Design. All rights reserved.
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are
@@ -32,20 +32,16 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "boost/python.hpp"
-
 #include "IECoreUSD/SceneAlgo.h"
+#include "IECoreUSD/USDScene.h"
 
-using namespace boost::python;
+using namespace std;
+using namespace pxr;
+using namespace IECore;
+using namespace IECoreScene;
 using namespace IECoreUSD;
 
-BOOST_PYTHON_MODULE( _IECoreUSD )
+SceneInterfacePtr IECoreUSD::SceneAlgo::sceneFromStage( const pxr::UsdStageRefPtr &stage )
 {
-	{
-		object module( borrowed( PyImport_AddModule( "IECoreUSD.SceneAlgo" ) ) );
-		scope().attr( "SceneAlgo" ) = module;
-		scope moduleScope( module );
-
-		def( "sceneFromStage", &SceneAlgo::sceneFromStage );
-	}
+	return new USDScene( stage );
 }

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -361,8 +361,13 @@ class USDScene::IO : public RefCounted
 					throw Exception( "Unsupported OpenMode" );
 			}
 
-			m_timeCodesPerSecond = m_stage->GetTimeCodesPerSecond();
-			m_rootPrim = m_stage->GetPseudoRoot();
+			initStage();
+		}
+
+		IO( const pxr::UsdStageRefPtr &stage, IndexedIO::OpenMode openMode )
+			: m_fileName( "" ), m_openMode( openMode ), m_stage( stage )
+		{
+			initStage();
 		}
 
 		~IO() override
@@ -375,6 +380,12 @@ class USDScene::IO : public RefCounted
 				}
 				m_stage->GetRootLayer()->Save();
 			}
+		}
+
+		void initStage()
+		{
+			m_timeCodesPerSecond = m_stage->GetTimeCodesPerSecond();
+			m_rootPrim = m_stage->GetPseudoRoot();
 		}
 
 		const std::string &fileName() const
@@ -444,6 +455,12 @@ class USDScene::IO : public RefCounted
 
 USDScene::USDScene( const std::string &fileName, IndexedIO::OpenMode openMode )
 	:	m_root( new IO( fileName, openMode ) ),
+		m_location( new Location( m_root->root() ) )
+{
+}
+
+USDScene::USDScene( const pxr::UsdStageRefPtr &stage )
+	:	m_root( new IO( stage, IndexedIO::Read ) ),
 		m_location( new Location( m_root->root() ) )
 {
 }

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -41,6 +41,10 @@
 
 #include "IECore/PathMatcherData.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/usd/usd/stage.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
 namespace IECoreUSD
 {
 
@@ -49,6 +53,7 @@ class USDScene : public IECoreScene::SceneInterface
 	public:
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( USDScene, IECoreUSD::USDSceneTypeId, IECoreScene::SceneInterface )
 		USDScene( const std::string &path, IECore::IndexedIO::OpenMode mode );
+		explicit USDScene( const pxr::UsdStageRefPtr &stage );
 
 		~USDScene() override;
 

--- a/contrib/IECoreUSD/src/IECoreUSD/bindings/IEUSDModule.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/bindings/IEUSDModule.cpp
@@ -47,5 +47,9 @@ BOOST_PYTHON_MODULE( _IECoreUSD )
 		scope moduleScope( module );
 
 		def( "sceneFromStage", &SceneAlgo::sceneFromStage );
+		def( "getScene", &SceneAlgo::getScene );
+		def( "cacheStage", &SceneAlgo::cacheStage );
+		def( "getStageId", &SceneAlgo::getStageId );
+		def( "eraseStage", &SceneAlgo::eraseStage );
 	}
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2327,7 +2327,8 @@ class USDSceneTest( unittest.TestCase ) :
 		pxr.UsdGeom.Camera.Define( stage, "/a/c" )
 		stage.OverridePrim( "/a/b" ).GetReferences().AddReference( os.path.join( os.path.dirname( __file__ ), "data", "cube.usda" ), "/pCube1" )
 
-		scene = IECoreUSD.SceneAlgo.sceneFromStage( stage )
+		id = IECoreUSD.SceneAlgo.cacheStage( stage )
+		scene = IECoreUSD.SceneAlgo.getScene( id )
 		self.assertEqual( scene.childNames(), [ "a" ] )
 
 		a = scene.child( "a" )


### PR DESCRIPTION
This utility can be used to wrap a live in-memory `pxr::UsdStage` into an `IECoreScene::SceneInterface` (as though the stage was already written to a file).

I'm putting this up as a draft for now. It follows some discussion @johnhaddon and I had already, but I'm not convinced I like the utility method... As a client of `SceneInterfaces`, its confusing to not just call `SceneInterface.create` or `SharedSceneInterfaces.get` as normal...

I wonder if it'd be worth the extra effort of adding `SceneInterface.create( const CompoundData *args )` (as we've discussed for other uses) and having `USDScene` check `args` for a `stage`, so we can replace the python access from

`scene = IECoreUSD.SceneAlgo.sceneFromStage( stage )`

to

`scene = IECoreScene.SceneInterface.create( { "stage" : stage } )`

Note also I've currently hard-coded to Read mode only when providing a stage. I'm not sure if that's a good idea, but it was easier to get the draft PR up today without testing write mode...