### PR TITLE
CI : Update host OS to Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         include:
 
           - name: linux-python2
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.0.0
             options: .github/workflows/main/options.posix
@@ -49,7 +49,7 @@ jobs:
             publish: true
 
           - name: linux-python2-debug
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: DEBUG
             containerImage: gafferhq/build:1.0.0
             options: .github/workflows/main/options.posix
@@ -58,7 +58,7 @@ jobs:
             publish: false
 
           - name: linux-python3
-            os: ubuntu-16.04
+            os: ubuntu-20.04
             buildType: RELEASE
             containerImage: gafferhq/build:1.0.0
             options: .github/workflows/main/options.posix


### PR DESCRIPTION
As described at actions/virtual-environments#3287, support for Ubuntu 16.04 was dropped by GitHub on September 20th. Our CI workflows are now failing to start because they can't find a worker.

We could update to either 18.04 or 20.04, and I don't know enough to make a truly informed decision between the two. Plumping for 20.04 since if it works, it will give us the longest period before we have to switch up again.

In practice this shouldn't affect us much at all, because we only use the host OS to launch a Docker container with our preferred CentOS7 build environment, and all the real work happens in there.
