### PR TITLE
DisplayDriverServer : Fix type used in range check

### DIFF
--- a/src/IECoreImage/DisplayDriverServer.cpp
+++ b/src/IECoreImage/DisplayDriverServer.cpp
@@ -126,7 +126,7 @@ class DisplayDriverServer::PrivateData : public RefCounted
 			m_acceptor( m_service ),
 			m_thread()
 		{
-			if( g_portRange.first != std::numeric_limits<int>::min() || g_portRange.second != std::numeric_limits<int>::max() )
+			if( g_portRange.first != std::numeric_limits<DisplayDriverServer::Port>::min() || g_portRange.second != std::numeric_limits<DisplayDriverServer::Port>::max() )
 			{
 				if( portNumber == 0 )
 				{


### PR DESCRIPTION
I'm going to be re-tagging 10.1.7.0 for #1148 so I thought this might as well get rebased onto RB-10.1 instead of #1147 where I'd targeted master.