### PR TITLE
IECoreUSDModule : add bindings for dataAlgo

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/bindings/IEUSDModule.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/bindings/IEUSDModule.cpp
@@ -32,8 +32,19 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
+#include "IECoreUSD/DataAlgo.h"
+
 #include "boost/python.hpp"
+
+using namespace boost::python;
+using namespace IECoreUSD;
 
 BOOST_PYTHON_MODULE( _IECoreUSD )
 {
+    object dataAlgoModule( handle<>( borrowed( PyImport_AddModule( "IECoreUSD.DataAlgo" ) ) ) );
+    scope().attr( "DataAlgo" ) = dataAlgoModule;
+    scope dataAlgoModuleScope( dataAlgoModule );
+
+    def( "role", &DataAlgo::role );
+    def( "valueTypeName", &DataAlgo::valueTypeName );
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/All.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/All.py
@@ -39,6 +39,7 @@ import IECore
 
 from USDSceneTest import USDSceneTest
 from SceneCacheFileFormatTest import SceneCacheFileFormatTest
+from DataAlgoTest import DataAlgoTest
 
 unittest.TestProgram(
 	testRunner = unittest.TextTestRunner(

--- a/contrib/IECoreUSD/test/IECoreUSD/DataAlgoTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/DataAlgoTest.py
@@ -1,0 +1,72 @@
+##########################################################################
+#
+#  Copyright (c) 2021, Hypothetical Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in the
+#       documentation and/or other materials provided with the distribution.
+#
+#     * Neither the name of Image Engine Design nor the names of any
+#       other contributors to this software may be used to endorse or
+#       promote products derived from this software without specific prior
+#       written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+#  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+#  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+#  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+#  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+#  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+#  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+#  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+#  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+#  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+#  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+##########################################################################
+
+import unittest
+import imath
+
+import IECore
+import IECoreUSD
+
+class DataAlgoTest( unittest.TestCase ) :
+
+    def testRoleBinding( self ) :
+        
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.Point ), "Point" )
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.Vector ), "Vector" )
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.Normal ), "Normal" )
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.UV ), "TextureCoordinate" )
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.Color ), "Color" )
+        self.assertEqual( IECoreUSD.DataAlgo.role( IECore.GeometricData.Interpretation.Rational ), "" )
+
+    def testValueTypeNameBinding( self ) :
+
+        v3 = IECore.V3fData( imath.V3f( 0.0 ) )
+        v2 = IECore.V2fData( imath.V2f( 0.0 ) )
+
+        v3.setInterpretation( IECore.GeometricData.Interpretation.Point )
+        self.assertEqual( IECoreUSD.DataAlgo.valueTypeName( v3 ).type.typeName, "GfVec3f" )
+
+        v3.setInterpretation( IECore.GeometricData.Interpretation.Vector )
+        self.assertEqual( IECoreUSD.DataAlgo.valueTypeName( v3 ).type.typeName, "GfVec3f" )
+
+        v3.setInterpretation( IECore.GeometricData.Interpretation.Normal )
+        self.assertEqual( IECoreUSD.DataAlgo.valueTypeName( v3 ).type.typeName, "GfVec3f" )
+
+        v2.setInterpretation( IECore.GeometricData.Interpretation.UV )
+        self.assertEqual( IECoreUSD.DataAlgo.valueTypeName( v2 ).type.typeName, "GfVec2f" )
+
+        self.assertEqual( IECoreUSD.DataAlgo.valueTypeName( IECore.Color3fData( imath.Color3f( 0.0 ) ) ).type.typeName, "GfVec3f" )
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add bindings for select IECoreUSD functions. In addition to making these functions available in Python, Windows no longer optimizes away the entire module and we can avoid introducing a new Python import scheme based on dynamic module loading.

### Related Issues ###

More background is in #1154, #938 and #940.

### Breaking Changes ###

- None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
- [X] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
