### PR TITLE
ComputationCacheTest : relax test for increased memory limit

### DIFF
--- a/test/IECore/ComputationCacheTest.cpp
+++ b/test/IECore/ComputationCacheTest.cpp
@@ -118,8 +118,12 @@ struct ComputationCacheTest
 		cache.get( ComputationParams(4) );
 		cache.get( ComputationParams(5) );
 		BOOST_CHECK_EQUAL( size_t(4), cache.cachedComputations() );
-		BOOST_CHECK( cache.get( ComputationParams(4), Cache::NullIfMissing ) );
-		BOOST_CHECK( cache.get( ComputationParams(5), Cache::NullIfMissing ) );
+		res2 = cache.get( ComputationParams( 2 ), Cache::NullIfMissing );
+		res3 = cache.get( ComputationParams( 3 ), Cache::NullIfMissing );
+		ConstObjectPtr res4 = cache.get( ComputationParams( 4 ), Cache::NullIfMissing );
+		ConstObjectPtr res5 = cache.get( ComputationParams( 5 ), Cache::NullIfMissing );
+		/// Cache should have two values present, two missing
+		BOOST_CHECK_EQUAL( (int)!res2 + (int)!res3 + (int)!res4 + (int)!res5, 2 );
 
 		/// clears the all values
 		cache.clear();


### PR DESCRIPTION
The order of evicted values from a parallel LRUCache can depend on the thread count, causing this test to fail on some hardware configurations. This tests that the correct number of items are in the cache, rather than specific items being in the cache.

### Related Issues ###

- #1191

### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
- [X] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
