### PR TITLE
SceneCacheFileFormat : Fix compilation with GCC 9

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -204,7 +204,7 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 					{
 						sceneToLink = SharedSceneInterfaces::get( filePath );
 					}
-					catch( IOException )
+					catch( const IOException & )
 					{
 						IECore::msg(
 							IECore::Msg::Warning,


### PR DESCRIPTION
This is the same problem fixed once already by 1544de9ee105023973ccf1256f8eda251184f7ab.
