### PR TITLE
Avoid deprecated Arnold API

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2983,6 +2983,7 @@ arnoldEnv = env.Clone( **arnoldEnvSets )
 arnoldEnvAppends = {
 	"CXXFLAGS" : [
 		"-DIECoreArnold_EXPORTS",
+		"-DAI_ENABLE_DEPRECATION_WARNINGS",
 	] + formatSystemIncludes( arnoldEnv, "$ARNOLD_ROOT/include" ),
 	"CPPPATH" : [
 		"contrib/IECoreArnold/include",

--- a/SConstruct
+++ b/SConstruct
@@ -3120,7 +3120,7 @@ if doConfigure :
 		arnoldTestEnv["ENV"]["PYTHONPATH"] += ":./contrib/IECoreArnold/python:" + arnoldEnv.subst( "$ARNOLD_ROOT/python" )
 		arnoldTestEnv["ENV"][testEnv["TEST_LIBRARY_PATH_ENV_VAR"]] += ":" + arnoldEnv.subst( ":".join( arnoldPythonModuleEnv["LIBPATH"] ) )
 		arnoldTestEnv["ENV"]["PATH"] = arnoldEnv.subst( "$ARNOLD_ROOT/bin" ) + ":" + arnoldTestEnv["ENV"]["PATH"]
-		arnoldTestEnv["ENV"]["ARNOLD_PLUGIN_PATH"] = "contrib/IECoreArnold/test/IECoreArnold/plugins"
+		arnoldTestEnv["ENV"]["ARNOLD_PLUGIN_PATH"] = "contrib/IECoreArnold/test/IECoreArnold/plugins:contrib/IECoreArnold/test/IECoreArnold/metadata"
 		arnoldTest = arnoldTestEnv.Command( "contrib/IECoreArnold/test/IECoreArnold/results.txt", arnoldPythonModule, "$PYTHON $TEST_ARNOLD_SCRIPT --verbose" )
 		NoCache( arnoldTest )
 		arnoldTestEnv.Depends( arnoldTest, [ arnoldPythonModule + arnoldDriverForTest + arnoldLibrary ] )

--- a/contrib/IECoreArnold/include/IECoreArnold/CameraAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/CameraAlgo.h
@@ -47,8 +47,8 @@ namespace IECoreArnold
 namespace CameraAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace CameraAlgo
 

--- a/contrib/IECoreArnold/include/IECoreArnold/CurvesAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/CurvesAlgo.h
@@ -47,8 +47,8 @@ namespace IECoreArnold
 namespace CurvesAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::CurvesPrimitive *curves, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::CurvesPrimitive *curves, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace CurvesAlgo
 

--- a/contrib/IECoreArnold/include/IECoreArnold/MeshAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/MeshAlgo.h
@@ -47,8 +47,8 @@ namespace IECoreArnold
 namespace MeshAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace MeshAlgo
 

--- a/contrib/IECoreArnold/include/IECoreArnold/NodeAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/NodeAlgo.h
@@ -50,19 +50,19 @@ namespace NodeAlgo
 /// Converts the specified IECore::Object into an equivalent
 /// Arnold object, returning nullptr if no conversion is
 /// available.
-IECOREARNOLD_API AtNode *convert( const IECore::Object *object, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 /// Converts the specified IECore::Object samples into an
 /// equivalent moving Arnold object. If no motion converter
 /// is available, then returns a standard conversion of the
 /// first sample.
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 /// Signature of a function which can convert an IECore::Object
 /// into an Arnold object.
-typedef AtNode * (*Converter)( const IECore::Object *, const std::string &nodeName, const AtNode *parentNode );
+typedef AtNode * (*Converter)( const IECore::Object *, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode );
 /// Signature of a function which can convert a series of IECore::Object
 /// samples into a moving Arnold object.
-typedef AtNode * (*MotionConverter)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode );
+typedef AtNode * (*MotionConverter)( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode );
 
 /// Registers a converter for a specific type.
 /// Use the ConverterDescription utility class in preference to
@@ -78,8 +78,8 @@ class ConverterDescription
 	public :
 
 		/// Type-specific conversion functions.
-		typedef AtNode *(*Converter)( const T *, const std::string&, const AtNode* );
-		typedef AtNode *(*MotionConverter)( const std::vector<const T *> &, float, float, const std::string&, const AtNode* );
+		typedef AtNode *(*Converter)( const T *, AtUniverse *, const std::string&, const AtNode* );
+		typedef AtNode *(*MotionConverter)( const std::vector<const T *> &, float, float, AtUniverse *, const std::string&, const AtNode* );
 
 		ConverterDescription( Converter converter, MotionConverter motionConverter = nullptr )
 		{

--- a/contrib/IECoreArnold/include/IECoreArnold/PointsAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/PointsAlgo.h
@@ -47,8 +47,8 @@ namespace IECoreArnold
 namespace PointsAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace PointsAlgo
 

--- a/contrib/IECoreArnold/include/IECoreArnold/SphereAlgo.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/SphereAlgo.h
@@ -47,8 +47,8 @@ namespace IECoreArnold
 namespace SphereAlgo
 {
 
-IECOREARNOLD_API AtNode *convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, const AtNode *parentNode = nullptr );
-IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
+IECOREARNOLD_API AtNode *convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr );
 
 } // namespace SphereAlgo
 

--- a/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
@@ -44,31 +44,29 @@
 namespace IECoreArnold
 {
 
-/// Manages the Arnold universe. This is problematic because there
-/// can be only one instance at a time, but many applications have
-/// need for more than one.
+/// Manages Arnold initialisation via `AiBegin()` and creation and
+/// destruction of AtUniverse objects via `AiUniverse()` and
+/// `AiUniverseDestroy()`.
 class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 {
 
 	public :
 
-		/// Ensures that the Arnold universe has been created and
-		/// that all plugins and metadata files on the ARNOLD_PLUGIN_PATH
-		/// have been loaded. If writable is true, then throws if
-		/// there is already a writer.
+		/// Ensures that the Arnold API is initialised and that all plugins and
+		/// metadata files on the ARNOLD_PLUGIN_PATH have been loaded.
+		/// Constructs with a uniquely owned universe if `writable == true`, and
+		/// a potentially shared universe otherwise. The latter is useful for
+		/// making queries via the `AiNodeEntry` API.
 		UniverseBlock( bool writable );
-		/// "Releases" the universe. Currently we only actually
-		/// call `AiEnd()` for writable universes, because it is
-		/// essential to clean them up properly. We leave readable
-		/// universes active to avoid the startup cost the next
-		/// time around.
+		/// Releases the universe created by the constructor.
 		~UniverseBlock();
 
-		AtUniverse *universe() { return nullptr; } // We always use the default universe at present
+		AtUniverse *universe() { return m_universe; }
 
 	private :
 
-		bool m_writable;
+		const bool m_writable;
+		AtUniverse *m_universe;
 
 };
 

--- a/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
@@ -39,6 +39,8 @@
 
 #include "boost/noncopyable.hpp"
 
+#include "ai_universe.h"
+
 namespace IECoreArnold
 {
 
@@ -61,6 +63,8 @@ class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 		/// universes active to avoid the startup cost the next
 		/// time around.
 		~UniverseBlock();
+
+		AtUniverse *universe() { return nullptr; } // We always use the default universe at present
 
 	private :
 

--- a/contrib/IECoreArnold/python/IECoreArnold/UniverseBlock.py
+++ b/contrib/IECoreArnold/python/IECoreArnold/UniverseBlock.py
@@ -43,6 +43,7 @@ class UniverseBlock :
 	def __enter__( self ) :
 
 		self.__universeBlock = _IECoreArnold._UniverseBlock( self.__writable )
+		return self.__universeBlock.universe()
 
 	def __exit__( self, type, value, traceBack ) :
 

--- a/contrib/IECoreArnold/src/IECoreArnold/CameraAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/CameraAlgo.cpp
@@ -124,7 +124,7 @@ void setShutterCurveParameter( AtNode *camera, const IECore::Data *value )
 }
 
 // Performs the part of the conversion that is shared by both animated and non-animated cameras.
-AtNode *convertCommon( const IECoreScene::Camera *camera, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convertCommon( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	// Use projection to decide what sort of camera node to create
 	const std::string projection = camera->getProjection();
@@ -132,15 +132,15 @@ AtNode *convertCommon( const IECoreScene::Camera *camera, const std::string &nod
 	AtNode *result = nullptr;
 	if( projection=="perspective" )
 	{
-		result = AiNode( g_perspCameraArnoldString, AtString( nodeName.c_str() ), parentNode );
+		result = AiNode( universe, g_perspCameraArnoldString, AtString( nodeName.c_str() ), parentNode );
 	}
 	else if( projection=="orthographic" )
 	{
-		result = AiNode( g_orthoCameraArnoldString, AtString( nodeName.c_str() ), parentNode );
+		result = AiNode( universe, g_orthoCameraArnoldString, AtString( nodeName.c_str() ), parentNode );
 	}
 	else
 	{
-		result = AiNode( AtString( projection.c_str() ), AtString( nodeName.c_str() ), parentNode );
+		result = AiNode( universe, AtString( projection.c_str() ), AtString( nodeName.c_str() ), parentNode );
 	}
 
 	// Set clipping planes
@@ -257,9 +257,9 @@ void setAnimatedFloat( AtNode *node, AtString name, const std::vector<const IECo
 
 } // namespace
 
-AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, const std::string &nodeName, const AtNode *parentNode )
+AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( camera, nodeName, parentNode );
+	AtNode *result = convertCommon( camera, universe, nodeName, parentNode );
 	if( camera->getProjection()=="perspective" )
 	{
 		AiNodeSetFlt( result, g_fovArnoldString, fieldOfView( camera ) );
@@ -274,9 +274,9 @@ AtNode *CameraAlgo::convert( const IECoreScene::Camera *camera, const std::strin
 	return result;
 }
 
-AtNode *CameraAlgo::convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *CameraAlgo::convert( const std::vector<const IECoreScene::Camera *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( samples[0], nodeName, parentNode );
+	AtNode *result = convertCommon( samples[0], universe, nodeName, parentNode );
 	if( samples[0]->getProjection()=="perspective" )
 	{
 		setAnimatedFloat( result, g_fovArnoldString, samples, fieldOfView );

--- a/contrib/IECoreArnold/src/IECoreArnold/CurvesAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/CurvesAlgo.cpp
@@ -124,10 +124,10 @@ void convertUVs( const IECoreScene::CurvesPrimitive *curves, AtNode *node )
 	AiNodeSetArray( node, g_uvsArnoldString, array );
 }
 
-AtNode *convertCommon( const IECoreScene::CurvesPrimitive *curves, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convertCommon( const IECoreScene::CurvesPrimitive *curves, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 
-	AtNode *result = AiNode( g_curvesArnoldString, AtString( nodeName.c_str() ), parentNode );
+	AtNode *result = AiNode( universe, g_curvesArnoldString, AtString( nodeName.c_str() ), parentNode );
 
 	const std::vector<int> verticesPerCurve = curves->verticesPerCurve()->readable();
 	AiNodeSetArray(
@@ -172,13 +172,13 @@ AtNode *convertCommon( const IECoreScene::CurvesPrimitive *curves, const std::st
 
 } // namespace
 
-AtNode *IECoreArnold::CurvesAlgo::convert( const IECoreScene::CurvesPrimitive *curves, const std::string &nodeName, const AtNode *parentNode )
+AtNode *IECoreArnold::CurvesAlgo::convert( const IECoreScene::CurvesPrimitive *curves, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	// Arnold (and IECoreArnold::ShapeAlgo) does not support Vertex PrimitiveVariables for
 	// cubic CurvesPrimitives, so we resample the variables to Varying first.
 	ConstCurvesPrimitivePtr resampledCurves = ::resampleCurves( curves );
 
-	AtNode *result = convertCommon( resampledCurves.get(), nodeName, parentNode );
+	AtNode *result = convertCommon( resampledCurves.get(), universe, nodeName, parentNode );
 	ShapeAlgo::convertP( resampledCurves.get(), result, g_pointsArnoldString );
 	ShapeAlgo::convertRadius( resampledCurves.get(), result );
 
@@ -197,7 +197,7 @@ AtNode *IECoreArnold::CurvesAlgo::convert( const IECoreScene::CurvesPrimitive *c
 	return result;
 }
 
-AtNode *IECoreArnold::CurvesAlgo::convert( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *IECoreArnold::CurvesAlgo::convert( const std::vector<const IECoreScene::CurvesPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	// Arnold (and IECoreArnold::ShapeAlgo) does not support Vertex PrimitiveVariables for
 	// cubic CurvesPrimitives, so we resample the variables to Varying first.
@@ -220,7 +220,7 @@ AtNode *IECoreArnold::CurvesAlgo::convert( const std::vector<const IECoreScene::
 		}
 	}
 
-	AtNode *result = convertCommon( updatedSamples.front().get(), nodeName, parentNode );
+	AtNode *result = convertCommon( updatedSamples.front().get(), universe, nodeName, parentNode );
 
 	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString );
 	ShapeAlgo::convertRadius( primitiveSamples, result );

--- a/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/MeshAlgo.cpp
@@ -229,12 +229,12 @@ void convertCornersAndCreases( const IECoreScene::MeshPrimitive *mesh, AtNode *n
 	AiNodeSetArray( node, g_creaseSharpnessArnoldString, sharpnessesArray );
 }
 
-AtNode *convertCommon( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, const AtNode *parentNode = nullptr )
+AtNode *convertCommon( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr )
 {
 
 	// Make the result mesh and add topology
 
-	AtNode *result = AiNode( g_polymeshArnoldString, AtString( nodeName.c_str() ), parentNode );
+	AtNode *result = AiNode( universe, g_polymeshArnoldString, AtString( nodeName.c_str() ), parentNode );
 
 	const std::vector<int> &verticesPerFace = mesh->verticesPerFace()->readable();
 	AiNodeSetArray(
@@ -381,9 +381,9 @@ NodeAlgo::ConverterDescription<MeshPrimitive> g_description( MeshAlgo::convert, 
 // Implementation of public API
 //////////////////////////////////////////////////////////////////////////
 
-AtNode *MeshAlgo::convert( const IECoreScene::MeshPrimitive *mesh, const std::string &nodeName, const AtNode *parentNode )
+AtNode *MeshAlgo::convert( const IECoreScene::MeshPrimitive *mesh, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( mesh, nodeName, parentNode );
+	AtNode *result = convertCommon( mesh, universe, nodeName, parentNode );
 
 	ShapeAlgo::convertP( mesh, result, g_vlistArnoldString );
 
@@ -404,9 +404,9 @@ AtNode *MeshAlgo::convert( const IECoreScene::MeshPrimitive *mesh, const std::st
 	return result;
 }
 
-AtNode *MeshAlgo::convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *MeshAlgo::convert( const std::vector<const IECoreScene::MeshPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( samples.front(), nodeName, parentNode );
+	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode );
 
 	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
 	ShapeAlgo::convertP( primitiveSamples, result, g_vlistArnoldString );

--- a/contrib/IECoreArnold/src/IECoreArnold/NodeAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/NodeAlgo.cpp
@@ -78,7 +78,7 @@ namespace IECoreArnold
 namespace NodeAlgo
 {
 
-AtNode *convert( const IECore::Object *object, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const IECore::Object *object, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	const Registry &r = registry();
 	Registry::const_iterator it = r.find( object->typeId() );
@@ -86,10 +86,10 @@ AtNode *convert( const IECore::Object *object, const std::string &nodeName, cons
 	{
 		return nullptr;
 	}
-	return it->second.converter( object, nodeName, parentNode );
+	return it->second.converter( object, universe, nodeName, parentNode );
 }
 
-AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const std::vector<const IECore::Object *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	if( samples.empty() )
 	{
@@ -115,11 +115,11 @@ AtNode *convert( const std::vector<const IECore::Object *> &samples, float motio
 
 	if( it->second.motionConverter )
 	{
-		return it->second.motionConverter( samples, motionStart, motionEnd, nodeName, parentNode );
+		return it->second.motionConverter( samples, motionStart, motionEnd, universe, nodeName, parentNode );
 	}
 	else
 	{
-		return it->second.converter( firstSample, nodeName, parentNode );
+		return it->second.converter( firstSample, universe, nodeName, parentNode );
 	}
 }
 

--- a/contrib/IECoreArnold/src/IECoreArnold/PointsAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/PointsAlgo.cpp
@@ -65,10 +65,10 @@ const AtString g_sphereArnoldString( "sphere" );
 
 NodeAlgo::ConverterDescription<PointsPrimitive> g_description( PointsAlgo::convert, PointsAlgo::convert );
 
-AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, const AtNode *parentNode = nullptr )
+AtNode *convertCommon( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode = nullptr )
 {
 
-	AtNode *result = AiNode( g_pointsArnoldString, AtString( nodeName.c_str() ), parentNode );
+	AtNode *result = AiNode( universe, g_pointsArnoldString, AtString( nodeName.c_str() ), parentNode );
 
 	// mode
 
@@ -114,9 +114,9 @@ namespace IECoreArnold
 namespace PointsAlgo
 {
 
-AtNode *convert( const IECoreScene::PointsPrimitive *points, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const IECoreScene::PointsPrimitive *points, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( points, nodeName, parentNode );
+	AtNode *result = convertCommon( points, universe, nodeName, parentNode );
 
 	ShapeAlgo::convertP( points, result, g_pointsArnoldString );
 	ShapeAlgo::convertRadius( points, result );
@@ -126,9 +126,9 @@ AtNode *convert( const IECoreScene::PointsPrimitive *points, const std::string &
 	return result;
 }
 
-AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *convert( const std::vector<const IECoreScene::PointsPrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = convertCommon( samples.front(), nodeName, parentNode );
+	AtNode *result = convertCommon( samples.front(), universe, nodeName, parentNode );
 
 	std::vector<const IECoreScene::Primitive *> primitiveSamples( samples.begin(), samples.end() );
 	ShapeAlgo::convertP( primitiveSamples, result, g_pointsArnoldString );

--- a/contrib/IECoreArnold/src/IECoreArnold/SphereAlgo.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/SphereAlgo.cpp
@@ -82,11 +82,11 @@ NodeAlgo::ConverterDescription<SpherePrimitive> g_description( SphereAlgo::conve
 // Implementation of public API
 //////////////////////////////////////////////////////////////////////////
 
-AtNode *SphereAlgo::convert( const IECoreScene::SpherePrimitive *sphere, const std::string &nodeName, const AtNode *parentNode )
+AtNode *SphereAlgo::convert( const IECoreScene::SpherePrimitive *sphere, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
 	warnIfUnsupported( sphere );
 
-	AtNode *result = AiNode( g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
+	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
 	ShapeAlgo::convertPrimitiveVariables( sphere, result );
 
 	AiNodeSetFlt( result, g_radiusArnoldString, sphere->radius() );
@@ -94,9 +94,9 @@ AtNode *SphereAlgo::convert( const IECoreScene::SpherePrimitive *sphere, const s
 	return result;
 }
 
-AtNode *SphereAlgo::convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, const std::string &nodeName, const AtNode *parentNode )
+AtNode *SphereAlgo::convert( const std::vector<const IECoreScene::SpherePrimitive *> &samples, float motionStart, float motionEnd, AtUniverse *universe, const std::string &nodeName, const AtNode *parentNode )
 {
-	AtNode *result = AiNode( g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
+	AtNode *result = AiNode( universe, g_sphereArnoldString, AtString( nodeName.c_str() ), parentNode );
 	ShapeAlgo::convertPrimitiveVariables( samples.front(), result );
 
 	AtArray *radiusSamples = AiArrayAllocate( 1, samples.size(), AI_TYPE_FLOAT );

--- a/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
@@ -90,13 +90,6 @@ void begin()
 
 	AiBegin();
 
-#if ARNOLD_VERSION_NUM < 60004
-
-	// We set the console flags again, as older Arnold versions seem to update the flags during AiBegin.
-	AiMsgSetConsoleFlags( AI_LOG_ERRORS | AI_LOG_WARNINGS );
-
-#endif
-
 	const char *pluginPaths = getenv( "ARNOLD_PLUGIN_PATH" );
 	if( pluginPaths )
 	{

--- a/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/UniverseBlock.cpp
@@ -47,6 +47,10 @@
 using namespace IECore;
 using namespace IECoreArnold;
 
+#if ARNOLD_VERSION_NUM >= 70000
+#define IECOREARNOLD_MULTIPLE_UNIVERSES
+#endif
+
 namespace
 {
 
@@ -85,8 +89,12 @@ void begin()
 {
 	// Default to logging errors / warnings only - we may not even be using this universe block to perform a render,
 	// we might just be loading some shader metadata or something, so we don't want to be dumping lots of
-	// unnecessary output
+	// unnecessary output.
+#ifdef IECOREARNOLD_MULTIPLE_UNIVERSES
+	AiMsgSetConsoleFlags( nullptr, AI_LOG_ERRORS | AI_LOG_WARNINGS );
+#else
 	AiMsgSetConsoleFlags( AI_LOG_ERRORS | AI_LOG_WARNINGS );
+#endif
 
 	AiBegin();
 
@@ -98,14 +106,66 @@ void begin()
 	}
 }
 
+#ifdef IECOREARNOLD_MULTIPLE_UNIVERSES
+
+class ArnoldAPIScope
+{
+	public :
+
+		ArnoldAPIScope()
+			:	m_sharedUniverse( nullptr )
+		{
+			begin();
+		}
+
+		~ArnoldAPIScope()
+		{
+			if( m_sharedUniverse )
+			{
+				AiUniverseDestroy( m_sharedUniverse );
+			}
+			AiEnd();
+		}
+
+		/// \todo This can probably be removed in future. Non-writable
+		/// UniverseBlock users really just want `AiBegin()` to have been called
+		/// so they can query plugins, and they don't need an actual universe at
+		/// all. We just make one so we can implement the original UniverseBlock
+		/// semantics.
+		AtUniverse *sharedUniverse()
+		{
+			if( !m_sharedUniverse )
+			{
+				m_sharedUniverse = AiUniverse();
+			}
+			return m_sharedUniverse;
+		}
+
+	private :
+
+		AtUniverse *m_sharedUniverse;
+};
+
+static ArnoldAPIScope g_apiScope;
+
+#else
+
 tbb::spin_mutex g_mutex;
 int g_count = 0;
 bool g_haveWriter = false;
 
+#endif
+
 } // namespace
 
 UniverseBlock::UniverseBlock( bool writable )
+	:	m_writable( writable )
 {
+#ifdef IECOREARNOLD_MULTIPLE_UNIVERSES
+	m_universe = m_writable ? AiUniverse() : g_apiScope.sharedUniverse();
+#else
+	// Careful management of the default universe, so that there
+	// can be multiple readers but only one writer.
 	tbb::spin_mutex::scoped_lock lock( g_mutex );
 
 	if( writable )
@@ -119,7 +179,7 @@ UniverseBlock::UniverseBlock( bool writable )
 			g_haveWriter = true;
 		}
 	}
-	m_writable = writable;
+	m_universe = nullptr;
 
 	g_count++;
 	if( AiUniverseIsActive() )
@@ -128,10 +188,17 @@ UniverseBlock::UniverseBlock( bool writable )
 	}
 
 	begin();
+#endif
 }
 
 UniverseBlock::~UniverseBlock()
 {
+#ifdef IECOREARNOLD_MULTIPLE_UNIVERSES
+	if( m_writable )
+	{
+		AiUniverseDestroy( m_universe );
+	}
+#else
 	tbb::spin_mutex::scoped_lock lock( g_mutex );
 
 	g_count--;
@@ -157,4 +224,5 @@ UniverseBlock::~UniverseBlock()
 			begin();
 		}
 	}
+#endif
 }

--- a/contrib/IECoreArnold/src/IECoreArnold/bindings/UniverseBlockBinding.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/bindings/UniverseBlockBinding.cpp
@@ -39,6 +39,30 @@
 using namespace boost::python;
 using namespace IECoreArnold;
 
+namespace
+{
+
+object universeWrapper( UniverseBlock &universeBlock )
+{
+	AtUniverse *universe = universeBlock.universe();
+	if( universe )
+	{
+		object arnold = import( "arnold" );
+		object ctypes = import( "ctypes" );
+		return ctypes.attr( "cast" )(
+			(uint64_t)universeBlock.universe(),
+			ctypes.attr( "POINTER" )( object( arnold.attr( "AtUniverse" ) ) )
+		);
+	}
+	else
+	{
+		// Default universe, represented as `None` in Python.
+		return object();
+	}
+}
+
+} // namespace
+
 namespace IECoreArnold
 {
 
@@ -47,7 +71,9 @@ void bindUniverseBlock()
 
 	// This is bound with a preceding _ and then turned into a context
 	// manager for the "with" statement in IECoreArnold/UniverseBlock.py
-	class_<UniverseBlock, boost::noncopyable>( "_UniverseBlock", init<bool>( ( arg( "writable" ) ) ) );
+	class_<UniverseBlock, boost::noncopyable>( "_UniverseBlock", init<bool>( ( arg( "writable" ) ) ) )
+		.def( "universe", &universeWrapper )
+	;
 
 }
 

--- a/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/outputDriver/OutputDriver.cpp
@@ -198,7 +198,7 @@ void driverOpen( AtNode *node, struct AtOutputIterator *iterator, AtBBox2 displa
 	// IECoreImage::Format and then use that in place of the display
 	// window.
 	parameters->writable()["pixelAspect"] = new FloatData(
-		AiNodeGetFlt( AiUniverseGetOptions(), g_pixelAspectRatioArnoldString )
+		AiNodeGetFlt( AiUniverseGetOptions( AiNodeGetUniverse( node ) ), g_pixelAspectRatioArnoldString )
 	);
 
 	const std::string driverType = AiNodeGetStr( node, g_driverTypeArnoldString ).c_str();

--- a/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/CameraAlgoTest.py
@@ -48,7 +48,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertPerspective( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			c = IECoreScene.Camera(
 				parameters = {
@@ -59,7 +59,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 				}
 			)
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testCamera" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testCamera" )
 			screenWindow = c.frustum()
 
 			self.assertTrue( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( n ) ), "persp_camera" )
@@ -82,7 +82,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertCustomProjection( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			n = IECoreArnold.NodeAlgo.convert(
 				IECoreScene.Camera(
@@ -92,6 +92,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 						"vertical_fov" : 80.0,
 					}
 				),
+				universe,
 				"testCamera"
 			)
 
@@ -106,7 +107,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 		random.seed( 42 )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 			for i in range( 40 ):
 				resolution = imath.V2i( random.randint( 10, 1000 ), random.randint( 10, 1000 ) )
 				pixelAspectRatio = random.uniform( 0.5, 2 )
@@ -132,7 +133,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 				if i < 20:
 					c.parameters()["screenWindow"] = screenWindow
 
-				n = IECoreArnold.NodeAlgo.convert( c, "testCamera" )
+				n = IECoreArnold.NodeAlgo.convert( c, universe, "testCamera" )
 
 				arnoldType = "persp_camera"
 				if c.parameters()["projection"].value == "orthographic":
@@ -174,7 +175,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertAnimatedParameters( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			samples = []
 			for i in range( 0, 2 ) :
@@ -186,8 +187,8 @@ class CameraAlgoTest( unittest.TestCase ) :
 				camera.setFocusDistance( i + 100 )
 				samples.append( camera )
 
-			animatedNode = IECoreArnold.NodeAlgo.convert( samples, 1.0, 2.0, "samples" )
-			nodes = [ IECoreArnold.NodeAlgo.convert( samples[i], "sample{}".format( i ) ) for i, sample in enumerate( samples ) ]
+			animatedNode = IECoreArnold.NodeAlgo.convert( samples, 1.0, 2.0, universe, "samples" )
+			nodes = [ IECoreArnold.NodeAlgo.convert( samples[i], universe, "sample{}".format( i ) ) for i, sample in enumerate( samples ) ]
 
 			self.assertEqual( arnold.AiNodeGetFlt( animatedNode, "motion_start" ), 1.0 )
 			self.assertEqual( arnold.AiNodeGetFlt( animatedNode, "motion_start" ), 1.0 )
@@ -244,10 +245,10 @@ class CameraAlgoTest( unittest.TestCase ) :
 		camera = IECoreScene.Camera()
 		camera.setProjection( "perspective" )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			animatedNode = IECoreArnold.NodeAlgo.convert( [ camera, camera ], 1.0, 2.0, "samples" )
-			node = IECoreArnold.NodeAlgo.convert( camera, "sample" )
+			animatedNode = IECoreArnold.NodeAlgo.convert( [ camera, camera ], 1.0, 2.0, universe, "samples" )
+			node = IECoreArnold.NodeAlgo.convert( camera, universe, "sample" )
 
 			for parameter in [
 				"screen_window_min",
@@ -278,7 +279,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 
 	def testConvertShutterCurve( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			camera = IECoreScene.Camera()
 			camera.setProjection( "perspective" )
@@ -292,7 +293,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 				],
 			)
 
-			node = IECoreArnold.NodeAlgo.convert( camera, "camera" )
+			node = IECoreArnold.NodeAlgo.convert( camera, universe, "camera" )
 			curve = arnold.AiNodeGetArray( node, "shutter_curve" )
 			self.assertEqual( arnold.AiArrayGetNumElements( curve ), 4 )
 			self.assertEqual( arnold.AiArrayGetVec2( curve, 0 ), arnold.AtVector2( 0, 0 ) )
@@ -312,7 +313,7 @@ class CameraAlgoTest( unittest.TestCase ) :
 				],
 			)
 
-			node = IECoreArnold.NodeAlgo.convert( camera, "camera" )
+			node = IECoreArnold.NodeAlgo.convert( camera, universe, "camera" )
 			curve = arnold.AiNodeGetArray( node, "shutter_curve" )
 			self.assertEqual( arnold.AiArrayGetNumElements( curve ), 25 )
 			for i in range( 0, 25 ) :

--- a/contrib/IECoreArnold/test/IECoreArnold/CurvesTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/CurvesTest.py
@@ -59,9 +59,9 @@ class CurvesTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ imath.V3f( 2 ) ] * 4 ),
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( [ c1, c2 ], -0.25, 0.25, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( [ c1, c2 ], -0.25, 0.25, universe, "testCurve" )
 
 			a = arnold.AiNodeGetArray( n, "points" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 4 )
@@ -83,11 +83,11 @@ class CurvesTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ imath.V3f( x, 0, 0 ) for x in range( 0, 4 ) ] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			# No N - should be a ribbon
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testCurve" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "ribbon" )
 			self.assertEqual( arnold.AiArrayGetNumElements( arnold.AiNodeGetArray( n, "orientations" ).contents ), 0 )
 
@@ -98,7 +98,7 @@ class CurvesTest( unittest.TestCase ) :
 				IECore.V3fVectorData( [ imath.V3f( 0, math.sin( x ), math.cos( x ) ) for x in range( 0, 4 ) ] )
 			)
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testCurve" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "oriented" )
 			orientations = arnold.AiNodeGetArray( n, "orientations" )
 			self.assertEqual( arnold.AiArrayGetNumElements( orientations.contents ), 4 )
@@ -114,7 +114,7 @@ class CurvesTest( unittest.TestCase ) :
 				IECore.V3fVectorData( [ imath.V3f( 0, math.sin( x + 0.2 ), math.cos( x + 0.2 ) ) for x in range( 0, 4 ) ] )
 			)
 
-			n = IECoreArnold.NodeAlgo.convert( [ c, c2 ], 0.0, 1.0, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( [ c, c2 ], 0.0, 1.0, universe, "testCurve" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "oriented" )
 
 			orientations = arnold.AiNodeGetArray( n, "orientations" )
@@ -143,9 +143,9 @@ class CurvesTest( unittest.TestCase ) :
 			)
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testCurve" )
 
 			uvs = arnold.AiNodeGetArray( n, "uvs" ).contents
 			self.assertEqual( arnold.AiArrayGetNumElements( uvs ), 2 )
@@ -173,9 +173,9 @@ class CurvesTest( unittest.TestCase ) :
 			)
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testCurve" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testCurve" )
 
 			uvs = arnold.AiNodeGetArray( n, "uvs" ).contents
 			self.assertEqual( arnold.AiArrayGetNumElements( uvs ), 4 )
@@ -248,9 +248,9 @@ class CurvesTest( unittest.TestCase ) :
 		)
 		self.assertTrue( c4.arePrimitiveVariablesValid() )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( c, "testLinearCurve" )
+			n = IECoreArnold.NodeAlgo.convert( c, universe, "testLinearCurve" )
 			r = arnold.AiNodeGetArray( n, "radius" )
 			self.assertEqual( arnold.AiArrayGetNumElements( r.contents ), 4 )
 			self.assertEqual( arnold.AiArrayGetNumKeys( r.contents ), 1 )
@@ -261,7 +261,7 @@ class CurvesTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetFlt( r, i ), 0.5 )
 				self.assertEqual( arnold.AiArrayGetFlt( foo, i ), 1.5 )
 
-			n2 = IECoreArnold.NodeAlgo.convert( [ c, c2 ], -0.25, 0.25, "testLinearCurves" )
+			n2 = IECoreArnold.NodeAlgo.convert( [ c, c2 ], -0.25, 0.25, universe, "testLinearCurves" )
 			r2 = arnold.AiNodeGetArray( n2, "radius" )
 			self.assertEqual( arnold.AiArrayGetNumElements( r2.contents ), 4 )
 			self.assertEqual( arnold.AiArrayGetNumKeys( r2.contents ), 2 )
@@ -277,7 +277,7 @@ class CurvesTest( unittest.TestCase ) :
 
 			# for cubic curves, radius will have been converted to Varying, so it will have fewer elements
 
-			n3 = IECoreArnold.NodeAlgo.convert( c3, "testBSplineCurve" )
+			n3 = IECoreArnold.NodeAlgo.convert( c3, universe, "testBSplineCurve" )
 			r3 = arnold.AiNodeGetArray( n3, "radius" )
 			self.assertEqual( arnold.AiArrayGetNumElements( r3.contents ), 12 )
 			self.assertEqual( arnold.AiArrayGetNumKeys( r3.contents ), 1 )
@@ -288,7 +288,7 @@ class CurvesTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetFlt( r3, i ), 0.5 )
 				self.assertEqual( arnold.AiArrayGetFlt( foo3, i ), 1.5 )
 
-			n4 = IECoreArnold.NodeAlgo.convert( [ c3, c4 ], -0.25, 0.25, "testBSplineCurves" )
+			n4 = IECoreArnold.NodeAlgo.convert( [ c3, c4 ], -0.25, 0.25, universe, "testBSplineCurves" )
 			r4 = arnold.AiNodeGetArray( n4, "radius" )
 			self.assertEqual( arnold.AiArrayGetNumElements( r4.contents ), 12 )
 			self.assertEqual( arnold.AiArrayGetNumKeys( r4.contents ), 2 )

--- a/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/MeshTest.py
@@ -52,9 +52,9 @@ class MeshTest( unittest.TestCase ) :
 		m["uv"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, m["uv"].expandedData() )
 		uvData = m["uv"].data
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			uvs = arnold.AiNodeGetArray( n, "uvlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( uvs.contents ), 4 )
@@ -73,9 +73,9 @@ class MeshTest( unittest.TestCase ) :
 		uvData = m["uv"].data
 		uvIds = m["uv"].indices
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			uvs = arnold.AiNodeGetArray( n, "uvlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( uvs.contents ), 4 )
@@ -98,9 +98,9 @@ class MeshTest( unittest.TestCase ) :
 		uvData = m["myMap"].data
 		indicesData = m["myMap"].indices
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			uvs = arnold.AiNodeGetArray( n, "myMap" )
 			self.assertEqual( arnold.AiArrayGetNumElements( uvs.contents ), 4 )
@@ -129,9 +129,9 @@ class MeshTest( unittest.TestCase ) :
 				IECore.V3fVectorData( [ imath.V3f( 1, 0, 0 ), imath.V3f( -1, 0, 0 ) ] ), IECore.IntVectorData( [0]* 8 + [1]* 8 )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( normals.contents ), 4 )
@@ -139,7 +139,7 @@ class MeshTest( unittest.TestCase ) :
 			for i in range( 0, 4 ) :
 				self.assertEqual( arnold.AiArrayGetVec( normals, i ), arnold.AtVector( 1, 0, 0 ) )
 
-			n = IECoreArnold.NodeAlgo.convert( mFaceVaryingIndexed, "testMesh2" )
+			n = IECoreArnold.NodeAlgo.convert( mFaceVaryingIndexed, universe, "testMesh2" )
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			normalIndices = arnold.AiNodeGetArray( n, "nidxs" )
 
@@ -148,7 +148,7 @@ class MeshTest( unittest.TestCase ) :
 				self.assertEqual( arnold.AiArrayGetVec( normals, arnold.AiArrayGetInt( normalIndices, i ) ),
 					arnold.AtVector( *refNormals[i//4] ) )
 
-			n = IECoreArnold.NodeAlgo.convert( mVertexIndexed, "testMesh3" )
+			n = IECoreArnold.NodeAlgo.convert( mVertexIndexed, universe, "testMesh3" )
 			normals = arnold.AiNodeGetArray( n, "nlist" )
 			normalIndices = arnold.AiNodeGetArray( n, "nidxs" )
 			for i in range( 0, 36 ) :
@@ -168,9 +168,9 @@ class MeshTest( unittest.TestCase ) :
 			IECore.V3fVectorData( [ imath.V3f( v ) for v in range( 0, 4 ) ] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
 			v = arnold.AiNodeGetArray( n, "myV3fPrimVar" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 4 )
@@ -191,9 +191,9 @@ class MeshTest( unittest.TestCase ) :
 			IECore.FloatVectorData( range( 0, 16 ) )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
 			ia = arnold.AiNodeGetArray( n, "myPrimVaridxs" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 16 )
@@ -216,9 +216,9 @@ class MeshTest( unittest.TestCase ) :
 			IECore.IntVectorData( [ 0, 0, 0, 0, 1, 1, 1, 1 ] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
 			ia = arnold.AiNodeGetArray( n, "myPrimVaridxs" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 2 )
@@ -248,9 +248,9 @@ class MeshTest( unittest.TestCase ) :
 			IECore.IntVectorData( [ 0, 1, 0, 1 ] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			self.assertEqual( arnold.AiNodeLookUpUserParameter( n, "myPrimVaridxs" ), None )
 
@@ -273,9 +273,9 @@ class MeshTest( unittest.TestCase ) :
 		m2["P"].data[1] -= imath.V3f( 0, 0, 1 )
 		IECoreScene.MeshNormalsOp()( input = m2, copyInput = False )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			node = IECoreArnold.NodeAlgo.convert( [ m1, m2 ], -0.25, 0.25, "testMesh" )
+			node = IECoreArnold.NodeAlgo.convert( [ m1, m2 ], -0.25, 0.25, universe, "testMesh" )
 
 			vList = arnold.AiNodeGetArray( node, "vlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( vList.contents ), 4 )
@@ -311,10 +311,10 @@ class MeshTest( unittest.TestCase ) :
 
 		expectedMsg = 'Primitive variable "name" will be ignored because it clashes with Arnold\'s built-in parameters'
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 			msg = IECore.CapturingMessageHandler()
 			with msg :
-				IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+				IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			self.assertEqual( len(msg.messages), 1 )
 			self.assertEqual( msg.messages[-1].message, expectedMsg )
@@ -332,8 +332,8 @@ class MeshTest( unittest.TestCase ) :
 		IECore.setGeometricInterpretation( vectors, IECore.GeometricData.Interpretation.Vector )
 		m["vectors"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, vectors )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
-			node = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
+			node = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			p = arnold.AiNodeGetArray( node, "points" )
 			self.assertEqual( arnold.AiArrayGetType( p.contents ), arnold.AI_TYPE_VECTOR )
 
@@ -348,9 +348,9 @@ class MeshTest( unittest.TestCase ) :
 			IECore.BoolVectorData( [ True, False, True, False ] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			a = arnold.AiNodeGetArray( n, "myBoolPrimVar" )
 
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 4 )
@@ -372,9 +372,9 @@ class MeshTest( unittest.TestCase ) :
 			] )
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 			a = arnold.AiNodeGetArray( n, "myColor" )
 
 			self.assertEqual( arnold.AiArrayGetType( a.contents ), arnold.AI_TYPE_RGBA )
@@ -398,9 +398,9 @@ class MeshTest( unittest.TestCase ) :
 
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			uvArray = arnold.AiNodeGetArray( n, "uvlist" )
 			self.assertEqual( arnold.AiArrayGetNumElements( uvArray.contents ), 4 )
@@ -430,9 +430,9 @@ class MeshTest( unittest.TestCase ) :
 		m.setCorners( IECore.IntVectorData( [ 3 ] ), IECore.FloatVectorData( [ 5 ] ) )
 		m.setCreases( IECore.IntVectorData( [ 3 ] ), IECore.IntVectorData( [ 0, 1, 2 ] ), IECore.FloatVectorData( [ 6 ] ) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( m, "testMesh" )
+			n = IECoreArnold.NodeAlgo.convert( m, universe, "testMesh" )
 
 			idxArray = arnold.AiNodeGetArray( n, "crease_idxs" )
 			for i, v in enumerate( [ 0, 1, 1, 2, 3, 3 ] ) :

--- a/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/PointsTest.py
@@ -48,36 +48,36 @@ class PointsTest( unittest.TestCase ) :
 
 	def testConverterResultType( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			p = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 10 ) ] ) )
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 
 			self.assertTrue( type( n ) is type( arnold.AiNode( "points" ) ) )
 
 	def testMode( self ) :
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
 			p = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 10 ) ] ) )
 
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "disk" )
 
 			p["type"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, "particle" )
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "disk" )
 
 			p["type"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, "disk" )
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "disk" )
 
 			p["type"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, "sphere" )
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "sphere" )
 
 			p["type"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, "patch" )
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetStr( n, "mode" ), "quad" )
 
 	def testConstantPrimitiveVariable( self ) :
@@ -85,9 +85,9 @@ class PointsTest( unittest.TestCase ) :
 		p = IECoreScene.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntData( 10 ) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
 
 	def testConstantArrayPrimitiveVariable( self ) :
@@ -95,9 +95,9 @@ class PointsTest( unittest.TestCase ) :
 		p = IECoreScene.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntVectorData( range( 0, 10 ) ) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			a = arnold.AiNodeGetArray( n, "myPrimVar" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 10 )
 			for i in range( 0, 10 ) :
@@ -108,9 +108,9 @@ class PointsTest( unittest.TestCase ) :
 		p = IECoreScene.PointsPrimitive( IECore.V3fVectorData( 10 ) )
 		p["myPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.IntData( 10 ) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetInt( n, "myPrimVar" ), 10 )
 
 	def testVertexPrimitiveVariable( self ) :
@@ -122,9 +122,9 @@ class PointsTest( unittest.TestCase ) :
 
 			self.assertTrue( p.arePrimitiveVariablesValid() )
 
-			with IECoreArnold.UniverseBlock( writable = True ) :
+			with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-				n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+				n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 				a = arnold.AiNodeGetArray( n, "myPrimVar" )
 				self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 10 )
 				for i in range( 0, 10 ) :
@@ -136,9 +136,9 @@ class PointsTest( unittest.TestCase ) :
 		p["truePrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 		p["falsePrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( False ) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( p, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( p, universe, "testPoints" )
 			self.assertEqual( arnold.AiNodeGetBool( n, "truePrimVar" ), True )
 			self.assertEqual( arnold.AiNodeGetBool( n, "falsePrimVar" ), False )
 
@@ -156,9 +156,9 @@ class PointsTest( unittest.TestCase ) :
 			IECore.FloatVectorData( [ 2 ] * 10 ),
 		)
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( [ p1, p2 ], -0.25, 0.25, "testPoints" )
+			n = IECoreArnold.NodeAlgo.convert( [ p1, p2 ], -0.25, 0.25, universe, "testPoints" )
 
 			a = arnold.AiNodeGetArray( n, "points" )
 			self.assertEqual( arnold.AiArrayGetNumElements( a.contents ), 10 )

--- a/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/SphereAlgoTest.py
@@ -46,9 +46,9 @@ class SphereAlgoTest( unittest.TestCase ) :
 	def testConvert( self ) :
 
 		s = IECoreScene.SpherePrimitive( 0.25 )
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( s, "testSphere" )
+			n = IECoreArnold.NodeAlgo.convert( s, universe, "testSphere" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( n ) ), "sphere" )
 			self.assertEqual( arnold.AiNodeGetFlt( n, "radius" ), 0.25 )
 
@@ -56,9 +56,9 @@ class SphereAlgoTest( unittest.TestCase ) :
 
 		s = [ IECoreScene.SpherePrimitive( 0.25 ), IECoreScene.SpherePrimitive( 0.5 ) ]
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( s, 0, 1, "testSphere" )
+			n = IECoreArnold.NodeAlgo.convert( s, 0, 1, universe, "testSphere" )
 			self.assertEqual( arnold.AiNodeEntryGetName( arnold.AiNodeGetNodeEntry( n ) ), "sphere" )
 
 			a = arnold.AiNodeGetArray( n, "radius" )
@@ -79,9 +79,9 @@ class SphereAlgoTest( unittest.TestCase ) :
 		s["f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, 2.5 )
 		s["m"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, imath.M44f( 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) )
 
-		with IECoreArnold.UniverseBlock( writable = True ) :
+		with IECoreArnold.UniverseBlock( writable = True ) as universe :
 
-			n = IECoreArnold.NodeAlgo.convert( s, "testSphere" )
+			n = IECoreArnold.NodeAlgo.convert( s, universe, "testSphere" )
 			self.assertEqual( arnold.AiNodeGetVec( n, "v" ), arnold.AtVector( 1, 2, 3 ) )
 			self.assertEqual( arnold.AiNodeGetRGB( n, "c" ), arnold.AtRGB( 1, 2, 3 ) )
 			self.assertEqual( arnold.AiNodeGetStr( n, "s" ), "test" )

--- a/contrib/IECoreArnold/test/IECoreArnold/UniverseBlockTest.py
+++ b/contrib/IECoreArnold/test/IECoreArnold/UniverseBlockTest.py
@@ -45,9 +45,12 @@ import IECoreArnold
 
 class UniverseBlockTest( unittest.TestCase ) :
 
+	__usingMultipleUniverses = [ int( v ) for v in arnold.AiGetVersion()[:3] ] >= [ 7, 0, 0 ]
+
 	def test( self ) :
 
-		self.assertFalse( arnold.AiUniverseIsActive() )
+		if not self.__usingMultipleUniverses :
+			self.assertFalse( arnold.AiUniverseIsActive() )
 
 		with IECoreArnold.UniverseBlock( writable = False ) :
 
@@ -72,7 +75,8 @@ class UniverseBlockTest( unittest.TestCase ) :
 			self.assertTrue( arnold.AiUniverseIsActive() )
 
 			createBlock( False )
-			self.assertRaisesRegexp( RuntimeError, "Arnold is already in use", createBlock, True )
+			if not self.__usingMultipleUniverses :
+				self.assertRaisesRegexp( RuntimeError, "Arnold is already in use", createBlock, True )
 
 		with IECoreArnold.UniverseBlock( writable = False ) :
 
@@ -82,10 +86,6 @@ class UniverseBlockTest( unittest.TestCase ) :
 			createBlock( False )
 
 	def testMetadataLoading( self ) :
-
-		os.environ["ARNOLD_PLUGIN_PATH"] = os.path.join( os.path.dirname( __file__ ), "metadata" )
-		with IECoreArnold.UniverseBlock( writable = True ) :
-			pass
 
 		with IECoreArnold.UniverseBlock( writable = False ) :
 
@@ -107,6 +107,7 @@ class UniverseBlockTest( unittest.TestCase ) :
 			arnold.AiMetaDataGetInt( e, "AA_samples", "cortex.testInt", i )
 			self.assertEqual( i.value, 12 )
 
+	@unittest.skipIf( __usingMultipleUniverses, "Not relevant" )
 	def testReadOnlyUniverseDoesntPreventWritableUniverseCleanup( self ) :
 
 		with IECoreArnold.UniverseBlock( writable = False ) :


### PR DESCRIPTION
Back in Arnold 5.2, an `AiUniverse()` function was added to allow the creation of secondary universes, and an `AtUniverse *` argument was added to API methods such as `AiNode()`. We've been using the older deprecated API ever since then, so this PR finally updates to use the newer functions. It also adds a build flag that turns on deprecation warnings for the Arnold API, forcing to catch problems much more quickly in future.