### PR TITLE
USDScene : Support USD 21.02

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -198,7 +198,8 @@ void writeSetInternal( const pxr::UsdPrim &prim, const pxr::TfToken &name, const
 		targets.push_back( toUSD( *it, /* relative = */ true ) );
 	}
 
-	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::ApplyCollection( prim, name, pxr::UsdTokens->explicitOnly );
+	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::Apply( prim, name );
+	collection.CreateExpansionRuleAttr( pxr::VtValue( pxr::UsdTokens->explicitOnly ) );
 	collection.CreateIncludesRel().SetTargets( targets );
 }
 


### PR DESCRIPTION
The `ApplyCollection()` method was removed, but it's straightforward enough to reproduce what it was doing.
