### PR TITLE
Alembic fixes

### DIFF
--- a/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveReader.inl
+++ b/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveReader.inl
@@ -101,7 +101,13 @@ void PrimitiveReader::readGeomParam( const T &param, const Alembic::Abc::ISample
 
 	if( param.getArrayExtent() > 1 )
 	{
-		IECore::msg( IECore::Msg::Warning, "FromAlembicGeomBaseConverter::convertArbGeomParam", boost::format( "Param \"%s\" has unsupported array extent" ) % param.getHeader().getName() );
+		IECore::msg(
+			IECore::Msg::Warning, "PrimitiveReader::convertArbGeomParam",
+			boost::format( "GeomParam \"%s\" on object \"%s\" has unsupported array extent %d" )
+				% param.getHeader().getName()
+				% param.getParent().getObject().getFullName()
+				% param.getArrayExtent()
+		);
 		return;
 	}
 

--- a/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveReader.inl
+++ b/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveReader.inl
@@ -143,7 +143,23 @@ void PrimitiveReader::readGeomParam( const T &param, const Alembic::Abc::ISample
 		pv.indices = indexData;
 	}
 
-	primitive->variables[primitiveVariableName] = pv;
+	if( primitive->isPrimitiveVariableValid( pv ) )
+	{
+		primitive->variables[primitiveVariableName] = pv;
+	}
+	else
+	{
+		IECore::msg(
+			IECore::Msg::Warning, "PrimitiveReader::readGeomParam",
+			boost::format(
+				"Ignoring invalid primitive variable \"%s\" on object \"%s\" (size %d, expected %d)"
+			)
+				% primitiveVariableName
+				% param.getParent().getObject().getFullName()
+				% (pv.indices ? pv.indices->readable().size() : data->readable().size())
+				% primitive->variableSize( pv.interpolation )
+		);
+	}
 }
 
 } // namespace IECoreAlembic

--- a/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveReader.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveReader.cpp
@@ -133,7 +133,12 @@ void PrimitiveReader::readArbGeomParams( const Alembic::Abc::ICompoundProperty &
 		}
 		else
 		{
-			msg( Msg::Warning, "FromAlembicGeomBaseConverter::convertArbGeomParams", boost::format( "Param \"%s\" has unsupported type" ) % header.getName() );
+			msg(
+				Msg::Warning, "PrimitiveReader::convertArbGeomParams",
+				boost::format( "GeomParam \"%s\" on object \"%s\" has unsupported type" )
+					% header.getName()
+					% params.getObject().getFullName()
+			);
 		}
 	}
 }


### PR DESCRIPTION
This fixes crashes caused by trying to load malformed Alembic files, and makes it easier to track down future problems by making the warning messages more informative.