### PR TITLE
Alembic CurvesReader : Fix loading of indexed UVs

### DIFF
--- a/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveWriter.inl
+++ b/contrib/IECoreAlembic/include/IECoreAlembic/PrimitiveWriter.inl
@@ -53,9 +53,12 @@ typename GeomParamType::Sample PrimitiveWriter::geomParamSample( const IECoreSce
 	result.setVals( data->readable() );
 	if( primitiveVariable.indices )
 	{
-		const std::vector<int> &signedIndices = primitiveVariable.indices->readable();
-		std::vector<unsigned int> unsignedIndices( signedIndices.begin(), signedIndices.end() );
-		result.setIndices( unsignedIndices );
+		result.setIndices(
+			Alembic::Abc::UInt32ArraySample(
+				reinterpret_cast<const uint32_t *>( primitiveVariable.indices->readable().data() ),
+				primitiveVariable.indices->readable().size()
+			)
+		);
 	}
 
 	return result;

--- a/contrib/IECoreAlembic/src/IECoreAlembic/CurvesReader.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/CurvesReader.cpp
@@ -36,6 +36,7 @@
 
 #include "IECoreScene/CurvesPrimitive.h"
 
+#include "IECore/DataAlgo.h"
 #include "IECore/MessageHandler.h"
 
 #include "Alembic/AbcGeom/ICurves.h"
@@ -148,9 +149,10 @@ class CurvesReader : public PrimitiveReader
 			{
 				Canceller::check( canceller );
 				readGeomParam( uvsParam, sampleSelector, result.get() );
-				if( auto uvData = result->variableData<V2fVectorData>( "uv" ) )
+				auto it = result->variables.find( "uv" );
+				if( it != result->variables.end() )
 				{
-					uvData->setInterpretation( GeometricData::UV );
+					setGeometricInterpretation( it->second.data.get(), GeometricData::UV );
 				}
 			}
 

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -1948,5 +1948,28 @@ class AlembicSceneTest( unittest.TestCase ) :
 		self.assertLess( time.time() - startTime, 0.06 )
 		self.assertTrue( cancelled[0] )
 
+	def testIndexedCurveUVs( self ) :
+
+		curves = IECoreScene.CurvesPrimitive(
+			verticesPerCurve = IECore.IntVectorData( [ 2, 2 ] ),
+			p = IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 4 ) ] )
+		)
+		curves["uv"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.V2fVectorData( [ imath.V2f( 0 ), imath.V2f( 1 ) ], IECore.GeometricData.Interpretation.UV ),
+			IECore.IntVectorData( [ 0, 1, 0, 1 ] )
+		)
+
+		fileName = os.path.join( self.temporaryDirectory(), "indexedCurveUVs.abc" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root.createChild( "curves" ).writeObject( curves, 0.0 )
+		del root
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual(
+			root.child( "curves" ).readObject( 0.0 ),
+			curves
+		)
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/IECoreScene/bindings/CurvesPrimitiveBinding.cpp
+++ b/src/IECoreScene/bindings/CurvesPrimitiveBinding.cpp
@@ -58,7 +58,11 @@ void bindCurvesPrimitive()
 {
 	RunTimeTypedClass<CurvesPrimitive>()
 		.def( init<>() )
-		.def( init<IntVectorDataPtr, optional<const CubicBasisf &, bool, ConstV3fVectorDataPtr> >() )
+		.def(
+			init<IntVectorDataPtr, const CubicBasisf &, bool, ConstV3fVectorDataPtr>(
+				( arg( "verticesPerCurve" ), arg( "basis" ) = IECore::CubicBasisf::linear(), arg( "periodic" ) = false, arg( "p" ) = object() )
+			)
+		)
 		.def( "numCurves", &CurvesPrimitive::numCurves )
 		.def( "verticesPerCurve", &verticesPerFace, "A copy of the list of vertices per curve." )
 		.def( "basis", &CurvesPrimitive::basis, return_value_policy<copy_const_reference>() )

--- a/test/IECoreScene/CurvesPrimitiveTest.py
+++ b/test/IECoreScene/CurvesPrimitiveTest.py
@@ -94,6 +94,19 @@ class CurvesPrimitiveTest( unittest.TestCase ) :
 		self.assertRaises( Exception, IECoreScene.CurvesPrimitive, IECore.IntVectorData( [ 3 ] ), IECore.CubicBasisf.bSpline() )
 		self.assertRaises( Exception, IECoreScene.CurvesPrimitive, IECore.IntVectorData( [ 5 ] ), IECore.CubicBasisf.bezier() )
 
+	def testConstructorKeywords( self ) :
+
+		c = IECoreScene.CurvesPrimitive(
+			verticesPerCurve = IECore.IntVectorData( [ 3 ] ),
+			periodic = True,
+			p = IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 3 ) ] )
+		)
+
+		self.assertEqual( c.verticesPerCurve(), IECore.IntVectorData( [ 3 ] ) )
+		self.assertEqual( c.periodic(), True )
+		self.assertEqual( c.basis(), IECore.CubicBasisf.linear() )
+		self.assertEqual( c["P"].data, IECore.V3fVectorData( [ imath.V3f( x ) for x in range( 0, 3 ) ], IECore.GeometricData.Interpretation.Point ) )
+
 	def testCopy( self ) :
 
 		i = IECore.IntVectorData( [ 4 ] )


### PR DESCRIPTION
The call to `variableData()` resulted in this error :

```
Primitive::variableData() can only be used for non-indexed variables. Use Primitive::expandedVariableData() or access Primitive::variables directly. Primitive variable name: 'uv'
```