### PR TITLE
SceneCacheFileFormat : Fix compilation with GCC 9

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -198,7 +198,7 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 				{
 					sceneToLink = SharedSceneInterfaces::get( filePath );
 				}
-				catch( IOException )
+				catch( const IOException & )
 				{
 					IECore::msg(
 						IECore::Msg::Warning,


### PR DESCRIPTION
This was the error :

```
contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp:201:12: error: catching polymorphic type 'class IECore::IOException' by value [-Werror=catch-value=]
```