### PR TITLE
IECoreGL::TextureLoader : Use OIIO and apply color convert correctly

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2158,9 +2158,10 @@ if env["WITH_GL"] and doConfigure :
 			# while still using -Werror.
 			"-Wno-format" if env["PLATFORM"] != "win32" else "",
 			"-Wno-strict-aliasing" if env["PLATFORM"] != "win32" else "",
-		] + formatSystemIncludes( glEnv, "$GLEW_INCLUDE_PATH" ),
+		] + formatSystemIncludes( glEnv, [ "$GLEW_INCLUDE_PATH", "$OIIO_INCLUDE_PATH" ] ),
 		"LIBPATH" : [
 			"$GLEW_LIB_PATH",
+			"$OIIO_LIB_PATH",
 		],
 	}
 
@@ -2189,6 +2190,7 @@ if env["WITH_GL"] and doConfigure :
 				os.path.basename( coreEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				os.path.basename( imageEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				os.path.basename( sceneEnv.subst( "$INSTALL_LIB_NAME" ) ),
+				"OpenImageIO$OIIO_LIB_SUFFIX",
 			]
 		)
 

--- a/config/installDependencies.py
+++ b/config/installDependencies.py
@@ -54,7 +54,7 @@ else :
 
 platform = { "darwin": "osx", "win32": "windows" }.get( sys.platform, "linux" )
 if platform == "osx" or platform == "linux" :
-	defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/0.54.2.0/gafferDependencies-0.54.2.0-" + platform + ".tar.gz"
+	defaultURL = "https://github.com/GafferHQ/dependencies/releases/download/3.0.0/gafferDependencies-3.0.0-Python2-" + platform + ".tar.gz"
 else :
 	defaultURL = "https://github.com/hypothetical-inc/gafferDependencies/releases/download/0.54.1.0/gafferDependencies-0.54.1.0-windows-msvc2017.zip"
 

--- a/test/IECoreGL/TextureLoaderTest.py
+++ b/test/IECoreGL/TextureLoaderTest.py
@@ -32,6 +32,7 @@
 #
 ##########################################################################
 
+import imath
 import os
 import unittest
 
@@ -81,6 +82,20 @@ class TextureLoaderTest( unittest.TestCase ) :
 		size = i.dataWindow.size()
 
 		self.assertLessEqual( max( size.x, size.y ), int( 0.5 * maxResolution ) )
+
+	def testDataWindow( self ) :
+
+		l = IECoreGL.TextureLoader( IECore.SearchPath( "./" ) )
+
+		self.assertEqual(
+			l.load( "test/IECoreImage/data/exr/imageCropDataWindow.exr" ).imagePrimitive(),
+			l.load( "test/IECoreImage/data/exr/imageCropDataWindowMatched.exr" ).imagePrimitive()
+		)
+
+		self.assertEqual(
+			l.load( "test/IECoreImage/data/exr/oversizeDataWindow.exr" ).imagePrimitive().dataWindow,
+			imath.Box2i( imath.V2i(0,0), imath.V2i(255,255) )
+		)
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Avoid use of deprecated IECoreImage::ImageReader and ToGLTextureConverter, and let OIIO do the color convert of the whole image at once, which means it will handle unpremulting and repremulting correctly.

When paired with https://github.com/GafferHQ/gaffer/pull/4269, this will result in perfect edges on Gaffer icons.  Without that PR, it will remove the dark edges, but not fix the overexpanded alpha edges, resulting in icons looking slightly too thick.

Code looks pretty good to me, but I still need to do some testing of images with data windows, and using maximumResolution to set the mip level.