### PR TITLE
IECoreScene::PrimitiveVariable::IndexedView : Add explicit bool conversion

### DIFF
--- a/include/IECoreScene/PrimitiveVariable.h
+++ b/include/IECoreScene/PrimitiveVariable.h
@@ -163,6 +163,16 @@ class PrimitiveVariable::IndexedView
 			return m_indices;
 		}
 
+		explicit operator bool() const
+		{
+			return m_data != nullptr;
+		}
+
+		bool isValid() const
+		{
+			return static_cast< bool >( *this );
+		}
+
 	private :
 
 		static const std::vector<T> *data( const PrimitiveVariable &variable );


### PR DESCRIPTION
The current api assumes that the data pointer of an IECoreScene::PrimitiveVariable::IndexedView object
is always valid however a default constructed object has a null data pointer and calling any function
on such an object results in dereferencing a null pointer. This commit adds explicit conversion to bool
and an isValid() function that can be called to determine whether a given object is valid.

As an aside this change means that IECoreScene::Primitive::variableIndexedView() could simply return an
IECoreScene::PrimitiveVariable::IndexedView object directly instead of wrapping in a boost::optional.

### Checklist ###

- [ ] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Cortex project's prevailing coding style and conventions.
- [ ] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
