### PR TITLE
TypedData : fix template instantiation on Windows

### DIFF
--- a/include/IECore/SimpleTypedData.h
+++ b/include/IECore/SimpleTypedData.h
@@ -95,7 +95,7 @@ IECORE_DECLARE_TYPEDDATA( QuatdData, Imath::Quatd, double, SimpleDataHolder )
 IECORE_DECLARE_TYPEDDATA( LineSegment3fData, LineSegment3f, float, SimpleDataHolder )
 IECORE_DECLARE_TYPEDDATA( LineSegment3dData, LineSegment3d, double, SimpleDataHolder )
 
-#ifndef IECore_EXPORTS
+#if !defined(IECore_EXPORTS) && !defined(_MSC_VER)
 
 extern template class TypedData<bool>;
 extern template class TypedData<float>;

--- a/include/IECore/VectorTypedData.h
+++ b/include/IECore/VectorTypedData.h
@@ -94,7 +94,7 @@ IECORE_DECLARE_TYPEDDATA( QuatdVectorData, std::vector<Imath::Quatd>, double, Sh
 IECORE_DECLARE_TYPEDDATA( Color3fVectorData, std::vector<Imath::Color3f>, float, SharedDataHolder )
 IECORE_DECLARE_TYPEDDATA( Color4fVectorData, std::vector<Imath::Color4f>, float, SharedDataHolder )
 
-#ifndef IECore_EXPORTS
+#if !defined(IECore_EXPORTS) && !defined(_MSC_VER)
 
 extern template class TypedData<std::vector<bool>>;
 extern template class TypedData<std::vector<half>>;


### PR DESCRIPTION
This fixes a build error from Gaffer for Windows as a result of https://github.com/GafferHQ/gaffer/commit/bd8785473a2143d495529c75bccf2e6ab62ee17c. 
By including `Context.h` in `FormatData.cpp` we also get `Context.inl` and `SimpleTypedData.h`. This exposes an existing error with the `TypedData` instantiations on Windows where `extern` was conflicting with `dllexport`

- Instantiating a template as both `extern` and `__declspec(dllexport)` are mutually exclusive and generate warnings when building Cortex : https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-1-c4910?view=msvc-160
- Including both "SimpleTypedData.h" and "TypedData.inl" will cause multiple compilation errors because the template instantiations are not complete. For example:

    typeddata.inl(140): error C2664: 'void IECore::IndexedIO::read(const IECore::IndexedIO::EntryID &,unsigned short &) const': cannot convert argument 2 from 'T' to 'float &'
        with
        [
            T=bool
        ]

- Removing the `extern` and using `dllimport` instead of `dllexport` properly instantiates the types.

The macros expand such that Linux and Mac builds are the same as before, only Windows builds are affected.

### Related Issues ###

None

### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
- [X] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
