### PR TITLE
USDScene : Add basic support for custom attributes

### DIFF
--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -1,0 +1,10 @@
+#usda 1.0
+
+def Sphere "sphere"
+{
+	custom string customNotNamespaced = "red"
+	custom string customNamespaced:test = "green"
+	string notNamespaced = "blue"
+	string namespaced:test = "purple"
+	double radius = 10
+}


### PR DESCRIPTION
The appropriate mapping from USD's everything-is-an-attribute approach to Cortex's RenderMan-esque approach isn't especially clear. The waters are further muddied by constant primvars in USD, which can be written onto non-primitive locations, and would in many cases want to be treated as attributes in Cortex. And this is all made worse by the Cortex convention that attributes without a (colon delimited) namespace are standard attributes that should be supported by all renderer backends.

Here we're sidestepping the complexities above by adding support for an extremely limited subset of attributes - custom attributes whose name includes a colon delimited namespace. This is sufficient to enable some key workflows at Cinesite, without committing to any particular approach to deal with the complexities above.

