### PR TITLE
MurmurHash : Make Constructor inline

### DIFF
--- a/include/IECore/MurmurHash.h
+++ b/include/IECore/MurmurHash.h
@@ -58,11 +58,11 @@ class IECORE_API MurmurHash
 
 	public :
 
-		MurmurHash();
-		MurmurHash( const MurmurHash &other );
+		inline MurmurHash();
+		inline MurmurHash( const MurmurHash &other );
 
 		// Construct directly from known internal values
-		MurmurHash( uint64_t h1, uint64_t h2 );
+		inline MurmurHash( uint64_t h1, uint64_t h2 );
 
 		/// Appends a single value. Arithmetic types are supported natively,
 		/// and custom types can be added by providing an implementation of

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -68,6 +68,21 @@ inline uint64_t fmix( uint64_t k )
 	return k;
 }
 
+inline MurmurHash::MurmurHash()
+    :   m_h1( 0 ), m_h2( 0 )
+{
+}
+
+inline MurmurHash::MurmurHash( const MurmurHash &other )
+    :   m_h1( other.m_h1 ), m_h2( other.m_h2 )
+{
+}
+
+inline MurmurHash::MurmurHash( uint64_t h1, uint64_t h2 )
+    :   m_h1( h1 ), m_h2( h2 )
+{
+}
+
 inline void MurmurHash::appendRaw( const void *data, size_t bytes, int elementSize )
 {
 	const size_t nBlocks = bytes / 16;

--- a/src/IECore/MurmurHash.cpp
+++ b/src/IECore/MurmurHash.cpp
@@ -39,21 +39,6 @@
 
 using namespace IECore;
 
-MurmurHash::MurmurHash()
-	:	m_h1( 0 ), m_h2( 0 )
-{
-}
-
-MurmurHash::MurmurHash( const MurmurHash &other )
-	:	m_h1( other.m_h1 ), m_h2( other.m_h2 )
-{
-}
-
-MurmurHash::MurmurHash( uint64_t h1, uint64_t h2 )
-	:	m_h1( h1 ), m_h2( h2 )
-{
-}
-
 std::string MurmurHash::toString() const
 {
 	std::stringstream s;


### PR DESCRIPTION
I assume this is probably an ABI break ... it's probably not urgent to roll out - the difference isn't huge, but any performance evaluation of Gaffer involving lots of hashes should probably be done on top of this.