### PR TITLE
Build options for rv 2021

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1915,6 +1915,11 @@ if doConfigure :
 		imageTestEnv = testEnv.Clone()
 		imageTestEnv["ENV"]["PYTHONPATH"] = imageTestEnv["ENV"]["PYTHONPATH"] + ":python"
 
+		imageEnvLibPath = ":".join( imageEnvPrepends["LIBPATH"] )
+		imageLibs = imageTestEnv.subst( imageEnvLibPath )
+		imageTestLibs = imageTestEnv["ENV"][imageTestEnv["TEST_LIBRARY_PATH_ENV_VAR"]]
+		imageTestEnv["ENV"][imageTestEnv["TEST_LIBRARY_PATH_ENV_VAR"]] = ":".join( [imageLibs, imageTestLibs] )
+
 		imageTest = imageTestEnv.Command( "test/IECoreImage/results.txt", imagePythonModule, "$PYTHON $TEST_IMAGE_SCRIPT --verbose" )
 		NoCache( imageTest )
 		imageTestEnv.Depends( imageTest, [ corePythonModule + imagePythonModule ]  )

--- a/config/ie/options
+++ b/config/ie/options
@@ -415,14 +415,16 @@ if targetApp=="rv" :
 	rvLibs = os.path.join( rvRoot, "lib" )
 
 	if distutils.version.LooseVersion(rvVersion) >= distutils.version.LooseVersion("7.8.0"):
-		BOOST_INCLUDE_PATH = rvIncludes
-		BOOST_LIB_PATH = rvLibs
-		BOOST_LIB_SUFFIX = rvReg.get( "boostLibSuffix", BOOST_LIB_SUFFIX )
+		if "boostVersion" in rvReg:
+			BOOST_INCLUDE_PATH = rvIncludes
+			BOOST_LIB_PATH = rvLibs
+			BOOST_LIB_SUFFIX = rvReg.get( "boostLibSuffix", BOOST_LIB_SUFFIX )
 
-		# NOTE: At the moment RV doesn't provide OIIO headers, so we rely on
-		# the default `OIIO_INCLUDE_PATH` value.
-		OIIO_LIB_PATH = rvLibs
-		OIIO_LIB_SUFFIX = rvReg.get( "OpenImageIOLibSuffix", OIIO_LIB_SUFFIX )
+		if "OpenImageIOVersion" in rvReg:
+			# NOTE: At the moment RV doesn't provide OIIO headers, so we rely on
+			# the default `OIIO_INCLUDE_PATH` value.
+			OIIO_LIB_PATH = rvLibs
+			OIIO_LIB_SUFFIX = rvReg.get( "OpenImageIOLibSuffix", OIIO_LIB_SUFFIX )
 
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )


### PR DESCRIPTION
The last few versions of RV gave us some trouble because of several incompatibilities with our build environment, sometimes forcing us to use our own libraries and sometimes the ones provided by RV.
These changes should give us more flexibility in managing incompatibilities by setting or not setting `boostVersion` and `OpenImageIOVersion` in the IE Registry for each given RV version, rather than having to update the options file every time.
Until the VFX Platform solves this problem for us, of course.

**NOTE:** IECoreImage tests are still not passing when run via scons, they crash at the first `import IECoreImage` call. Running the test code inside an RV session works.

Build
---
- update IE config options to support RV 2021.x.x (#????)
- add library paths to IECoreImage test env (#????)


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] ~I have updated the documentation, if applicable.~
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] ~If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.~
