### PR TITLE
FromHoudiniPointsConverter : Fix seg faults transferring string attributes

### DIFF
--- a/src/IECoreHoudini/FromHoudiniPointsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPointsConverter.cpp
@@ -81,7 +81,11 @@ ObjectPtr FromHoudiniPointsConverter::doDetailConversion( const GU_Detail *geo, 
 {
 	PointsPrimitivePtr result = new PointsPrimitive( geo->getNumPoints() );
 
-	transferAttribs( geo, result.get(), operands, PrimitiveVariable::Vertex );
+	// If points are present, transfer the attributes, otherwise return the empty PointsPrimitive
+	if ( geo->getNumPoints() )
+	{
+		transferAttribs( geo, result.get(), operands, PrimitiveVariable::Vertex );
+	}
 
 	return result;
 }

--- a/test/IECoreHoudini/FromHoudiniPointsConverter.py
+++ b/test/IECoreHoudini/FromHoudiniPointsConverter.py
@@ -1031,5 +1031,27 @@ class TestFromHoudiniPointsConverter( IECoreHoudini.TestCase ) :
 		self.assertEqual( result["rest"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
 		self.assertEqual( result["N"].data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
 
+	# testing that we don't transfer attributes and get an empty PointsPrimitive in case of zero points present in Houdini
+	def testZeroPoints( self ):
+
+		obj = hou.node( "/obj" )
+		geo = obj.createNode( "geo", run_init_scripts=False )
+		null = geo.createNode( "null" )
+		pointAttr = geo.createNode( "attribcreate", exact_type_name=True )
+		pointAttr.setInput( 0, null )
+		pointAttr.parm( "name" ).set( "test_attribute" )
+		pointAttr.parm( "type" ).set( 3 )
+		pointAttr.parm( "string" ).set( "test_string" )
+
+		converter = IECoreHoudini.FromHoudiniPointsConverter( pointAttr )
+		self.assertTrue( converter.isInstanceOf( IECore.TypeId( IECoreHoudini.TypeId.FromHoudiniPointsConverter ) ) )
+
+		result = converter.convert()
+		self.assertTrue( result.isInstanceOf( IECoreScene.TypeId.PointsPrimitive ) )
+		self.assertTrue( result.arePrimitiveVariablesValid() )
+		self.assertEqual( result.numPoints, 0 )
+		self.assertFalse( result.values() )
+
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Writing a point cache to disk will make Houdini crash with a segmentation fault transferring string attributes from Houdini to the Cortex PointsPrimitive if there are no points in the GU_Detail. This can, for example, happen with a particle simulation where no particles have been emitted yet, but we still want to export the whole frame range.

The changes in this PR avoid the Houdini crashes by skipping the attribute transfer completely if no points are present in the GU_Detail. There further is no need to transfer empty attributes (the "P" attribute is always present, although empty) and returning an empty PointsPrimitive is sufficient at this point.