### PR TITLE
IECoreHoudini : Fix empty points with string attribs

### DIFF
--- a/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniGeometryConverter.cpp
@@ -785,6 +785,11 @@ void FromHoudiniGeometryConverter::transferTags( const GU_Detail *geo, Primitive
 DataPtr FromHoudiniGeometryConverter::extractStringVectorData( const GA_Attribute *attr, const GA_Range &range, IntVectorDataPtr &indexData ) const
 {
 	StringVectorDataPtr data = new StringVectorData();
+	if( range.empty() )
+	{
+		// we return early in this case to avoid building invalid indices
+		return data;
+	}
 
 	size_t numStrings = 0;
 	std::vector<std::string> strings;

--- a/src/IECoreHoudini/FromHoudiniPointsConverter.cpp
+++ b/src/IECoreHoudini/FromHoudiniPointsConverter.cpp
@@ -61,6 +61,8 @@ FromHoudiniGeometryConverter::Convertability FromHoudiniPointsConverter::canConv
 	size_t numPrims = geo->getNumPrimitives();
 	if ( !numPrims )
 	{
+		/// \todo: An alternative to consider would be to register a `FromHoudiniNullConverter` as the `Ideal`
+		/// converter when there are also no points in the detail.
 		return Ideal;
 	}
 
@@ -81,11 +83,7 @@ ObjectPtr FromHoudiniPointsConverter::doDetailConversion( const GU_Detail *geo, 
 {
 	PointsPrimitivePtr result = new PointsPrimitive( geo->getNumPoints() );
 
-	// If points are present, transfer the attributes, otherwise return the empty PointsPrimitive
-	if ( geo->getNumPoints() )
-	{
-		transferAttribs( geo, result.get(), operands, PrimitiveVariable::Vertex );
-	}
+	transferAttribs( geo, result.get(), operands, PrimitiveVariable::Vertex );
 
 	return result;
 }

--- a/test/IECoreHoudini/FromHoudiniPointsConverter.py
+++ b/test/IECoreHoudini/FromHoudiniPointsConverter.py
@@ -1031,8 +1031,7 @@ class TestFromHoudiniPointsConverter( IECoreHoudini.TestCase ) :
 		self.assertEqual( result["rest"].data.getInterpretation(), IECore.GeometricData.Interpretation.Point )
 		self.assertEqual( result["N"].data.getInterpretation(), IECore.GeometricData.Interpretation.Normal )
 
-	# testing that we don't transfer attributes and get an empty PointsPrimitive in case of zero points present in Houdini
-	def testZeroPoints( self ):
+	def testZeroPointsWithStringAttribs( self ):
 
 		obj = hou.node( "/obj" )
 		geo = obj.createNode( "geo", run_init_scripts=False )
@@ -1050,8 +1049,10 @@ class TestFromHoudiniPointsConverter( IECoreHoudini.TestCase ) :
 		self.assertTrue( result.isInstanceOf( IECoreScene.TypeId.PointsPrimitive ) )
 		self.assertTrue( result.arePrimitiveVariablesValid() )
 		self.assertEqual( result.numPoints, 0 )
-		self.assertFalse( result.values() )
-
+		self.assertEqual( result.keys(), [ "P", "test_attribute", "varmap" ] )
+		self.assertEqual( result["P"].data, IECore.V3fVectorData( [], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( result["test_attribute"].data, IECore.StringVectorData() )
+		self.assertEqual( result["test_attribute"].indices, None )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Fixes
---

- FromHoudiniPointsConverter : Revert behaviour from ImageEngine/cortex#1157
  - We continue to export empty PrimitiveVariables when there are no points, because downstream processing often requires the existance of P at a minimum.
- FromHoudiniGeometryConverter : Fixed crash with empty string attribs ranges