### PR TITLE
CI : Bump Arnold version to 6.2.0.0

### DIFF
--- a/.github/workflows/main/installArnold.sh
+++ b/.github/workflows/main/installArnold.sh
@@ -37,7 +37,7 @@
 
 set -e
 
-arnoldVersion=6.0.1.0
+arnoldVersion=6.2.0.0
 
 if [[ `uname` = "Linux" ]] ; then
 	arnoldPlatform=linux


### PR DESCRIPTION
The release packages we're uploading from GitHub Actions CI are intended to be compatible replacements for GafferHQ/dependencies version 3, and that's only possible if the Arnold versions match. This mismatch is the cause of at least some of the problems on https://github.com/GafferHQ/gaffer/pull/4175.
