### PR TITLE
UniverseBlock : Add `universe()` method

### DIFF
--- a/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
+++ b/contrib/IECoreArnold/include/IECoreArnold/UniverseBlock.h
@@ -39,6 +39,8 @@
 
 #include "boost/noncopyable.hpp"
 
+#include "ai_universe.h"
+
 namespace IECoreArnold
 {
 
@@ -61,6 +63,8 @@ class IECOREARNOLD_API UniverseBlock : public boost::noncopyable
 		/// universes active to avoid the startup cost the next
 		/// time around.
 		~UniverseBlock();
+
+		AtUniverse *universe() { return nullptr; } // We always use the default universe at present
 
 	private :
 

--- a/contrib/IECoreArnold/python/IECoreArnold/UniverseBlock.py
+++ b/contrib/IECoreArnold/python/IECoreArnold/UniverseBlock.py
@@ -43,6 +43,7 @@ class UniverseBlock :
 	def __enter__( self ) :
 
 		self.__universeBlock = _IECoreArnold._UniverseBlock( self.__writable )
+		return self.__universeBlock.universe()
 
 	def __exit__( self, type, value, traceBack ) :
 

--- a/contrib/IECoreArnold/src/IECoreArnold/bindings/UniverseBlockBinding.cpp
+++ b/contrib/IECoreArnold/src/IECoreArnold/bindings/UniverseBlockBinding.cpp
@@ -39,6 +39,30 @@
 using namespace boost::python;
 using namespace IECoreArnold;
 
+namespace
+{
+
+object universeWrapper( UniverseBlock &universeBlock )
+{
+	AtUniverse *universe = universeBlock.universe();
+	if( universe )
+	{
+		object arnold = import( "arnold" );
+		object ctypes = import( "ctypes" );
+		return ctypes.attr( "cast" )(
+			(uint64_t)universeBlock.universe(),
+			ctypes.attr( "POINTER" )( object( arnold.attr( "AtUniverse" ) ) )
+		);
+	}
+	else
+	{
+		// Default universe, represented as `None` in Python.
+		return object();
+	}
+}
+
+} // namespace
+
 namespace IECoreArnold
 {
 
@@ -47,7 +71,9 @@ void bindUniverseBlock()
 
 	// This is bound with a preceding _ and then turned into a context
 	// manager for the "with" statement in IECoreArnold/UniverseBlock.py
-	class_<UniverseBlock, boost::noncopyable>( "_UniverseBlock", init<bool>( ( arg( "writable" ) ) ) );
+	class_<UniverseBlock, boost::noncopyable>( "_UniverseBlock", init<bool>( ( arg( "writable" ) ) ) )
+		.def( "universe", &universeWrapper )
+	;
 
 }
 


### PR DESCRIPTION
This is a backport of a single commit from #1171, intended to make it easier to build and test Gaffer with both RB-10.2 and master.