### PR TITLE
DisplayDriverServer : Add mechanism to limit available ports

### DIFF
--- a/config/ie/ieCoreImageSetup.py
+++ b/config/ie/ieCoreImageSetup.py
@@ -1,0 +1,38 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import IECoreImage
+
+IECoreImage.DisplayDriverServer.registerPortRange( "gaffer", ( 40329, 40335 ) )
+IECoreImage.DisplayDriverServer.registerPortRange( "nuke", ( 40336, 40339 ) )

--- a/config/ie/ieCoreSceneSetup.py
+++ b/config/ie/ieCoreSceneSetup.py
@@ -1,3 +1,37 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
 import os
 
 import IECoreScene

--- a/config/ie/ieMayaSetup.py
+++ b/config/ie/ieMayaSetup.py
@@ -1,3 +1,37 @@
+##########################################################################
+#
+#  Copyright (c) 2020, Image Engine Design Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
 import maya.cmds
 
 # create the 'IE' menu when the UI is available

--- a/config/ie/options
+++ b/config/ie/options
@@ -516,6 +516,7 @@ else :
 	INSTALL_ALEMBICLIB_NAME = os.path.join( basePrefix, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 
 INSTALL_CORESCENE_POST_COMMAND = "scons -i -f config/ie/postCoreSceneInstall INSTALLPREFIX={prefix} install".format( prefix = appPrefix if targetApp else basePrefix )
+INSTALL_COREIMAGE_POST_COMMAND = "scons -i -f config/ie/postCoreImageInstall INSTALLPREFIX={prefix} install".format( prefix = appPrefix if targetApp else basePrefix )
 
 INSTALL_GLSL_HEADER_DIR =  os.path.join( basePrefix, "glsl" )
 INSTALL_GLSL_SHADER_DIR =  os.path.join( basePrefix, "glsl" )

--- a/config/ie/postCoreImageInstall
+++ b/config/ie/postCoreImageInstall
@@ -1,0 +1,52 @@
+########################################################################## 
+# 
+#  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+# 
+#  Redistribution and use in source and binary forms, with or without 
+#  modification, are permitted provided that the following conditions are 
+#  met: 
+# 
+#     * Redistributions of source code must retain the above copyright 
+#       notice, this list of conditions and the following disclaimer. 
+# 
+#     * Redistributions in binary form must reproduce the above copyright 
+#       notice, this list of conditions and the following disclaimer in the 
+#       documentation and/or other materials provided with the distribution. 
+# 
+#     * Neither the name of Image Engine Design nor the names of any 
+#       other contributors to this software may be used to endorse or 
+#       promote products derived from this software without specific prior 
+#       written permission. 
+# 
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS 
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING 
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+# 
+########################################################################## 
+ 
+########################################################################## 
+# 
+# This script is supposed to be called from scons. It is intended for use 
+# only with Image Engine's build. It depends on internal module "IEBuild". 
+# 
+########################################################################## 
+
+import sys
+
+import VersionControl 
+VersionControl.setVersion('IEBuild', '7.1.0')
+import IEBuild  
+
+IEBuild.Config(
+	ARGUMENTS,
+	configFiles = [ "config/ie/ieCoreImageSetup.py" ],
+	context = "IECoreImage",
+).finalize()

--- a/config/ie/postCoreMayaInstall
+++ b/config/ie/postCoreMayaInstall
@@ -42,7 +42,7 @@
 import sys
 
 import VersionControl 
-VersionControl.setVersion('IEBuild', '6.28.4')
+VersionControl.setVersion('IEBuild', '7.1.0')
 import IEBuild  
 
 IEBuild.Config(

--- a/config/ie/postCoreSceneInstall
+++ b/config/ie/postCoreSceneInstall
@@ -42,7 +42,7 @@
 import sys
 
 import VersionControl 
-VersionControl.setVersion('IEBuild', '6.28.4')
+VersionControl.setVersion('IEBuild', '7.1.0')
 import IEBuild  
 
 IEBuild.Config(

--- a/include/IECoreImage/DisplayDriverServer.h
+++ b/include/IECoreImage/DisplayDriverServer.h
@@ -60,13 +60,31 @@ class IECOREIMAGE_API DisplayDriverServer : public IECore::RunTimeTyped
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( DisplayDriverServer, DisplayDriverServerTypeId, IECore::RunTimeTyped );
 
+		/// \todo: Switch to uint16_t as it offers a more appropriate range
+		using Port = int;
+		using PortRange = std::pair<Port, Port>;
+
 		/// A port number of 0 causes a free port to be chosen
 		/// automatically. Call `portNumber()` after construction
 		/// to retrieve the actual number.
-		DisplayDriverServer( int portNumber = 0 );
+		DisplayDriverServer( Port portNumber = 0 );
 		~DisplayDriverServer() override;
 
-		int portNumber();
+		Port portNumber();
+
+		/// Used to artificially limit the available ports.
+		/// Automated port selection (via `portNumber = 0`) will
+		/// be clamped to this range and manually specifying an
+		/// out-of-range port will throw InvalidArgumentException
+		static void setPortRange( const PortRange &range );
+		static const PortRange &getPortRange();
+
+		/// Used to associate port ranges with specific names,
+		/// for example to query the port range of one application
+		/// from within another application.
+		static void registerPortRange( const std::string &name, const PortRange &range );
+		static void deregisterPortRange( const std::string &name );
+		static const PortRange &registeredPortRange( const std::string &name );
 
 	private:
 

--- a/include/IECoreImage/DisplayDriverServer.h
+++ b/include/IECoreImage/DisplayDriverServer.h
@@ -43,6 +43,7 @@
 
 #include "IECore/RunTimeTyped.h"
 #include "IECore/VectorTypedData.h"
+#include "IECore/Version.h"
 
 #include "boost/system/error_code.hpp"
 
@@ -60,8 +61,12 @@ class IECOREIMAGE_API DisplayDriverServer : public IECore::RunTimeTyped
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( DisplayDriverServer, DisplayDriverServerTypeId, IECore::RunTimeTyped );
 
-		/// \todo: Switch to uint16_t as it offers a more appropriate range
+#if CORTEX_COMPATIBILITY_VERSION > MAKE_CORTEX_COMPATIBILITY_VERSION( 10, 1 )
+		using Port = uint16_t;
+#else
 		using Port = int;
+#endif
+
 		using PortRange = std::pair<Port, Port>;
 
 		/// A port number of 0 causes a free port to be chosen

--- a/src/IECoreImageBindings/DisplayDriverServerBinding.cpp
+++ b/src/IECoreImageBindings/DisplayDriverServerBinding.cpp
@@ -46,6 +46,34 @@ using namespace IECore;
 using namespace IECorePython;
 using namespace IECoreImage;
 
+namespace
+{
+
+void setPortRange( boost::python::tuple range )
+{
+	DisplayDriverServer::setPortRange( { extract<DisplayDriverServer::Port>( range[0] ), extract<DisplayDriverServer::Port>( range[1] ) } );
+}
+
+boost::python::tuple getPortRange()
+{
+	auto range = DisplayDriverServer::getPortRange();
+	return boost::python::make_tuple( range.first, range.second );
+}
+
+void registerPortRange( const std::string &name, boost::python::tuple range )
+{
+	DisplayDriverServer::registerPortRange( name, { extract<DisplayDriverServer::Port>( range[0] ), extract<DisplayDriverServer::Port>( range[1] ) } );
+}
+
+
+boost::python::tuple registeredPortRange( const std::string &name )
+{
+	auto range = DisplayDriverServer::registeredPortRange( name );
+	return boost::python::make_tuple( range.first, range.second );
+}
+
+} // namespace
+
 namespace IECoreImageBindings
 {
 
@@ -54,8 +82,13 @@ void bindDisplayDriverServer()
 	using boost::python::arg;
 
 	RunTimeTypedClass<DisplayDriverServer>()
-		.def( init< int >( ( arg( "portNumber" ) = 0 ) ) )
+		.def( init<DisplayDriverServer::Port>( ( arg( "portNumber" ) = 0 ) ) )
 		.def( "portNumber", &DisplayDriverServer::portNumber )
+		.def( "setPortRange", &::setPortRange ).staticmethod( "setPortRange" )
+		.def( "getPortRange", &::getPortRange ).staticmethod( "getPortRange" )
+		.def( "registerPortRange", &::registerPortRange ).staticmethod( "registerPortRange" )
+		.def( "deregisterPortRange", &DisplayDriverServer::deregisterPortRange ).staticmethod( "deregisterPortRange" )
+		.def( "registeredPortRange", &registeredPortRange ).staticmethod( "registeredPortRange" )
 	;
 
 }


### PR DESCRIPTION
This adds `setPortRange/getPortRange` which can be used to limit and query the allowed ports for all `IECoreImage.DisplayDriverServers` in a given session. At IE we'll be settings these limits via config file (also included in this PR).

I'm not sure if `V2i` was the right choice, but I found it awkward using separate `int` for min/max values, and `IECore.FrameRange` would include a `step` that doesn't make sense here...