### PR TITLE
USDScene : Add constructor from a UsdStage

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -361,8 +361,13 @@ class USDScene::IO : public RefCounted
 					throw Exception( "Unsupported OpenMode" );
 			}
 
-			m_timeCodesPerSecond = m_stage->GetTimeCodesPerSecond();
-			m_rootPrim = m_stage->GetPseudoRoot();
+			initStage();
+		}
+
+		IO( const pxr::UsdStageRefPtr &stage, IndexedIO::OpenMode openMode )
+			: m_fileName( "" ), m_openMode( openMode ), m_stage( stage )
+		{
+			initStage();
 		}
 
 		~IO() override
@@ -375,6 +380,12 @@ class USDScene::IO : public RefCounted
 				}
 				m_stage->GetRootLayer()->Save();
 			}
+		}
+
+		void initStage()
+		{
+			m_timeCodesPerSecond = m_stage->GetTimeCodesPerSecond();
+			m_rootPrim = m_stage->GetPseudoRoot();
 		}
 
 		const std::string &fileName() const
@@ -444,6 +455,12 @@ class USDScene::IO : public RefCounted
 
 USDScene::USDScene( const std::string &fileName, IndexedIO::OpenMode openMode )
 	:	m_root( new IO( fileName, openMode ) ),
+		m_location( new Location( m_root->root() ) )
+{
+}
+
+USDScene::USDScene( const pxr::UsdStageRefPtr &stage, IndexedIO::OpenMode openMode )
+	:	m_root( new IO( stage, openMode ) ),
 		m_location( new Location( m_root->root() ) )
 {
 }

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -41,6 +41,10 @@
 
 #include "IECore/PathMatcherData.h"
 
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/usd/usd/stage.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
 namespace IECoreUSD
 {
 
@@ -49,6 +53,7 @@ class USDScene : public IECoreScene::SceneInterface
 	public:
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( USDScene, IECoreUSD::USDSceneTypeId, IECoreScene::SceneInterface )
 		USDScene( const std::string &path, IECore::IndexedIO::OpenMode mode );
+		USDScene( const pxr::UsdStageRefPtr &stage, IECore::IndexedIO::OpenMode mode );
 
 		~USDScene() override;
 


### PR DESCRIPTION
This is a purely private change taken from #1123 to enable @lucienfostier to use `USDScene` for writing SCC from a live stage in his upcoming SdfFileFormat PR.

If we feel the test coverage is needed, I could revive #1123, but I'd rather avoid the public API as we're likely to change it for Cortex 10.2 anyways.
