### PR TITLE
StringAlgoTest : Add more coverage for `matchMultiple()`

### DIFF
--- a/test/IECore/StringAlgoTest.py
+++ b/test/IECore/StringAlgoTest.py
@@ -131,6 +131,14 @@ class StringAlgoTest( unittest.TestCase ) :
 			( "bb", "*a b", False ),
 			( "bb", "*a bb", True ),
 			( "bb", "*a    bb", True ),
+			# Doesn't match, because "a b" specifies two different patterns
+			# separated by a space.
+			( "a b", "a b", False ),
+			( "apple ball", "apple ball", False ),
+			# Does match, because the escaping leaves us with a single pattern
+			# containing a space.
+			( "a b", "a\ b", True ),
+			( "apple ball", "apple\ ball", True ),
 		] :
 
 			if r :


### PR DESCRIPTION
0f4260577d313df31f4517a480134d162ac902a1 fixed bugs and performance issues related to wildcards and space separated patterns. One bug that I don't think I realised I was fixing at the time was the matching of spaces in the string against spaces separating match patterns. This appears to have affected some production scenes which were relying on the broken behaviour. Having reviewed the code again, I'm pretty sure we are doing the right thing, so I'm just beefing up the tests a little to assert that and make sure we don't change behaviour again in future.
