### PR TITLE
Scene cache data improvements

### DIFF
--- a/contrib/IECoreUSD/include/IECoreUSD/SceneCacheDataAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/SceneCacheDataAlgo.h
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREUSD_SCENECACHEDATAALGO_H
+#define IECOREUSD_SCENECACHEDATAALGO_H
+
+#include "IECoreUSD/Export.h"
+
+#include "IECoreScene/SceneInterface.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/base/tf/token.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
+// SceneCacheDataAlgo is suite of utilities used by SceneCacheData and SceneCacheFileFormat
+// classes responsible for loading Cortex Scene Cache Data into USD.
+// This header can be ignored in most other usage of IECoreUSD.
+
+namespace IECoreUSD
+{
+
+namespace SceneCacheDataAlgo
+{
+
+IECOREUSD_API pxr::TfToken internalRootNameToken();
+IECOREUSD_API IECore::InternedString internalRootName();
+IECOREUSD_API IECoreScene::SceneInterface::Path fromInternalPath( const IECoreScene::SceneInterface::Path& scenePath );
+IECOREUSD_API IECoreScene::SceneInterface::Path toInternalPath( const IECoreScene::SceneInterface::Path& scenePath );
+IECOREUSD_API std::string fromInternalName( const IECore::InternedString& name );
+IECOREUSD_API std::string toInternalName( const IECore::InternedString& name );
+
+} // namespace SceneCacheDataAlgo
+
+} // namespace IECoreUSD
+
+
+#endif // IECOREUSD_SCENECACHEDATAALGO_H

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -105,6 +105,7 @@ static InternedString g_ioType( "type" );
 static InternedString g_ioIndices( "indices" );
 static const SceneInterface::Path g_mayaFpsHeaderPath = { "header", "data", "CompoundObject", "data", "members", "maya", "data", "CompoundDataBase", "data", "members", "frameRate", "data"};
 static const SceneInterface::Path g_houdiniFpsHeaderPath = { "header", "data", "CompoundObject", "data", "members", "houdini", "data", "CompoundDataBase", "data", "members", "frameRate", "data"};
+static const VtValue g_empty = VtValue();
 } // namespace
 
 SceneCacheData::SceneCacheData( SdfFileFormat::FileFormatArguments args )
@@ -1250,7 +1251,7 @@ VtValue SceneCacheData::Get(const SdfPath &path, const TfToken & field) const
 	{
 		return *value;
 	}
-	return VtValue();
+	return g_empty;
 }
 
 void SceneCacheData::Set(const SdfPath &path, const TfToken & field, const VtValue& value)
@@ -1448,20 +1449,20 @@ bool SceneCacheData::GetBracketingTimeSamplesForPath( const SdfPath &path, doubl
 	return false;
 }
 
-const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time ) const
+const VtValue SceneCacheData::queryTimeSample( const SdfPath &path, double time ) const
 {
 	auto scenePath = USDScene::fromUSD( path.GetParentPath() );
 	auto currentScene = m_scene->scene( scenePath, SceneInterface::MissingBehaviour::NullIfMissing );
 	// ignore collection path
 	if ( !currentScene )
 	{
-		return nullptr;
+		return g_empty;
 	}
 	auto attributeName = path.GetNameToken();
 	if ( attributeName == g_xformTransform )
 	{
 		auto transform = currentScene->readTransformAsMatrix( frameToTime( time ) );
-		return new VtValue( DataAlgo::toUSD( transform ) );
+		return VtValue( DataAlgo::toUSD( transform ) );
 	}
 	else if ( attributeName == UsdGeomTokens->extent )
 	{
@@ -1469,7 +1470,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		VtArray<GfVec3f> extent;
 		extent.push_back( DataAlgo::toUSD( V3f( bound.min ) ) );
 		extent.push_back( DataAlgo::toUSD( V3f( bound.max ) ) );
-		return new VtValue( extent );
+		return VtValue( extent );
 	}
 	else if ( attributeName == UsdGeomTokens->visibility )
 	{
@@ -1477,16 +1478,16 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			if ( runTimeCast<const BoolData>( currentScene->readAttribute( SceneInterface::visibilityName, frameToTime( time ) ) )->readable() )
 			{
-				return new VtValue( UsdGeomTokens->inherited );
+				return VtValue( UsdGeomTokens->inherited );
 			}
 			else
 			{
-				return new VtValue( UsdGeomTokens->invisible );
+				return VtValue( UsdGeomTokens->invisible );
 			}
 		}
 		else
 		{
-			return new VtValue( UsdGeomTokens->inherited );
+			return VtValue( UsdGeomTokens->inherited );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->points )
@@ -1498,7 +1499,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 			if( pointsPrimVarIt != primitive->variables.end() )
 			{
 				auto usdPoints = PrimitiveAlgo::toUSDExpanded( pointsPrimVarIt->second );
-				return new VtValue( usdPoints );
+				return VtValue( usdPoints );
 			}
 		}
 	}
@@ -1511,7 +1512,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 			if( uvPrimVarIt != primitive->variables.end() )
 			{
 				auto usdST = DataAlgo::toUSD( uvPrimVarIt->second.data.get() );
-				return new VtValue( usdST );
+				return VtValue( usdST );
 			}
 		}
 	}
@@ -1526,7 +1527,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 				if ( auto uvIndices = uvPrimVarIt->second.indices )
 				{
 					auto usdStIndices = DataAlgo::toUSD( uvIndices.get() );
-					return new VtValue( usdStIndices );
+					return VtValue( usdStIndices );
 				}
 				else
 				{
@@ -1536,7 +1537,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 					{
 						identityUvIndices.push_back( i );
 					}
-					return new VtValue( DataAlgo::toUSD( identityUvIndicesData.get() ) );
+					return VtValue( DataAlgo::toUSD( identityUvIndicesData.get() ) );
 				}
 			}
 		}
@@ -1550,7 +1551,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 			if( normalsPrimVarIt != primitive->variables.end() )
 			{
 				auto usdNormals = PrimitiveAlgo::toUSDExpanded( normalsPrimVarIt->second );
-				return new VtValue( usdNormals );
+				return VtValue( usdNormals );
 			}
 		}
 	}
@@ -1565,7 +1566,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 				if ( auto normalsIndices = normalsPrimVarIt->second.indices )
 				{
 					auto usdStIndices = DataAlgo::toUSD( normalsIndices.get() );
-					return new VtValue( usdStIndices );
+					return VtValue( usdStIndices );
 				}
 				else
 				{
@@ -1575,7 +1576,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 					{
 						identityNormalsIndices.push_back( i );
 					}
-					return new VtValue( DataAlgo::toUSD( identityNormalsIndicesData.get() ) );
+					return VtValue( DataAlgo::toUSD( identityNormalsIndicesData.get() ) );
 				}
 			}
 		}
@@ -1586,7 +1587,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdFaceVertexCounts = DataAlgo::toUSD( mesh->verticesPerFace() );
-			return new VtValue( usdFaceVertexCounts );
+			return VtValue( usdFaceVertexCounts );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->curveVertexCounts )
@@ -1595,7 +1596,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto curves = dynamic_cast<const CurvesPrimitive *>( object.get() ) )
 		{
 			auto usdCurveVertexCounts = DataAlgo::toUSD( curves->verticesPerCurve() );
-			return new VtValue( usdCurveVertexCounts );
+			return VtValue( usdCurveVertexCounts );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->basis )
@@ -1623,7 +1624,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 
 			if( !basis.IsEmpty() )
 			{
-				return new VtValue( basis );
+				return VtValue( basis );
 			}
 		}
 	}
@@ -1634,11 +1635,11 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			if( curves->basis() == CubicBasisf::linear() )
 			{
-				return new VtValue( UsdGeomTokens->linear );
+				return VtValue( UsdGeomTokens->linear );
 			}
 			else
 			{
-				return new VtValue( UsdGeomTokens->cubic );
+				return VtValue( UsdGeomTokens->cubic );
 			}
 		}
 	}
@@ -1651,7 +1652,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 			if( widthPrimVarIt != primitive->variables.end() )
 			{
 				auto usdwidth = PrimitiveAlgo::toUSDExpanded( widthPrimVarIt->second );
-				return new VtValue( usdwidth );
+				return VtValue( usdwidth );
 			}
 		}
 	}
@@ -1662,7 +1663,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			float scale = 10.0f * camera->getFocalLengthWorldScale();
 			auto usdFocal = DataAlgo::toUSD( camera->getFocalLength() * scale );
-			return new VtValue( usdFocal );
+			return VtValue( usdFocal );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->horizontalAperture )
@@ -1672,7 +1673,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			float scale = 10.0f * camera->getFocalLengthWorldScale();
 			auto usdHorizontalAperture = DataAlgo::toUSD( camera->getAperture()[0] * scale );
-			return new VtValue( usdHorizontalAperture );
+			return VtValue( usdHorizontalAperture );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->verticalAperture )
@@ -1682,7 +1683,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			float scale = 10.0f * camera->getFocalLengthWorldScale();
 			auto usdverticalAperture = DataAlgo::toUSD( camera->getAperture()[1] * scale );
-			return new VtValue( usdverticalAperture );
+			return VtValue( usdverticalAperture );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->horizontalApertureOffset )
@@ -1692,7 +1693,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			float scale = 10.0f * camera->getFocalLengthWorldScale();
 			auto usdHorizontalApertureOffset = DataAlgo::toUSD( camera->getApertureOffset()[0] * scale );
-			return new VtValue( usdHorizontalApertureOffset );
+			return VtValue( usdHorizontalApertureOffset );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->verticalApertureOffset )
@@ -1702,7 +1703,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		{
 			float scale = 10.0f * camera->getFocalLengthWorldScale();
 			auto usdverticalApertureOffset = DataAlgo::toUSD( camera->getApertureOffset()[1] * scale );
-			return new VtValue( usdverticalApertureOffset );
+			return VtValue( usdverticalApertureOffset );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->faceVertexIndices )
@@ -1711,7 +1712,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdVerticesPerFace = DataAlgo::toUSD( mesh->vertexIds() );
-			return new VtValue( usdVerticesPerFace );
+			return VtValue( usdVerticesPerFace );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->cornerIndices )
@@ -1720,7 +1721,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdCornerIndices = DataAlgo::toUSD( mesh->cornerIds() );
-			return new VtValue( usdCornerIndices );
+			return VtValue( usdCornerIndices );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->cornerSharpnesses )
@@ -1729,7 +1730,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdCornerSharpnesses = DataAlgo::toUSD( mesh->cornerSharpnesses() );
-			return new VtValue( usdCornerSharpnesses );
+			return VtValue( usdCornerSharpnesses );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->creaseIndices )
@@ -1738,7 +1739,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdCreaseIndices = DataAlgo::toUSD( mesh->creaseIds() );
-			return new VtValue( usdCreaseIndices );
+			return VtValue( usdCreaseIndices );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->creaseLengths )
@@ -1747,7 +1748,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdCreaseLength = DataAlgo::toUSD( mesh->creaseLengths() );
-			return new VtValue( usdCreaseLength );
+			return VtValue( usdCreaseLength );
 		}
 	}
 	else if ( attributeName == UsdGeomTokens->creaseSharpnesses )
@@ -1756,7 +1757,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 		if ( auto mesh = dynamic_cast<const MeshPrimitive *>( object.get() ) )
 		{
 			auto usdCreaseSharpnesses = DataAlgo::toUSD( mesh->creaseSharpnesses() );
-			return new VtValue( usdCreaseSharpnesses );
+			return VtValue( usdCreaseSharpnesses );
 		}
 	}
 	else
@@ -1785,7 +1786,7 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 						if ( auto customIndices = customPrimVarIt->second.indices )
 						{
 							auto usdStIndices = DataAlgo::toUSD( customIndices.get() );
-							return new VtValue( usdStIndices );
+							return VtValue( usdStIndices );
 						}
 						else
 						{
@@ -1795,29 +1796,29 @@ const VtValue* SceneCacheData::queryTimeSample( const SdfPath &path, double time
 							{
 								identityCustomIndices.push_back( i );
 							}
-							return new VtValue( DataAlgo::toUSD( identityCustomIndicesData.get() ) );
+							return VtValue( DataAlgo::toUSD( identityCustomIndicesData.get() ) );
 						}
 					}
 					else
 					{
 						auto usdCustomPrimVar = PrimitiveAlgo::toUSDExpanded( customPrimVarIt->second );
-						return new VtValue( usdCustomPrimVar );
+						return VtValue( usdCustomPrimVar );
 					}
 				}
 			}
 		}
 	}
-	return nullptr;
+	return g_empty;
 }
 
 bool SceneCacheData::QueryTimeSample(const SdfPath &path, double time, VtValue *value) const
 {
 	auto result = queryTimeSample( path, time );
-	if ( result )
+	if ( result != g_empty )
 	{
 		if ( value )
 		{
-			*value = *result;
+			*value = result;
 		}
 		return true;
 	}
@@ -1842,9 +1843,9 @@ bool SceneCacheData::QueryTimeSample(const SdfPath &path, double time, VtValue *
 bool SceneCacheData::QueryTimeSample(const SdfPath &path, double time, SdfAbstractDataValue* value) const
 {
 	auto result = queryTimeSample( path, time );
-	if ( result )
+	if ( result != g_empty )
 	{
-		return !value || value->StoreValue( *result );
+		return !value || value->StoreValue( result );
 	}
 	else
 	{

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -489,7 +489,7 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 
 					// curve type
 					properties.push_back( UsdGeomTokens->type );
-					addProperty( primPath, UsdGeomTokens->type, SdfValueTypeNames->Token, false, SdfVariabilityVarying );
+					addProperty( primPath, UsdGeomTokens->type, SdfValueTypeNames->Token, false, SdfVariabilityVarying, &UsdGeomTokens->linear, false );
 
 					// curve basis
 					properties.push_back( UsdGeomTokens->basis );

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
@@ -170,9 +170,13 @@ private:
 	typedef std::map<std::string, std::vector<SdfPath>> collection;
 	collection m_collections;
 
+	typedef std::map<IECoreScene::SceneInterface::Path, IECoreScene::SceneInterface::Path> internalPathMap;
+	internalPathMap m_internalPaths;
+
 	void addCollections( SpecData& spec, TfTokenVector& properties, const SdfPath& primPath );
 	void addReference( IECoreScene::ConstSceneInterfacePtr scene, SpecData& spec, TfTokenVector& children );
 	void addValueClip( SpecData& spec, const VtVec2dArray times, const VtVec2dArray actives, const std::string& assetPath, const std::string& primPath);
+	void addInternalRoot( TfTokenVector children );
 
 	VtValue getTimeSampleMap( const SdfPath& path, const TfToken& field, const VtValue& value ) const;
 

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
@@ -116,7 +116,7 @@ protected:
 
 	void _VisitSpecs(SdfAbstractDataSpecVisitor* visitor) const override;
 private:
-	const VtValue * queryTimeSample(const SdfPath& path, double time) const;
+	const VtValue queryTimeSample(const SdfPath& path, double time) const;
 
 	const VtValue* GetSpecTypeAndFieldValue(const SdfPath& path, const TfToken& field, SdfSpecType* specType) const;
 	const VtValue* GetFieldValue(const SdfPath& path, const TfToken& field) const;

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
@@ -118,8 +118,8 @@ protected:
 private:
 	const VtValue queryTimeSample(const SdfPath& path, double time) const;
 
-	const VtValue* GetSpecTypeAndFieldValue(const SdfPath& path, const TfToken& field, SdfSpecType* specType) const;
-	const VtValue* GetFieldValue(const SdfPath& path, const TfToken& field) const;
+	const VtValue GetSpecTypeAndFieldValue(const SdfPath& path, const TfToken& field, SdfSpecType* specType) const;
+	const VtValue GetFieldValue(const SdfPath& path, const TfToken& field, bool loadTimeSampleMap=true) const;
 
 	VtValue* GetMutableFieldValue(const SdfPath& path, const TfToken& field);
 	VtValue* GetOrCreateFieldValue(const SdfPath& path, const TfToken& field);
@@ -173,6 +173,8 @@ private:
 	void addCollections( SpecData& spec, TfTokenVector& properties, const SdfPath& primPath );
 	void addReference( IECoreScene::ConstSceneInterfacePtr scene, SpecData& spec, TfTokenVector& children );
 	void addValueClip( SpecData& spec, const VtVec2dArray times, const VtVec2dArray actives, const std::string& assetPath, const std::string& primPath);
+
+	VtValue getTimeSampleMap( const SdfPath& path, const TfToken& field, const VtValue& value ) const;
 
 	const SdfFileFormat::FileFormatArguments m_arguments;
 	IECoreScene::ConstSceneInterfacePtr m_scene;

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheDataAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheDataAlgo.cpp
@@ -1,0 +1,139 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreUSD/SceneCacheDataAlgo.h"
+
+#include "boost/algorithm/string/replace.hpp"
+#include <boost/iostreams/filter/regex.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/regex.hpp>
+
+using namespace boost::iostreams;
+using namespace IECoreScene;
+using namespace IECoreUSD;
+using namespace pxr;
+
+
+namespace
+{
+static const IECore::InternedString g_internalRootName( "__IECOREUSD_ROOT" );
+static const pxr::TfToken g_internalRootNameToken( "__IECOREUSD_ROOT" );
+static const IECore::InternedString g_hyphen( "-" );
+static const IECore::InternedString g_hyphenSubstitute( std::string( 5, '_' ) );
+static const IECore::InternedString g_closingParenthesis( ")" );
+static const IECore::InternedString g_closingParenthesisSub( std::string( 3, '_' ) );
+static const IECore::InternedString g_openingParenthesis( "(" );
+static const IECore::InternedString g_openingParenthesisSub( std::string( 4, '_' ) );
+static const regex_filter g_filterHyphenFromInternal( boost::regex( g_hyphenSubstitute.value() ), g_hyphen.value() );
+static const regex_filter g_filterOpeningParenthesisFromInternal( boost::regex( g_openingParenthesisSub.value() ), g_openingParenthesis.value() );
+static const regex_filter g_filterClosingParenthesisFromInternal( boost::regex( g_closingParenthesisSub.value() ), g_closingParenthesis.value() );
+static const regex_filter g_filterHyphenToInternal( boost::regex( g_hyphen.value() ), g_hyphenSubstitute.value() );
+static const regex_filter g_filterOpeningParenthesisToInternal( boost::regex( "\\(" ), g_openingParenthesisSub.value() );
+static const regex_filter g_filterClosingParenthesisToInternal( boost::regex( "\\)" ), g_closingParenthesisSub.value() );
+}
+
+IECore::InternedString IECoreUSD::SceneCacheDataAlgo::internalRootName()
+{
+	return g_internalRootName;
+}
+
+pxr::TfToken IECoreUSD::SceneCacheDataAlgo::internalRootNameToken()
+{
+	return g_internalRootNameToken;
+}
+
+SceneInterface::Path IECoreUSD::SceneCacheDataAlgo::toInternalPath( const IECoreScene::SceneInterface::Path& scenePath )
+{
+	SceneInterface::Path result;
+	result.reserve( scenePath.size() + 1 );
+
+	if ( scenePath != SceneInterface::rootPath )
+	{
+		result.emplace_back( g_internalRootName );
+	}
+	for( auto& element : scenePath )
+	{
+		result.emplace_back( toInternalName( element ) );
+	}
+
+	return result;
+}
+
+SceneInterface::Path IECoreUSD::SceneCacheDataAlgo::fromInternalPath( const SceneInterface::Path& scenePath )
+{
+	SceneInterface::Path result;
+	result.reserve( scenePath.size() );
+	for( size_t i=0, end=scenePath.size(); i<end; i++ )
+	{
+		if ( i == 0 && scenePath[i] == g_internalRootName )
+		{
+			continue;
+		}
+		result.emplace_back( fromInternalName( scenePath[i] ) );
+	}
+
+	return result;
+}
+
+std::string IECoreUSD::SceneCacheDataAlgo::fromInternalName( const IECore::InternedString& name )
+{
+	std::string result;
+	filtering_ostream out;
+
+	out.push( g_filterHyphenFromInternal );
+	out.push( g_filterOpeningParenthesisFromInternal );
+	out.push( g_filterClosingParenthesisFromInternal );
+	out.push( back_inserter( result ) );
+
+	out<<name;
+	out.flush();
+
+	return result;
+}
+
+std::string IECoreUSD::SceneCacheDataAlgo::toInternalName( const IECore::InternedString& name )
+{
+	std::string result;
+	filtering_ostream out;
+
+	out.push( g_filterHyphenToInternal );
+	out.push( g_filterOpeningParenthesisToInternal );
+	out.push( g_filterClosingParenthesisToInternal );
+	out.push( back_inserter( result ) );
+
+	out<<name;
+	out.flush();
+
+	return result;
+}

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -171,7 +171,7 @@ void writeSetInternal( const pxr::UsdPrim &prim, const pxr::TfToken &name, const
 				continue;
 			}
 			pxr::UsdPrim childPrim = prim.GetStage()->DefinePrim( USDScene::toUSD( *it ) );
-			writeSetInternal( childPrim, name, set.subTree( *it ) );
+			writeSetInternal( childPrim, validName( name ), set.subTree( *it ) );
 			it.prune(); // Only visit children of root
 		}
 		return;
@@ -185,11 +185,11 @@ void writeSetInternal( const pxr::UsdPrim &prim, const pxr::TfToken &name, const
 
 #if USD_VERSION < 2009
 
-	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::ApplyCollection( prim, name, pxr::UsdTokens->explicitOnly );
+	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::ApplyCollection( prim, validName( name ), pxr::UsdTokens->explicitOnly );
 
 #else
 
-	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::Apply( prim, name );
+	pxr::UsdCollectionAPI collection = pxr::UsdCollectionAPI::Apply( prim, validName( name ) );
 	collection.CreateExpansionRuleAttr( pxr::VtValue( pxr::UsdTokens->explicitOnly ) );
 
 #endif


### PR DESCRIPTION
Given how USD `reference` works, referenced root from an external hierarchy **is not included** in the resulting hierarchy

- We are introducing an `internal root` in the hierarchy that will be **ignored** when referencing a `Scene Cache` file ( including for `Linked Scene Cache` converted as `reference` at runtime ).

- When loading Scene Cache as `sublayer`, the internal root will be visible but it will be skipped when writing out a Scene Cache file, allowing round tripping.

Fixes
---

- SceneCacheData: Avoid memory leaks with `queryTimeSamples` (#1158 )

Improvements
---

- SceneCacheData: Complete implementation for method requesting entire `timeSamples` field (#1158 )
- Support round tripping tags/hierarchy child names that are invalid for USD ( hyphen and parenthesis ) (#1158)


### Related Issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

- List any other unmerged PRs that this PR depends on

### Breaking Changes ###

- List any breaking API/ABI changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
