### PR TITLE
Per frame write scene cache file format

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -109,14 +109,22 @@ bool UsdSceneCacheFileFormat::CanRead(const string& filePath) const
 
 bool UsdSceneCacheFileFormat::Read( SdfLayer* layer, const string& resolvedPath, bool metadataOnly) const
 {
-	SdfAbstractDataRefPtr data = InitData( layer->GetFileFormatArguments() );
-	SceneCacheDataRefPtr sccData = TfStatic_cast<SceneCacheDataRefPtr>( data );
-	if ( !sccData->Open( resolvedPath ) )
+	try
+	{
+		layer->SetPermissionToEdit( true );
+		SdfAbstractDataRefPtr data = InitData( layer->GetFileFormatArguments() );
+		SceneCacheDataRefPtr sccData = TfStatic_cast<SceneCacheDataRefPtr>( data );
+		if ( !sccData->Open( resolvedPath ) )
+		{
+			return false;
+		}
+		_SetLayerData( layer, data );
+		return true;
+	}
+	catch( ... )
 	{
 		return false;
 	}
-	_SetLayerData( layer, data );
-	return true;
 }
 
 bool UsdSceneCacheFileFormat::WriteToFile( const SdfLayer& layer, const std::string& filePath, const std::string& comment, const FileFormatArguments& args) const

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -164,7 +164,13 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 		//transform
 		for ( auto& frame : frames )
 		{
-			outChild->writeTransform( inChild->readTransform( frame / fps ).get(), frame / fps );
+			try
+			{
+				outChild->writeTransform( inChild->readTransform( frame / fps ).get(), frame / fps );
+			}
+			catch( ... )
+			{
+			}
 		}
 		// location path
 		SceneInterface::Path currentPath;
@@ -232,7 +238,13 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 							for( const auto& time : times )
 							{
 								const auto& linkData = IECoreScene::LinkedScene::linkAttributeData( locationToLink.get(), time[1] / fps );
-								linkedOutScene->writeAttribute( IECoreScene::LinkedScene::linkAttribute, linkData.get(), time[0] / fps );
+								try
+								{
+									linkedOutScene->writeAttribute( IECoreScene::LinkedScene::linkAttribute, linkData.get(), time[0] / fps );
+								}
+								catch( ... )
+								{
+								}
 							}
 							return;
 						}
@@ -268,7 +280,13 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 		{
 			for ( auto& frame : frames )
 			{
-				outChild->writeObject( inChild->readObject( frame / fps ).get(), frame / fps );
+				try
+				{
+					outChild->writeObject( inChild->readObject( frame / fps ).get(), frame / fps );
+				}
+				catch( ... )
+				{
+				}
 			}
 		}
 
@@ -281,7 +299,13 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 			{
 				if ( inChild->readAttribute( attributeName, frame/ fps ) )
 				{
-					outChild->writeAttribute( attributeName, inChild->readAttribute( attributeName, frame / fps ).get(), frame / fps );
+					try
+					{
+						outChild->writeAttribute( attributeName, inChild->readAttribute( attributeName, frame / fps ).get(), frame / fps );
+					}
+					catch( ... )
+					{
+					}
 				}
 			}
 		}

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -144,7 +144,7 @@ void UsdSceneCacheFileFormat::writeLocation( const SdfLayer& layer, ConstSceneIn
 
 	if ( childName != SceneCacheDataAlgo::internalRootName() )
 	{
-		outChild = outScene->createChild( SceneCacheDataAlgo::fromInternalName( childName ) );
+		outChild = outScene->child( SceneCacheDataAlgo::fromInternalName( childName ), SceneInterface::MissingBehaviour::CreateIfMissing );
 
 		auto frames = layer.ListAllTimeSamples();
 		// static write a single sample.

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.h
@@ -60,7 +60,19 @@ TF_DECLARE_PUBLIC_TOKENS( UsdSceneCacheFileFormatTokens, USD_SCENE_CACHE_FILE_FO
 
 TF_DECLARE_WEAK_AND_REF_PTRS( UsdSceneCacheFileFormat );
 
-
+// We support FileFormatArguments to control the behaviour of the plugin for writing.
+// We can filter time samples within a frame range and support per frame writing.
+//
+// Support per frame write requires all of the following FileFormatArguments:
+//  - perFrameWrite: supported value is "1" when we want to use the per frame writing behaviour
+//   and "0" when write the file by calling WriteToFile only once.
+//  - currentFrame: string encoding the floating point value for the current frame number being written
+//  - firstFrame: string encoding the floating point value for the first frame to be written.
+//  - lastFrame: string encoding the floating point value for the last frame to be written.
+// `firstFrame` and `lastFrame` are used to figure out then we should open the file for writing ( currentFrame == firstFrame ) when using the per frame writing
+//   and when to close the file ( currentFrame == lastFrame ).
+//
+// `firstFrame` and `lastFrame` are also used to filter the time samples to be written ( only the time sample within the range are written ) both when using per frame writing and single write mode.
 class UsdSceneCacheFileFormat : public SdfFileFormat
 {
 	public:
@@ -86,7 +98,8 @@ class UsdSceneCacheFileFormat : public SdfFileFormat
 			const IECore::InternedString & childName,
 			IECoreScene::SceneInterfacePtr outScene,
 			double fps,
-			UsdStageRefPtr stage
+			UsdStageRefPtr stage,
+			std::set<double> frames
 		) const;
 
 	private:

--- a/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.cpp
@@ -1,0 +1,113 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "SdfFileFormatSharedSceneWriters.h"
+
+#include "IECore/LRUCache.h"
+
+using namespace IECore;
+using namespace IECoreScene;
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// Cache implementation
+//////////////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+
+typedef IECore::LRUCache< std::string, IECoreScene::SceneInterfacePtr > SceneLRUCache;
+
+class Cache : public SceneLRUCache
+{
+	public :
+
+		Cache( SceneLRUCache::Cost maxCost )
+			: SceneLRUCache( fileCacheGetter, maxCost )
+		{
+		}
+
+	private :
+
+		static SceneInterfacePtr fileCacheGetter( const std::string &fileName, size_t &cost )
+		{
+			SceneInterfacePtr result = SceneInterface::create( fileName, IECore::IndexedIO::Write );
+			cost = 1;
+			return result;
+		}
+};
+
+Cache &cache()
+{
+	static Cache *cache = new Cache( 200 );
+	return *cache;
+}
+
+} // namespace
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// SdfFileFormatSdfFileFormatSharedSceneWriters implementation
+//////////////////////////////////////////////////////////////////////////////////////////
+namespace IECoreUSD
+{
+SceneInterfacePtr SdfFileFormatSharedSceneWriters::get( const std::string &fileName )
+{
+	return cache().get( fileName );
+}
+
+void SdfFileFormatSharedSceneWriters::close( const std::string &fileName )
+{
+	cache().erase( fileName );
+}
+
+void SdfFileFormatSharedSceneWriters::closeAll()
+{
+	cache().clear();
+}
+
+void SdfFileFormatSharedSceneWriters::setMaxScenes( size_t numScenes )
+{
+	cache().setMaxCost( numScenes );
+}
+
+size_t SdfFileFormatSharedSceneWriters::getMaxScenes()
+{
+	return cache().getMaxCost();
+}
+
+size_t SdfFileFormatSharedSceneWriters::numScenes()
+{
+	return cache().currentCost();
+}
+} // namespace IECoreUSD
+

--- a/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.h
@@ -1,0 +1,73 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREUSD_SDFFILEFORMATSHAREDSCENEWRITERS_H
+#define IECOREUSD_SDFFILEFORMATSHAREDSCENEWRITERS_H
+
+#include "IECoreScene/SceneInterface.h"
+
+using namespace IECoreScene;
+
+namespace IECoreUSD
+{
+
+// Class used to support per frame write when writing USD data from Houdini's Solaris context.
+// We open the scene cache file for writing on the first frame of writing and close it for the last frame of writing.
+class SdfFileFormatSharedSceneWriters
+{
+	public :
+
+		static SceneInterfacePtr get( const std::string &fileName );
+
+		/// Close a single file from the cache
+		static void close( const std::string &fileName );
+
+		/// Close all the scene from the cache
+		static void closeAll();
+
+		/// Sets the limit for the number of scene interfaces that will
+		/// be cached internally.
+		static void setMaxScenes( size_t numScenes );
+		/// Returns the limit for the number of scene interfaces that will
+		/// be cached internally.
+		static size_t getMaxScenes();
+		/// Returns the number of scene interfaces currently in the cache.
+		static size_t numScenes();
+
+};
+
+} // namespace IECoreUSD
+
+#endif // IECOREUSD_SDFFILEFORMATSHAREDSCENEWRITERS_H
+

--- a/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
@@ -177,7 +177,7 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 
 		# root child
 		scene = IECoreScene.SharedSceneInterfaces.get( exportPath )
-		self.assertEqual( scene.childNames(), ["t", "r-invalid"] )
+		self.assertEqual( sorted( scene.childNames() ), sorted( ["t", "r-invalid"] ) )
 
 		# t child names
 		t = scene.child( "t" )


### PR DESCRIPTION
Add support for per frame writing ( Houdini Solaris `flush after each frame write mode` ) and writing only the time samples within the frame range via `SdfFileFormatArgs`. (#1178)

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
