### PR TITLE
IECore : Support MurmurHash::append for all types used by DataAlgo::dispatch

### DIFF
--- a/include/IECore/DateTimeData.h
+++ b/include/IECore/DateTimeData.h
@@ -53,6 +53,8 @@ namespace IECore
 /// the latter. See DateTimeData.cpp for further details.
 IECORE_DECLARE_TYPEDDATA( DateTimeData, boost::posix_time::ptime, void, SimpleDataHolder )
 
+IECORE_API void murmurHashAppend( IECore::MurmurHash &h, const boost::posix_time::ptime &time );
+
 } // namespace IECore
 
 #endif // IECORE_DATETIMEDATA_H

--- a/include/IECore/Spline.h
+++ b/include/IECore/Spline.h
@@ -37,6 +37,7 @@
 
 #include "IECore/CubicBasis.h"
 #include "IECore/Export.h"
+#include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathColor.h"
@@ -114,6 +115,9 @@ typedef Spline<double, double> Splinedd;
 
 typedef Spline<float, Imath::Color3f> SplinefColor3f;
 typedef Spline<float, Imath::Color4f> SplinefColor4f;
+
+template<typename X, typename Y>
+inline void murmurHashAppend( IECore::MurmurHash &h, const Spline<X,Y> &data );
 
 } // namespace IECore
 

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -372,6 +372,18 @@ inline bool Spline<X,Y>::operator!=( const Spline &rhs ) const
 	return basis!=rhs.basis || points!=rhs.points;
 }
 
+template<typename X, typename Y>
+inline void murmurHashAppend( IECore::MurmurHash &h, const Spline<X,Y> &data )
+{
+	h.append( data.basis.matrix );
+	h.append( data.basis.step );
+	for ( auto &p : data.points )
+	{
+		h.append( p.first );
+		h.append( p.second );
+	}
+}
+
 } // namespace IECore
 
 #endif // IECORE_SPLINE_INL

--- a/include/IECore/TransformationMatrix.h
+++ b/include/IECore/TransformationMatrix.h
@@ -36,6 +36,7 @@
 #define IE_CORE_TRANSFORMATIONMATRIX_H
 
 #include "IECore/Export.h"
+#include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathEuler.h"
@@ -86,6 +87,9 @@ class IECORE_EXPORT TransformationMatrix
 
 template<class T>
 std::ostream &operator << ( std::ostream &os, const TransformationMatrix<T> &x );
+
+template<class T>
+inline void murmurHashAppend( IECore::MurmurHash &h, const TransformationMatrix<T> &data );
 
 typedef TransformationMatrix<double> TransformationMatrixd;
 typedef TransformationMatrix<float> TransformationMatrixf;

--- a/include/IECore/TransformationMatrix.inl
+++ b/include/IECore/TransformationMatrix.inl
@@ -81,6 +81,20 @@ std::ostream &operator << ( std::ostream &os, const TransformationMatrix<T> &x )
 	return os;
 }
 
+template<class T>
+inline void murmurHashAppend( IECore::MurmurHash &h, const TransformationMatrix<T> &data )
+{
+	h.append( data.scalePivot );
+	h.append( data.scale );
+	h.append( data.shear );
+	h.append( data.scalePivotTranslation );
+	h.append( data.rotatePivot );
+	h.append( data.rotationOrientation );
+	h.append( data.rotate );
+	h.append( data.rotatePivotTranslation );
+	h.append( data.translate );
+}
+
 } // namespace IECore
 
 #endif // IE_CORE_TRANSFORMATIONMATRIX_INL

--- a/src/IECore/DateTimeData.cpp
+++ b/src/IECore/DateTimeData.cpp
@@ -106,13 +106,13 @@ void DateTimeData::load( LoadContextPtr context )
 	}
 }
 
-/// Here we specialise the SimpleDataHolder::hash() method to appropriately add our internal data to the hash.
-template<>
-void SimpleDataHolder<boost::posix_time::ptime>::hash( MurmurHash &h ) const
+template class TypedData< boost::posix_time::ptime >;
+
+void murmurHashAppend( IECore::MurmurHash &h, const boost::posix_time::ptime &time )
 {
-	h.append( boost::posix_time::to_iso_string( readable() ) );
+	// Kinda sloppy, but appears to be complete even for nanosecond resolution ptimes
+	h.append( boost::posix_time::to_iso_string( time ) );
 }
 
-template class TypedData< boost::posix_time::ptime >;
 
 } // namespace IECore

--- a/src/IECore/SplineData.cpp
+++ b/src/IECore/SplineData.cpp
@@ -117,22 +117,6 @@ IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( SplinefColor4fData, SplinefCol
 		m += sizeof( ValueType );																\
 		accumulator.accumulate( m );															\
 	}																							\
-\
-	template<>\
-	MurmurHash SharedDataHolder<TNAME::ValueType>::hash() const\
-	{\
-		MurmurHash result;\
-		const TNAME::ValueType &s = readable();\
-		result.append( s.basis.matrix );\
-		result.append( s.basis.step );\
-		TNAME::ValueType::PointContainer::const_iterator it;\
-		for( it=s.points.begin(); it!=s.points.end(); it++ )\
-		{\
-			result.append( it->first );\
-			result.append( it->second );\
-		}\
-		return result;\
-	}\
 
 SPECIALISE( SplineffData, float, 1 )
 SPECIALISE( SplineddData, double, 1 )

--- a/src/IECore/TransformationMatrixData.cpp
+++ b/src/IECore/TransformationMatrixData.cpp
@@ -121,22 +121,6 @@ static IndexedIO::EntryID g_valueEntry("value");
 		base.translate.y = *p++;																	\
 		base.translate.z = *p++;																	\
 	}\
-\
-	template<>\
-	void SimpleDataHolder<TNAME::ValueType>::hash( MurmurHash &h ) const\
-	{\
-		const TNAME::ValueType &v = readable();\
-		h.append( v.scalePivot );\
-		h.append( v.scale );\
-		h.append( v.shear );\
-		h.append( v.scalePivotTranslation );\
-		h.append( v.rotatePivot );\
-		h.append( v.rotationOrientation );\
-		h.append( v.rotate );\
-		h.append( v.rotate.order() );\
-		h.append( v.rotatePivotTranslation );\
-		h.append( v.translate );\
-	}\
 
 #define IE_CORE_DEFINEDATASPECIALISATION( TNAME, TID )							\
 	IECORE_RUNTIMETYPED_DEFINETEMPLATESPECIALISATION( TNAME, TID )					\

--- a/src/IECore/VectorTypedData.cpp
+++ b/src/IECore/VectorTypedData.cpp
@@ -214,29 +214,6 @@ void BoolVectorData::memoryUsage( Object::MemoryAccumulator &accumulator ) const
 }
 
 template<>
-MurmurHash SharedDataHolder<std::vector<bool> >::hash() const
-{
-	// we can't hash the raw data from inside the vector 'cos it's specialised
-	// to optimise for space, and that means the only access to the data is through
-	// a funny proxy class. so we repack the data into something we can deal with
-	// and hash that instead.
-	const std::vector<bool> &b = readable();
-	std::vector<unsigned char> p;
-	unsigned int s = b.size();
-	p.resize( s/8 + 1, 0 );
-	for( unsigned int i=0; i<b.size(); i++ )
-	{
-		if( b[i] )
-		{
-			p[i/8] |= 1 << (i % 8);
-		}
-	}
-	MurmurHash result;
-	result.append( &(p[0]), p.size() );
-	return result;
-}
-
-template<>
 void BoolVectorData::save( Object::SaveContext *context ) const
 {
 	Data::save( context );

--- a/src/IECorePython/MurmurHashBinding.cpp
+++ b/src/IECorePython/MurmurHashBinding.cpp
@@ -53,7 +53,7 @@ static std::string repr( const MurmurHash &hash )
 template<typename T>
 static void appendArray( MurmurHash &hash, typename TypedData<std::vector<T> >::ConstPtr data )
 {
-	hash.append( &(data->readable()[0]), data->readable().size() );
+	hash.append( data->readable() );
 }
 
 static void appendInt( MurmurHash &hash, int64_t v )
@@ -68,6 +68,11 @@ static void appendInt( MurmurHash &hash, int64_t v )
 	{
 		hash.append( v );
 	}
+}
+
+static long hash( MurmurHash *h )
+{
+	return h->h1();
 }
 
 void bindMurmurHash()
@@ -137,17 +142,18 @@ void bindMurmurHash()
 		.def( "append", &appendArray<Imath::Box3d>, return_self<>() )
 		.def( "append", &appendArray<Imath::Quatf>, return_self<>() )
 		.def( "append", &appendArray<Imath::Quatd>, return_self<>() )
+		.def( "append", &appendArray<bool>, return_self<>() )
 		.def( self == self )
 		.def( self != self )
 		.def( self < self )
 		.def( "copyFrom", &MurmurHash::operator=, return_self<>() )
 		.def( "__repr__", &repr )
 		.def( "__str__", &MurmurHash::toString )
+		.def( "__hash__", &hash )
 		.def( "toString", &MurmurHash::toString )
 		.def( "h1", &MurmurHash::h1 )
 		.def( "h2", &MurmurHash::h2 )
 	;
-
 }
 
 } // namespace IECorePython

--- a/test/IECore/MurmurHashTest.py
+++ b/test/IECore/MurmurHashTest.py
@@ -277,6 +277,9 @@ class MurmurHashTest( unittest.TestCase ) :
 			"7d797cac3609481774bec494f8c7dda7",
 		)
 
+	def testMurmurHashDispatch( self ):
+		IECore.testMurmurHashDispatch()
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
This makes it so that in a functor based to DataAlgo::dispatch, templated on T, you can call MurmurHash::append( T ).  This seems pretty useful.

The fixes are pretty straightforward:
* Spline and TransformationMatrix are easy to add just by hashing their components
* DataTimeData uses boost::posix_time::ptime, which is a bit tricky, because the storage format is undefined, and depending on build options, may be up to 96 bits.  I've gotten around this by using the string representation, which is a bit sloppy, but appears to support all possible representations, including special values - I'm not aware of anywhere performance critical where we're using DataTimeData, so this is probably fine for now.
* std::vector<bool> is a special case where we can't get a pointer to internal storage, because it's stored packed.  Hashing each element is slower, but std::vector<bool> should probably be avoided anywhere perf-critical ( possibly anywhere? )

Prereq for https://github.com/GafferHQ/gaffer/pull/4198