### PR TITLE
Build: Python 3 bytes to str fix

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1382,7 +1382,7 @@ Help( o.GenerateHelpText( env ) )
 
 def getPythonConfig( env, flags ) :
 
-	f = subprocess.Popen( env["PYTHON_CONFIG"] + " " + flags, env=env["ENV"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True )
+	f = subprocess.Popen( env["PYTHON_CONFIG"] + " " + flags, env=env["ENV"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, universal_newlines=True )
 	stdOut, stdErr = f.communicate()
 	r = stdOut.strip()
 	if f.returncode :


### PR DESCRIPTION
Build: Python 3 has a 'bytes' type so it needs to decode to a utf-8 string for a returning std out subprocess.

Generally describe what this PR will do, and why it is needed.

- Fixes Python 3-based SCons builds. Perhaps the check isn't necessary and a decode can be applied for Python 2?

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
- [x] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
