### PR TITLE
IECoreScene Windows tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
             buildType: RELEASE
             options: .github/workflows/main/options.windows
             dependenciesURL: https://github.com/hypothetical-inc/gafferDependencies/releases/download/3.1.1/gafferDependencies-3.1.1-Python3-windows.zip
-            tests: testCore testCorePython testImage
+            tests: testCore testCorePython testScene testImage
             publish: false
 
     runs-on: ${{ matrix.os }}

--- a/Changes
+++ b/Changes
@@ -7,6 +7,9 @@ Improvements
 ----
 
 - IECoreArnold : Prepare for multiple universes (#1171)
+- LinkedScene : Path element separators (forward and backslash) are now platform independent.
+  - Paths are internally stored using forward slash only.
+  - Paths are returned by `readAttribute` in OS-native format.
 
 Fixes
 -----

--- a/src/IECore/IndexedIO.cpp
+++ b/src/IECore/IndexedIO.cpp
@@ -37,6 +37,7 @@
 #include "IECore/Exception.h"
 
 #include "boost/filesystem/convenience.hpp"
+#include "boost/algorithm/string.hpp"
 
 #include <iostream>
 
@@ -76,6 +77,7 @@ IndexedIOPtr IndexedIO::create( const std::string &path, const IndexedIO::EntryI
 	IndexedIOPtr result = nullptr;
 
 	std::string extension = fs::extension(path);
+	boost::to_lower( extension );
 
 	const CreatorMap &createFns = creators();
 
@@ -101,9 +103,11 @@ void IndexedIO::registerCreator( const std::string &extension, CreatorFn f )
 {
 	CreatorMap &createFns = creators();
 
-	assert( createFns.find(extension) == createFns.end() );
+	const std::string extensionLower = boost::algorithm::to_lower_copy( extension );
 
-	createFns.insert( CreatorMap::value_type(extension, f) );
+	assert( createFns.find(extensionLower) == createFns.end() );
+
+	createFns.insert( CreatorMap::value_type(extensionLower, f) );
 }
 
 IndexedIO::~IndexedIO()

--- a/test/IECoreScene/All.py
+++ b/test/IECoreScene/All.py
@@ -107,6 +107,9 @@ from SceneAlgo import *
 from ShaderNetworkTest import ShaderNetworkTest
 from ShaderNetworkAlgoTest import ShaderNetworkAlgoTest
 from SharedSceneInterfacesTest import SharedSceneInterfacesTest
+from SceneInterfaceTest import SceneInterfaceTest
+from TransferSmoothSkinningWeightsOpTest import TransferSmoothSkinningWeightsOpTest
+from TypedPrimitiveOp import TestTypedPrimitiveOp
 
 if IECore.withFreeType() :
 	from FontTest import *

--- a/test/IECoreScene/Camera.py
+++ b/test/IECoreScene/Camera.py
@@ -57,8 +57,8 @@ class TestCamera( unittest.TestCase ) :
 		self.assertEqual( cc.parameters(), IECore.CompoundData() )
 		self.assertEqual( cc, c )
 
-		IECore.Writer.create( cc, "test/IECore/data/camera.cob" ).write()
-		ccc = IECore.Reader.create( "test/IECore/data/camera.cob" ).read()
+		IECore.Writer.create( cc, os.path.join( "test", "IECore", "data", "camera.cob" ) ).write()
+		ccc = IECore.Reader.create( os.path.join( "test", "IECore", "data", "camera.cob" ) ).read()
 
 		self.assertEqual( c, ccc )
 
@@ -69,8 +69,8 @@ class TestCamera( unittest.TestCase ) :
 		cc = c.copy()
 		self.assertEqual( cc, c )
 
-		IECore.Writer.create( cc, "test/IECore/data/camera.cob" ).write()
-		ccc = IECore.Reader.create( "test/IECore/data/camera.cob" ).read()
+		IECore.Writer.create( cc, os.path.join( "test", "IECore", "data", "camera.cob" ) ).write()
+		ccc = IECore.Reader.create( os.path.join( "test", "IECore", "data", "camera.cob" ) ).read()
 		self.assertEqual( ccc, c )
 
 	def testCameraParameters( self ) :
@@ -309,8 +309,8 @@ class TestCamera( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/IECore/data/camera.cob" ) :
-			os.remove( "test/IECore/data/camera.cob" )
+		if os.path.isfile( os.path.join( "test", "IECore", "data", "camera.cob" ) ) :
+			os.remove( os.path.join( "test", "IECore", "data", "camera.cob" ) )
 
 if __name__ == "__main__":
         unittest.main()

--- a/test/IECoreScene/CoordinateSystemTest.py
+++ b/test/IECoreScene/CoordinateSystemTest.py
@@ -51,8 +51,8 @@ class CoordinateSystemTest( unittest.TestCase ) :
 		aa = a.copy()
 		self.assertEqual( a, aa )
 
-		IECore.ObjectWriter( a, "test/IECore/data/coordSys.cob" ).write()
-		aaa = IECore.ObjectReader( "test/IECore/data/coordSys.cob" ).read()
+		IECore.ObjectWriter( a, os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).write()
+		aaa = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).read()
 
 		self.assertEqual( aaa, aa )
 		self.assertEqual( aaa.getName(), "b" )
@@ -103,7 +103,7 @@ class CoordinateSystemTest( unittest.TestCase ) :
 
 	def testLoadCobFromBeforeTransforms( self ) :
 
-		c = IECore.ObjectReader( "test/IECore/data/cobFiles/coordinateSystemBeforeTransforms.cob" ).read()
+		c = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "cobFiles", "coordinateSystemBeforeTransforms.cob" ) ).read()
 
 		self.assertEqual( c.getName(), "test" )
 		self.assertEqual( c.getTransform(), None )
@@ -111,14 +111,14 @@ class CoordinateSystemTest( unittest.TestCase ) :
 	def testLoadCobWithTransform( self ) :
 
 		c = IECoreScene.CoordinateSystem( "test", IECoreScene.MatrixTransform( imath.M44f() ) )
-		IECore.ObjectWriter( c, "test/IECore/data/coordSys.cob" ).write()
-		c = IECore.ObjectReader( "test/IECore/data/coordSys.cob" ).read()
+		IECore.ObjectWriter( c, os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).write()
+		c = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).read()
 
 		self.assertEqual( c.getTransform(), IECoreScene.MatrixTransform( imath.M44f() ) )
 
 		c = IECoreScene.CoordinateSystem( "test", None )
-		IECore.ObjectWriter( c, "test/IECore/data/coordSys.cob" ).write()
-		c = IECore.ObjectReader( "test/IECore/data/coordSys.cob" ).read()
+		IECore.ObjectWriter( c, os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).write()
+		c = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "coordSys.cob" ) ).read()
 
 		self.assertEqual( c.getTransform(), None )
 
@@ -151,9 +151,9 @@ class CoordinateSystemTest( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.exists( "test/IECore/data/coordSys.cob" ) :
+		if os.path.exists( os.path.join( "test", "IECore", "data", "coordSys.cob" ) ) :
 
-			os.remove( "test/IECore/data/coordSys.cob" )
+			os.remove( os.path.join( "test", "IECore", "data", "coordSys.cob" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/CurveExtrudeOp.py
+++ b/test/IECoreScene/CurveExtrudeOp.py
@@ -44,7 +44,7 @@ class CurveExtrudeOpTest( unittest.TestCase ) :
 
 	def testIt( self ) :
 
-		c = IECore.Reader.create( "test/IECore/data/cobFiles/torusCurves.cob" ).read()
+		c = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "torusCurves.cob" ) ).read()
 		assert( c.arePrimitiveVariablesValid() )
 
 		op = IECoreScene.CurveExtrudeOp()

--- a/test/IECoreScene/CurveLineariserTest.py
+++ b/test/IECoreScene/CurveLineariserTest.py
@@ -34,6 +34,9 @@
 
 import unittest
 import imath
+import os
+import tempfile
+import shutil
 import IECore
 import IECoreScene
 
@@ -58,8 +61,9 @@ class CurveLineariserTest( unittest.TestCase ) :
 
 		curves["constantwidth"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 0.001 ) )
 		curves2["constantwidth"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 0.001 ) )
-		IECore.ObjectWriter( curves, "/tmp/c.cob" ).write()
-		IECore.ObjectWriter( curves2, "/tmp/c2.cob" ).write()
+		tempDir = tempfile.mkdtemp()
+		IECore.ObjectWriter( curves, os.path.join( tempDir, "c.cob" ) ).write()
+		IECore.ObjectWriter( curves2, os.path.join( tempDir, "c2.cob" ) ).write()
 
 		for curveIndex in range( 0, curves.numCurves() ) :
 
@@ -84,6 +88,8 @@ class CurveLineariserTest( unittest.TestCase ) :
 						self.assertTrue( pv.equalWithAbsError( pv2, 0.005 ) )
 					else :
 						self.assertEqual( pv, pv2 )
+
+		shutil.rmtree( tempDir )
 
 	def test3SegmentBSpline( self ) :
 

--- a/test/IECoreScene/CurvesPrimitiveEvaluatorTest.py
+++ b/test/IECoreScene/CurvesPrimitiveEvaluatorTest.py
@@ -38,6 +38,9 @@ import time
 import threading
 import math
 import unittest
+import tempfile
+import os
+import shutil
 import imath
 import IECore
 import IECoreScene
@@ -1176,6 +1179,8 @@ class CurvesPrimitiveEvaluatorTest( unittest.TestCase ) :
 
 		rand = imath.Rand32()
 
+		tempDir = tempfile.mkdtemp()
+
 		for basis in ( IECore.CubicBasisf.linear(), IECore.CubicBasisf.bezier(), IECore.CubicBasisf.bSpline(), IECore.CubicBasisf.catmullRom() ) :
 
 			for i in range( 0, 10 ) :
@@ -1198,7 +1203,7 @@ class CurvesPrimitiveEvaluatorTest( unittest.TestCase ) :
 				curves = IECoreScene.CurvesPrimitive( vertsPerCurve, basis, False, p )
 
 				curves["constantwidth"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 0.01 ) )
-				IECore.ObjectWriter( curves, "/tmp/curves.cob" ).write()
+				IECore.ObjectWriter( curves, os.path.join( tempDir, "curves.cob" ) ).write()
 
 				e = IECoreScene.CurvesPrimitiveEvaluator( curves )
 				result = e.createResult()
@@ -1222,6 +1227,8 @@ class CurvesPrimitiveEvaluatorTest( unittest.TestCase ) :
 
 						self.assertTrue( abs( (p2 - p).length() ) < 0.05 )
 						self.assertEqual( c2, c )
+
+		shutil.rmtree( tempDir )
 
 	def testTopologyMethods( self ) :
 

--- a/test/IECoreScene/CurvesPrimitiveTest.py
+++ b/test/IECoreScene/CurvesPrimitiveTest.py
@@ -122,13 +122,13 @@ class CurvesPrimitiveTest( unittest.TestCase ) :
 		p = IECore.V3fVectorData( [ imath.V3f( 0 ), imath.V3f( 1 ), imath.V3f( 2 ), imath.V3f( 3 ) ] )
 		c = IECoreScene.CurvesPrimitive( i, IECore.CubicBasisf.bSpline(), True, p )
 
-		IECore.Writer.create( c, "test/IECore/data/curves.cob" ).write()
+		IECore.Writer.create( c, os.path.join( "test", "IECore", "data", "curves.cob" ) ).write()
 
-		cc = IECore.Reader.create( "test/IECore/data/curves.cob" ).read()
+		cc = IECore.Reader.create( os.path.join( "test", "IECore", "data", "curves.cob" ) ).read()
 
 		self.assertEqual( cc, c )
 
-		c = IECore.Reader.create( "test/IECore/data/cobFiles/torusCurves.cob" ).read()
+		c = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "torusCurves.cob" ) ).read()
 
 	def testVariableSize( self ) :
 
@@ -226,8 +226,8 @@ class CurvesPrimitiveTest( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/IECore/data/curves.cob" ) :
-			os.remove( "test/IECore/data/curves.cob" )
+		if os.path.isfile( os.path.join( "test", "IECore", "data", "curves.cob" ) ) :
+			os.remove( os.path.join( "test", "IECore", "data", "curves.cob" ) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/DiskPrimitiveTest.py
+++ b/test/IECoreScene/DiskPrimitiveTest.py
@@ -69,7 +69,7 @@ class DiskPrimitiveTest( unittest.TestCase ) :
 
 		p = IECoreScene.DiskPrimitive( 2, 1, 180 )
 
-		io = IECore.IndexedIO.create( "test/IECore/disk.fio", IECore.IndexedIO.OpenMode.Write )
+		io = IECore.IndexedIO.create( os.path.join( "test", "IECore", "disk.fio" ), IECore.IndexedIO.OpenMode.Write )
 		p.save( io, "test" )
 		pp = IECore.Object.load( io, "test" )
 
@@ -77,8 +77,8 @@ class DiskPrimitiveTest( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/IECore/disk.fio" ) :
-			os.remove( "test/IECore/disk.fio" )
+		if os.path.isfile( os.path.join( "test", "IECore", "disk.fio" ) ) :
+			os.remove( os.path.join( "test", "IECore", "disk.fio" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/FontTest.py
+++ b/test/IECoreScene/FontTest.py
@@ -34,6 +34,7 @@
 
 import unittest
 import threading
+import os
 
 import IECore
 import IECoreScene
@@ -42,13 +43,13 @@ class FontTest( unittest.TestCase ) :
 
 	def testConstructors( self ) :
 
-		f = IECoreScene.Font( "test/IECore/data/fonts/Vera.ttf" )
+		f = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
 
 		self.assertRaises( Exception, IECoreScene.Font, "notAFont" )
 
 	def test( self ) :
 
-		f = IECoreScene.Font( "test/IECore/data/fonts/Vera.ttf" )
+		f = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
 
 		g = f.meshGroup( "hello world" )
 		m = f.mesh( "hello world" )
@@ -70,7 +71,7 @@ class FontTest( unittest.TestCase ) :
 
 	def testCharBound( self ) :
 
-		f = IECoreScene.Font( "test/IECore/data/fonts/Vera.ttf" )
+		f = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
 
 		b = f.bound()
 		for c in range( 0, 128 ) :
@@ -80,7 +81,7 @@ class FontTest( unittest.TestCase ) :
 
 	def testThreading( self ) :
 
-		font = IECoreScene.Font( "test/IECore/data/fonts/Vera.ttf" )
+		font = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
 
 		def f() :
 
@@ -98,7 +99,7 @@ class FontTest( unittest.TestCase ) :
 
 	def testLineSpacing( self ) :
 
-		font = IECoreScene.Font( "test/IECore/data/fonts/Vera.ttf" )
+		font = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
 		self.assertAlmostEqual( font.getLineSpacing(), 1.2 )
 
 		font.setLineSpacing( 1.25 )

--- a/test/IECoreScene/Group.py
+++ b/test/IECoreScene/Group.py
@@ -77,9 +77,9 @@ class TestGroup( unittest.TestCase ) :
 		self.assertTrue( not gg.children()[0].isSame( g.children()[0] ) )
 		self.assertTrue( not gg.state()[0].isSame( g.state()[0] ) )
 
-		IECore.ObjectWriter( g, "test/group.cob" ).write()
+		IECore.ObjectWriter( g, os.path.join( "test", "group.cob" ) ).write()
 
-		ggg = IECore.ObjectReader( "test/group.cob" ).read()
+		ggg = IECore.ObjectReader( os.path.join( "test", "group.cob" ) ).read()
 
 		self.assertEqual( gg, ggg )
 		self.assertTrue( not gg.children()[0].isSame(ggg.children()[0] ) )
@@ -98,9 +98,9 @@ class TestGroup( unittest.TestCase ) :
 			child.blindData()["id"] = IECore.IntData( i )
 			g.addChild( child )
 
-		IECore.ObjectWriter( g, "test/group.cob" ).write()
+		IECore.ObjectWriter( g, os.path.join( "test", "group.cob" ) ).write()
 
-		ggg = IECore.ObjectReader( "test/group.cob" ).read()
+		ggg = IECore.ObjectReader( os.path.join( "test", "group.cob" ) ).read()
 
 		for i in range( 100 ):
 
@@ -318,8 +318,8 @@ class TestGroup( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile("test/group.cob"):
-			os.remove("test/group.cob")
+		if os.path.isfile(os.path.join( "test", "group.cob" )):
+			os.remove(os.path.join( "test", "group.cob" ))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/IDXReaderTest.py
+++ b/test/IECoreScene/IDXReaderTest.py
@@ -34,6 +34,7 @@
 
 import unittest
 import imath
+import os
 import IECore
 import IECoreScene
 
@@ -44,12 +45,12 @@ class IDXReaderTest( unittest.TestCase ) :
 		r = IECoreScene.IDXReader()
 		self.assertEqual( r["fileName"].getTypedValue(), "" )
 
-		r = IECoreScene.IDXReader( "test/IECore/data/idxFiles/test.idx" )
-		self.assertEqual( r["fileName"].getTypedValue(), "test/IECore/data/idxFiles/test.idx" )
+		r = IECoreScene.IDXReader( os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) )
+		self.assertEqual( r["fileName"].getTypedValue(), os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) )
 
 	def testReading( self ) :
 
-		r = IECoreScene.IDXReader( "test/IECore/data/idxFiles/test.idx" )
+		r = IECoreScene.IDXReader( os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) )
 
 		o = r.read()
 
@@ -78,12 +79,12 @@ class IDXReaderTest( unittest.TestCase ) :
 
 	def testCanRead( self ) :
 
-		self.assertTrue( IECoreScene.IDXReader.canRead( "test/IECore/data/idxFiles/test.idx" ) )
-		self.assertFalse( IECoreScene.IDXReader.canRead( "test/IECore/data/cobFiles/ball.cob" ) )
+		self.assertTrue( IECoreScene.IDXReader.canRead( os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) ) )
+		self.assertFalse( IECoreScene.IDXReader.canRead( os.path.join( "test", "IECore", "data", "cobFiles", "ball.cob" ) ) )
 
 	def testRegistration( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/idxFiles/test.idx" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) )
 		self.assertTrue( isinstance( r, IECoreScene.IDXReader ) )
 
 if __name__ == "__main__":

--- a/test/IECoreScene/LinkedSceneTest.py
+++ b/test/IECoreScene/LinkedSceneTest.py
@@ -117,7 +117,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		attr = IECoreScene.LinkedScene.linkAttributeData( m )
 		expectedAttr = IECore.CompoundData(
 			{
-				"fileName": IECore.StringData(os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" )),
+				"fileName": IECore.StringData("/".join( [ "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ] ) ),
 				"root": IECore.InternedStringVectorData( [] )
 			}
 		)
@@ -127,7 +127,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		attr = IECoreScene.LinkedScene.linkAttributeData( A )
 		expectedAttr = IECore.CompoundData(
 			{
-				"fileName": IECore.StringData(os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" )),
+				"fileName": IECore.StringData("/".join( [ "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ] ) ),
 				"root": IECore.InternedStringVectorData( [ 'A' ] )
 			}
 		)
@@ -1160,6 +1160,37 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( r.readSet( "don" ), IECore.PathMatcher(['/C', '/C/D/A'] ) )
 		self.assertEqual( r.readSet( "stew" ), IECore.PathMatcher(['/C/D/A/B'] ) )
+
+	def testPathIsNative( self ):
+
+		targetSceneFile = os.path.join( self.tempDir, "target.scc" )
+
+		w = IECoreScene.LinkedScene( targetSceneFile, IECore.IndexedIO.OpenMode.Write )
+		A = w.createChild( "A" )
+		B = A.createChild( "B" )
+
+		del B, A, w
+
+		r = IECoreScene.SceneCache( targetSceneFile, IECore.IndexedIO.OpenMode.Read )
+
+		sceneFile = os.path.join( self.tempDir, "scene.lscc" )
+		w = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
+		C = w.createChild( "C" )
+		
+		C.writeLink( r )
+
+		del w, C
+
+		r = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Read )
+		C = r.child( "C" )
+
+		self.assertEqual(
+			C.readAttribute( IECoreScene.LinkedScene.fileNameLinkAttribute, 0 ),
+			IECore.StringData( targetSceneFile )
+		)
+
+		self.assertEqual( C.childNames(), [ "A" ] )
+
 
 	def setUp( self ) :
 		self.tempDir = tempfile.mkdtemp()

--- a/test/IECoreScene/LinkedSceneTest.py
+++ b/test/IECoreScene/LinkedSceneTest.py
@@ -692,8 +692,8 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertEqual( i2.childNames(), [ "a" ] )
 		del l, i0, i1, i2
 
-		os.remove( os.path.join( self.tempDir, "toBeRemoved.scc" ) )
 		IECoreScene.SharedSceneInterfaces.clear()
+		os.remove( os.path.join( self.tempDir, "toBeRemoved.scc" ) )
 
 		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( sorted(l.childNames()), [ "instance0", "instance1", "instance2" ] )

--- a/test/IECoreScene/LinkedSceneTest.py
+++ b/test/IECoreScene/LinkedSceneTest.py
@@ -37,6 +37,8 @@ import sys
 import os
 import math
 import unittest
+import tempfile
+import shutil
 
 import IECore
 import IECoreScene
@@ -71,38 +73,38 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testFactoryFunction( self ):
 		# test Write factory function
-		m = IECoreScene.SceneInterface.create( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		m = IECoreScene.SceneInterface.create( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		self.assertTrue( isinstance( m, IECoreScene.LinkedScene ) )
-		self.assertEqual( m.fileName(), "/tmp/test.lscc" )
+		self.assertEqual( m.fileName(), os.path.join( self.tempDir, "test.lscc" ) )
 		self.assertRaises( RuntimeError, m.readBound, 0.0 )
 		del m
 		# test Read factory function
-		m = IECoreScene.SceneInterface.create( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneInterface.create( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( m.attributeNames(), [])
 		self.assertTrue( isinstance( m, IECoreScene.LinkedScene ) )
-		self.assertEqual( m.fileName(), "/tmp/test.lscc" )
+		self.assertEqual( m.fileName(), os.path.join( self.tempDir, "test.lscc" ) )
 		m.readBound( 0.0 )
 
 	def testConstructors( self ):
 
 		# test Read from a previously opened scene.
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		l = IECoreScene.LinkedScene( m )
 		# test Write mode
-		m = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		m = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		self.assertTrue( isinstance( m, IECoreScene.LinkedScene ) )
-		self.assertEqual( m.fileName(), "/tmp/test.lscc" )
+		self.assertEqual( m.fileName(), os.path.join( self.tempDir, "test.lscc" ) )
 		self.assertRaises( RuntimeError, m.readBound, 0.0 )
 		del m
 		# test Read mode
-		m = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertTrue( isinstance( m, IECoreScene.LinkedScene ) )
-		self.assertEqual( m.fileName(), "/tmp/test.lscc" )
+		self.assertEqual( m.fileName(), os.path.join( self.tempDir, "test.lscc" ) )
 		m.readBound( 0.0 )
 
 	def testAppendRaises( self ) :
-		self.assertRaises( RuntimeError, IECoreScene.SceneInterface.create, "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Append )
-		self.assertRaises( RuntimeError, IECoreScene.LinkedScene, "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Append )
+		self.assertRaises( RuntimeError, IECoreScene.SceneInterface.create, os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Append )
+		self.assertRaises( RuntimeError, IECoreScene.LinkedScene, os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Append )
 
 	def testReadNonExistentRaises( self ) :
 		self.assertRaises( RuntimeError, IECoreScene.LinkedScene, "iDontExist.lscc", IECore.IndexedIO.OpenMode.Read )
@@ -111,11 +113,11 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( IECoreScene.LinkedScene.linkAttribute, "sceneInterface:link" )
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		attr = IECoreScene.LinkedScene.linkAttributeData( m )
 		expectedAttr = IECore.CompoundData(
 			{
-				"fileName": IECore.StringData("test/IECore/data/sccFiles/animatedSpheres.scc"),
+				"fileName": IECore.StringData(os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" )),
 				"root": IECore.InternedStringVectorData( [] )
 			}
 		)
@@ -125,7 +127,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		attr = IECoreScene.LinkedScene.linkAttributeData( A )
 		expectedAttr = IECore.CompoundData(
 			{
-				"fileName": IECore.StringData("test/IECore/data/sccFiles/animatedSpheres.scc"),
+				"fileName": IECore.StringData(os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" )),
 				"root": IECore.InternedStringVectorData( [ 'A' ] )
 			}
 		)
@@ -141,11 +143,11 @@ class LinkedSceneTest( unittest.TestCase ) :
 		generateTestFiles = False	# change this to True to recreate the LinkedScene files for other tests.
 		testFilesSuffix = "_newTags"
 		if generateTestFiles :
-			outputPath = "test/IECore/data/sccFiles"
+			outputPath = os.path.join( "test", "IECore", "data", "sccFiles" )
 		else :
-			outputPath = "/tmp"
+			outputPath = self.tempDir
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		A = m.child("A")
 
 		l = IECoreScene.LinkedScene( os.path.join(outputPath,"instancedSpheres%s.lscc"%testFilesSuffix), IECore.IndexedIO.OpenMode.Write )
@@ -230,9 +232,9 @@ class LinkedSceneTest( unittest.TestCase ) :
 		messageHandler = IECore.CapturingMessageHandler()
 		with messageHandler :
 
-			m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+			m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 
-			l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+			l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 			i0 = l.createChild("instance0")
 			i0.writeLink( m )
 
@@ -249,9 +251,9 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testTimeRemapping( self ):
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		# save animated spheres with double the speed and with offset, using less samples (time remapping)
 		i0 = l.createChild("instance0")
 		i0.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( m, 0.0 ), 1.0 )
@@ -270,7 +272,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del i0, i1, i2, l
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( l.numBoundSamples(), 5 )
 		self.assertEqual( l.hasAttribute( "sceneInterface:link.time" ), False )
 		i0 = l.child("instance0")
@@ -332,29 +334,29 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testNestedTimeRemapping( self ):
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 
 		A = m.child("A")
 
-		l2 = IECoreScene.LinkedScene( "/tmp/test3.lscc", IECore.IndexedIO.OpenMode.Write )
+		l2 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test3.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		t2 = l2.createChild("transform2")
 		i2 = t2.createChild("instance2")
 		i2.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( m, 0.0 ), 0.0 )
 		i2.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( m, 2.0 ), 1.0 )
 
 		del l2, i2, t2
-		l2 = IECoreScene.LinkedScene( "/tmp/test3.lscc", IECore.IndexedIO.OpenMode.Read )
+		l2 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test3.lscc" ), IECore.IndexedIO.OpenMode.Read )
 
-		l1 = IECoreScene.LinkedScene( "/tmp/test2.lscc", IECore.IndexedIO.OpenMode.Write )
+		l1 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test2.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		t1 = l1.createChild("transform1")
 		i1 = t1.createChild("instance1")
 		i1.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( l2, 0.0 ), 0.0 )
 		i1.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( l2, 2.0 ), 1.0 )
 
 		del l1, i1, t1
-		l1 = IECoreScene.LinkedScene( "/tmp/test2.lscc", IECore.IndexedIO.OpenMode.Read )
+		l1 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test2.lscc" ), IECore.IndexedIO.OpenMode.Read )
 
-		l0 = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l0 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		t0 = l0.createChild("transform0")
 		i0 = t0.createChild("instance0")
 		i0.writeAttribute( IECoreScene.LinkedScene.linkAttribute, IECoreScene.LinkedScene.linkAttributeData( l1, 0.0 ), 0.0 )
@@ -362,8 +364,8 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del l0, i0, t0
 
-		l0 = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
-		l = IECoreScene.LinkedScene( "/tmp/testTop.lscc", IECore.IndexedIO.OpenMode.Write )
+		l0 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "testTop.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		t = l.createChild("transform")
 		i = t.createChild("instance")
 		i.writeLink( l0 )
@@ -373,7 +375,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del m, l0, l1, l2
 
-		l = IECoreScene.LinkedScene( "/tmp/testTop.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "testTop.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		t = l.child("transform")
 		i = t.child("instance")
 		t0 = i.child("transform0")
@@ -407,7 +409,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertEqual( i2.readAttribute( "sceneInterface:link.time", 0 ).value, 0 )
 
 		# test multiple retiming of the transform:
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		Aa = m.child("A")
 		self.assertEqual( Aa.readTransformAsMatrix( 0.1 ), A.readTransformAsMatrix( 0.1 / 8 ) )
 		self.assertEqual( Aa.readTransformAsMatrix( 0.2 ), A.readTransformAsMatrix( 0.2 / 8 ) )
@@ -422,14 +424,14 @@ class LinkedSceneTest( unittest.TestCase ) :
 	def testOldStyleTimeRemapping( self ):
 
 		# write as a scene cache so we can write old style attributes:
-		l2 = IECoreScene.SceneCache( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l2 = IECoreScene.SceneCache( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		t2 = l2.createChild("transform2")
 		i2 = t2.createChild("instance2")
 
 		# write with time locked to zero:
 		linkAttr = IECore.CompoundData(
 			{
-				"fileName": IECore.StringData("test/IECore/data/sccFiles/animatedSpheres.scc"),
+				"fileName": IECore.StringData(os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" )),
 				"root": IECore.InternedStringVectorData( [] ),
 				"time": IECore.DoubleData( 0.0 )
 			}
@@ -438,12 +440,12 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del l2, i2, t2
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		t2 = l.child("transform2")
 		i2 = t2.child("instance2")
 		A = i2.child("A")
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		Aa = m.child("A")
 
 		# time should be locked to zero:
@@ -498,9 +500,9 @@ class LinkedSceneTest( unittest.TestCase ) :
 				self.assertTrue( virtualScene.hasChild(c) )
 				recurseCompare( basePath + [ str(c) ], virtualScene.child(c), realScene.child(c), False )
 
-		env = IECoreScene.LinkedScene( "test/IECore/data/sccFiles/environment%s.lscc" % fileVersion, IECore.IndexedIO.OpenMode.Read )	# created by testWriting() when generateTestFiles=True and testFilesSuffix is defined.
-		l = IECoreScene.LinkedScene( "test/IECore/data/sccFiles/instancedSpheres%s.lscc" % fileVersion, IECore.IndexedIO.OpenMode.Read )	# created by testWriting() when generateTestFiles=True and testFilesSuffix is defined.
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		env = IECoreScene.LinkedScene( os.path.join( "test", "IECore", "data", "sccFiles", "environment%s.lscc" % fileVersion ), IECore.IndexedIO.OpenMode.Read )	# created by testWriting() when generateTestFiles=True and testFilesSuffix is defined.
+		l = IECoreScene.LinkedScene( os.path.join( "test", "IECore", "data", "sccFiles", "instancedSpheres%s.lscc" % fileVersion ), IECore.IndexedIO.OpenMode.Read )	# created by testWriting() when generateTestFiles=True and testFilesSuffix is defined.
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 
 		base = env.child('base')
 		self.assertEqual( set(base.childNames()), set(['test1','test2','test3','test4','test5']) )
@@ -558,7 +560,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 			return sorted( map( lambda s: str(s), values ) )
 
 		# create a base scene
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		l.writeTags( ['top'] )
 		a = l.createChild('a')
 		a.writeTags( [ "testA" ] )
@@ -568,7 +570,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		del a, b, l
 
 		# now create a linked scene that should inherit the tags from the base one, plus add other ones
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		a = l.child('a')
 		b = l.child('b')
 
@@ -588,7 +590,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertTrue( b.hasTag("testB", IECoreScene.SceneInterface.TagFilter.EveryTag) )
 		self.assertFalse( b.hasTag("testA", IECoreScene.SceneInterface.TagFilter.EveryTag) )
 
-		l2 = IECoreScene.LinkedScene( "/tmp/test2.lscc", IECore.IndexedIO.OpenMode.Write )
+		l2 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test2.lscc" ), IECore.IndexedIO.OpenMode.Write )
 
 		A = l2.createChild('A')
 		A.writeLink( l )
@@ -619,7 +621,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del l, a, b, l2, A, B, C, c, D
 
-		l2 = IECoreScene.LinkedScene( "/tmp/test2.lscc", IECore.IndexedIO.OpenMode.Read )
+		l2 = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test2.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		A = l2.child("A")
 		Aa = A.child("a")
 		B = l2.child("B")
@@ -664,12 +666,12 @@ class LinkedSceneTest( unittest.TestCase ) :
 	def testMissingLinkedScene( self ) :
 
 		import shutil
-		shutil.copyfile( "test/IECore/data/sccFiles/animatedSpheres.scc", "/tmp/toBeRemoved.scc" )
+		shutil.copyfile( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), os.path.join( self.tempDir, "toBeRemoved.scc" ) )
 
-		m = IECoreScene.SceneCache( "/tmp/toBeRemoved.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( self.tempDir, "toBeRemoved.scc" ), IECore.IndexedIO.OpenMode.Read )
 		A = m.child("A")
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		i0 = l.createChild("instance0")
 		i0.writeLink( m )
 		i1 = l.createChild("instance1")
@@ -680,7 +682,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		i2.writeTransform( IECore.M44dData( imath.M44d().translate( imath.V3d( 2, 0, 0 ) ) ), 0.0 )
 		del i0, i1, i2, l, m, A
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( sorted(l.childNames()), [ "instance0", "instance1", "instance2" ] )
 		i0 = l.child( "instance0" )
 		self.assertEqual( sorted(i0.childNames()), [ "A", "B" ] )
@@ -690,10 +692,10 @@ class LinkedSceneTest( unittest.TestCase ) :
 		self.assertEqual( i2.childNames(), [ "a" ] )
 		del l, i0, i1, i2
 
-		os.remove( "/tmp/toBeRemoved.scc" )
+		os.remove( os.path.join( self.tempDir, "toBeRemoved.scc" ) )
 		IECoreScene.SharedSceneInterfaces.clear()
 
-		l = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		l = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( sorted(l.childNames()), [ "instance0", "instance1", "instance2" ] )
 		i0 = l.child( "instance0" )
 		self.assertEqual( i0.childNames(), [] )
@@ -704,16 +706,16 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testLinkBoundTransformMismatch( self ) :
 
-		scene = IECoreScene.SceneCache( "/tmp/test.scc", IECore.IndexedIO.OpenMode.Write )
+		scene = IECoreScene.SceneCache( os.path.join( self.tempDir, "test.scc" ), IECore.IndexedIO.OpenMode.Write )
 		child = scene.createChild( "child" )
 		mesh = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( 0 ), imath.V3f( 1 ) ) )
 		child.writeObject( mesh, 0 )
 
 		del scene, child
 
-		child = IECoreScene.SceneCache( "/tmp/test.scc", IECore.IndexedIO.OpenMode.Read ).child( "child" )
+		child = IECoreScene.SceneCache( os.path.join( self.tempDir, "test.scc" ), IECore.IndexedIO.OpenMode.Read ).child( "child" )
 
-		linked = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Write )
+		linked = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Write )
 		parent = linked.createChild( "parent" )
 		transform = IECore.M44dData( imath.M44d().translate( imath.V3d( 1, 0, 0 ) ) )
 		parent.writeTransform( transform, 1.0 )
@@ -724,7 +726,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del linked, parent, child, childLink
 
-		linked = IECoreScene.LinkedScene( "/tmp/test.lscc", IECore.IndexedIO.OpenMode.Read )
+		linked = IECoreScene.LinkedScene( os.path.join( self.tempDir, "test.lscc" ), IECore.IndexedIO.OpenMode.Read )
 		parent = linked.child( "parent" )
 		childLink = parent.child( "childLink" )
 
@@ -788,8 +790,8 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testHashes( self ):
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
-		sceneFile = "/tmp/test.lscc"
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		i0 = l.createChild("instance0")
 		i0.writeLink( m )
@@ -867,8 +869,8 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testHashesWithRetimedLinks( self ) :
 
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
-		sceneFile = "/tmp/test.lscc"
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		# save animated spheres with double the speed and with offset, using less samples (time remapping)
 		i0 = l.createChild("instance0")
@@ -917,8 +919,8 @@ class LinkedSceneTest( unittest.TestCase ) :
 	def testReadExtraChildrenAtLink( self ) :
 
 		# create a base scene
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
-		sceneFile = "/tmp/test.lscc"
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.SceneCache( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		# save animated spheres with double the speed and with offset, using less samples (time remapping)
 		link = l.createChild("link")
@@ -941,11 +943,11 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testWriteExtraChildrenAtLink( self ) :
 
-		sceneFile = "/tmp/test.lscc"
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 
 		# write a link:
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		link = l.createChild("link")
 		link.writeLink( m )
 
@@ -985,11 +987,11 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 	def testChildNameClashes( self ) :
 
-		sceneFile = "/tmp/test.lscc"
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 
 		# write a link:
-		m = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		m = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		link = l.createChild("link")
 		link.writeLink( m )
 
@@ -998,7 +1000,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		del l, link
 
-		sceneFile = "/tmp/test.lscc"
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		l = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		link = l.createChild("link")
 
@@ -1020,7 +1022,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# A {'don': ['/B'] }
 		#    B {'stew' : ['/'] }
 
-		sceneFile = "/tmp/test.lscc"
+		sceneFile = os.path.join( self.tempDir, "test.lscc" )
 		w = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		A = w.createChild( "A" )
 		B = A.createChild( "B" )
@@ -1043,7 +1045,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# A {'don': ['/B'] }
 		#    B {'stew' : ['/'] }
 
-		sceneFile = "/tmp/target.scc"
+		sceneFile = os.path.join( self.tempDir, "target.scc" )
 		w = IECoreScene.SceneCache( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		A = w.createChild( "A" )
 		B = A.createChild( "B" )
@@ -1060,7 +1062,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# C
 		#    D -> [target.scc, /]
 
-		sceneFile = "/tmp/scene.lscc"
+		sceneFile = os.path.join( self.tempDir, "scene.lscc" )
 		w = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		C = w.createChild( "C" )
 		D = C.createChild( "D" )
@@ -1080,7 +1082,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# A {'don': ['/'] }
 		#    B {'stew' : ['/'] }
 
-		sceneFile = "/tmp/target.scc"
+		sceneFile = os.path.join( self.tempDir, "target.scc" )
 		w = IECoreScene.SceneCache( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		A = w.createChild( "A" )
 		B = A.createChild( "B" )
@@ -1097,7 +1099,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# C
 		#    D -> [target.scc, /]
 
-		sceneFile = "/tmp/scene.lscc"
+		sceneFile = os.path.join( self.tempDir, "scene.lscc" )
 		w = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		C = w.createChild( "C" )
 		D = C.createChild( "D" )
@@ -1124,7 +1126,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# A tags = ['don']
 		#    B tags = ['stew']
 
-		sceneFile = "/tmp/target.scc"
+		sceneFile = os.path.join( self.tempDir, "target.scc" )
 		w = IECoreScene.SceneCache( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		A = w.createChild( "A" )
 		B = A.createChild( "B" )
@@ -1141,7 +1143,7 @@ class LinkedSceneTest( unittest.TestCase ) :
 		# C tags = ['don']
 		#    D -> [target.scc, /]
 
-		sceneFile = "/tmp/scene.lscc"
+		sceneFile = os.path.join( self.tempDir, "scene.lscc" )
 		w = IECoreScene.LinkedScene( sceneFile, IECore.IndexedIO.OpenMode.Write )
 		C = w.createChild( "C" )
 		D = C.createChild( "D" )
@@ -1158,6 +1160,13 @@ class LinkedSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( r.readSet( "don" ), IECore.PathMatcher(['/C', '/C/D/A'] ) )
 		self.assertEqual( r.readSet( "stew" ), IECore.PathMatcher(['/C/D/A/B'] ) )
+
+	def setUp( self ) :
+		self.tempDir = tempfile.mkdtemp()
+
+	def tearDown( self ) :
+		IECoreScene.SharedSceneInterfaces.clear()
+		shutil.rmtree( self.tempDir )
 
 
 if __name__ == "__main__":

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -73,14 +73,14 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testSimple( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 100 )
 		self.pointTest( m, p, 100 )
 
 
 	def testRaisesExceptionIfInvalidUVs( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 
 		del m['uv']
 
@@ -89,14 +89,14 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testHighDensity( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 50000, offset = imath.V2f( 0.0001, 0.0001 ) )
 
 		self.pointTest( m, p, 50000 )
 
 	def testDensityMaskPrimVar( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		m = IECoreScene.MeshAlgo.triangulate( m )
 		numFaces = m.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		m['density'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.FloatVectorData( [ float(x)/numFaces for x in range( 0, numFaces ) ] ) )
@@ -107,7 +107,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testOffsetParameter( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		density = 500
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = density, offset = imath.V2f( 0, 0 ) )
 		pOffset = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = density, offset = imath.V2f( 0.5, 0.75 ) )
@@ -122,7 +122,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testDistanceBetweenPoints( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 
 		density = 300
 		points = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = density )
@@ -138,7 +138,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testPointOrder( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		m2 = m.copy()
 		m2['P'].data += imath.V3f( 0, 5, 0 )
 		pos = m["P"].data
@@ -160,7 +160,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def testDensityRange( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		self.assertRaises( RuntimeError, IECoreScene.MeshAlgo.distributePoints, m, -1.0 )
 
 	def testVertexUVs( self ) :
@@ -187,7 +187,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		canceller = IECore.Canceller()
 		cancelled = [False]
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 
 		def backgroundRun():
 			try:
@@ -212,7 +212,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 	def setUp( self ) :
 
-		os.environ["CORTEX_POINTDISTRIBUTION_TILESET"] = "test/IECore/data/pointDistributions/pointDistributionTileSet2048.dat"
+		os.environ["CORTEX_POINTDISTRIBUTION_TILESET"] = os.path.join( "test", "IECore", "data", "pointDistributions", "pointDistributionTileSet2048.dat" )
 
 if sys.platform == "darwin" :
 

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -69,7 +69,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		for f in range( 0, mesh.verticesPerFace.size() ) :
 			if "density" in mesh :
 				density = mesh["density"].data[f] * origDensity
-			self.assertTrue( abs(pointsPerFace[f] - density * mesh['faceArea'].data[f]) <= density * error )
+			self.assertTrue( abs( pointsPerFace[f] - density * mesh['faceArea'].data[f] ) <= density * error + len(positions) * error * error )
 
 	def testSimple( self ) :
 

--- a/test/IECoreScene/MeshAlgoNormalsTest.py
+++ b/test/IECoreScene/MeshAlgoNormalsTest.py
@@ -36,6 +36,7 @@ import math
 import threading
 import time
 import unittest
+import os
 
 import IECore
 import IECoreScene
@@ -61,7 +62,7 @@ class MeshAlgoNormalsTest( unittest.TestCase ) :
 
 	def testSphere( self ) :
 
-		s = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		s = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 		del s["N"]
 
 		normals = IECoreScene.MeshAlgo.calculateNormals( s )

--- a/test/IECoreScene/MeshAlgoReorderTest.py
+++ b/test/IECoreScene/MeshAlgoReorderTest.py
@@ -36,6 +36,7 @@ import IECoreScene
 import IECore
 
 import imath
+import os
 
 import unittest
 
@@ -157,31 +158,31 @@ class MeshAlgoReorderTest( unittest.TestCase ) :
 
 	def testQuadSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 
 		IECoreScene.MeshAlgo.reorderVertices( m, 0, 1, 21 )
 
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
-		expected = IECore.Reader.create( "test/IECore/data/expectedResults/meshVertexReorderQuadSphere.cob" ).read()
+		expected = IECore.Reader.create( os.path.join( "test", "IECore", "data", "expectedResults", "meshVertexReorderQuadSphere.cob" ) ).read()
 
 		self.assertEqual( m, expected )
 
 	def testSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 
 		IECoreScene.MeshAlgo.reorderVertices( m, 20, 1, 21 )
 
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
-		expected = IECore.Reader.create( "test/IECore/data/expectedResults/meshVertexReorderSphere.cob" ).read()
+		expected = IECore.Reader.create( os.path.join( "test", "IECore", "data", "expectedResults", "meshVertexReorderSphere.cob" ) ).read()
 
 		self.assertEqual( m, expected )
 
 	def testCube( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 
 		IECoreScene.MeshAlgo.reorderVertices( m, 0, 1, 3 )
 

--- a/test/IECoreScene/MeshAlgoTangentsTest.py
+++ b/test/IECoreScene/MeshAlgoTangentsTest.py
@@ -40,6 +40,7 @@ import IECore
 import IECoreScene
 
 import imath
+import os
 
 class MeshAlgoTangentsTest( unittest.TestCase ) :
 
@@ -98,7 +99,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 
 	def testJoinedUVEdges( self ) :
 
-		mesh = IECore.ObjectReader( "test/IECore/data/cobFiles/twoTrianglesWithSharedUVs.cob" ).read()
+		mesh = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "cobFiles", "twoTrianglesWithSharedUVs.cob" ) ).read()
 		self.assertTrue( mesh.arePrimitiveVariablesValid() )
 
 		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh )
@@ -113,7 +114,7 @@ class MeshAlgoTangentsTest( unittest.TestCase ) :
 
 	def testSplitAndOpposedUVEdges( self ) :
 
-		mesh = IECore.ObjectReader( "test/IECore/data/cobFiles/twoTrianglesWithSplitAndOpposedUVs.cob" ).read()
+		mesh = IECore.ObjectReader( os.path.join( "test", "IECore", "data", "cobFiles", "twoTrianglesWithSplitAndOpposedUVs.cob" ) ).read()
 
 		tangentPrimVar, bitangentPrimVar = IECoreScene.MeshAlgo.calculateTangentsFromUV( mesh )
 

--- a/test/IECoreScene/MeshAlgoTriangulateTest.py
+++ b/test/IECoreScene/MeshAlgoTriangulateTest.py
@@ -104,7 +104,7 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 
 	def testQuadrangulatedSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 		P = m["P"].data
 
 		self.assertEqual ( len( m.vertexIds ), 1560 )
@@ -131,7 +131,7 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 
 	def testTriangulatedSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 
 
 		result = IECoreScene.MeshAlgo.triangulate( m )
@@ -169,7 +169,7 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 
 	def testConstantPrimVars( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 
 		m["constantScalar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 1 ) )
 		m["constantArray"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringVectorData( [ "one", "two" ] ) )
@@ -234,7 +234,7 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 	def testTriangulatePerformance( self ):
 
 		for i in range(10):
-			root = IECoreScene.SceneInterface.create( "/path/to/cache.scc", IECore.IndexedIO.OpenMode.Read )
+			root = IECoreScene.SceneInterface.create( os.path.sep + os.path.join( "path", "to", "cache.scc" ), IECore.IndexedIO.OpenMode.Read )
 			body = root.scene(['location', 'of', 'object'])
 
 			objects = []

--- a/test/IECoreScene/MeshNormalsOpTest.py
+++ b/test/IECoreScene/MeshNormalsOpTest.py
@@ -34,6 +34,7 @@
 
 import unittest
 import imath
+import os
 import IECore
 import IECoreScene
 import math
@@ -72,7 +73,7 @@ class MeshNormalsOpTest( unittest.TestCase ) :
 
 	def testSphere( self ) :
 
-		s = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		s = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 		del s["N"]
 		self.assertTrue( not "N" in s )
 

--- a/test/IECoreScene/MeshPrimitive.py
+++ b/test/IECoreScene/MeshPrimitive.py
@@ -57,7 +57,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( m, m.copy() )
 		self.assertEqual( m.maxVerticesPerFace(), 0 )
 
-		iface = IECore.IndexedIO.create( "test/IECore/mesh.fio", IECore.IndexedIO.OpenMode.Write )
+		iface = IECore.IndexedIO.create( os.path.join( "test", "IECore", "mesh.fio" ), IECore.IndexedIO.OpenMode.Write )
 		m.save( iface, "test" )
 		mm = IECore.Object.load( iface, "test" )
 		self.assertEqual( m, mm )
@@ -86,13 +86,13 @@ class TestMeshPrimitive( unittest.TestCase ) :
 
 		m.setTopology( m.verticesPerFace, m.vertexIds, "catmullClark" )
 
-		mm = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		mm = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 		self.assertTrue( mm.arePrimitiveVariablesValid() )
 
 	def testUVsFromFile( self ) :
 
 		# get the original values from a legacy cob file
-		f = IECore.FileIndexedIO("test/IECore/data/cobFiles/pSphereShape1.cob", [], IECore.IndexedIO.OpenMode.Read )
+		f = IECore.FileIndexedIO(os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ), [], IECore.IndexedIO.OpenMode.Read )
 		ff = f.directory( [ "object", "data", "Primitive" ] )
 		# make sure its a legacy file
 		self.assertEqual( ff.read( "ioVersion" ).value, 1 )
@@ -102,7 +102,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( rawValues[-1], 0 )
 
 		# read legacy file and confirm values are packed into V2f and unflipped
-		sphere = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		sphere = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 		self.assertTrue( sphere.arePrimitiveVariablesValid() )
 		self.assertEqual( sphere["uv"].data.getInterpretation(), IECore.GeometricData.Interpretation.UV )
 		self.assertEqual( sphere["uv"].data[0][0], 0 )
@@ -111,8 +111,8 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( sphere["uv"].data[-1][1], 1 )
 
 		# write a new file and confirm values remain consistent
-		IECore.Writer.create( sphere, "test/IECore/mesh.cob" ).write()
-		newSphere = IECore.Reader.create( "test/IECore/mesh.cob" ).read()
+		IECore.Writer.create( sphere, os.path.join( "test", "IECore", "mesh.cob" ) ).write()
+		newSphere = IECore.Reader.create( os.path.join( "test", "IECore", "mesh.cob" ) ).read()
 		self.assertTrue( newSphere.arePrimitiveVariablesValid() )
 		self.assertEqual( newSphere["uv"].data.getInterpretation(), IECore.GeometricData.Interpretation.UV )
 		self.assertEqual( newSphere["uv"].data[0][0], 0 )
@@ -123,7 +123,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( newSphere, sphere )
 
 		# get the original values from a legacy SceneCache file
-		f = IECore.FileIndexedIO("test/IECore/data/sccFiles/animatedSpheres.scc", [], IECore.IndexedIO.OpenMode.Read )
+		f = IECore.FileIndexedIO( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), [], IECore.IndexedIO.OpenMode.Read )
 		ff = f.directory( [ "root", "children", "A", "children", "a", "object", "0", "data", "Primitive" ] )
 		# make sure its a legacy file
 		self.assertEqual( ff.read( "ioVersion" ).value, 1 )
@@ -143,7 +143,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 		self.assertEqual( len(rawMap1Indices), 1560 )
 
 		# read legacy file and confirm values are packed into V2f and unflipped
-		s = IECoreScene.SceneCache( "test/IECore/data/sccFiles/animatedSpheres.scc", IECore.IndexedIO.OpenMode.Read )
+		s = IECoreScene.SceneCache( os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ), IECore.IndexedIO.OpenMode.Read )
 		ss = s.scene( [ "A", "a" ] )
 		animSphere = ss.readObject( 0 )
 		self.assertEqual( animSphere["uv"].data.getInterpretation(), IECore.GeometricData.Interpretation.UV )
@@ -405,7 +405,7 @@ class TestMeshPrimitive( unittest.TestCase ) :
 	def testLegacyIndices( self ) :
 
 		# load a legacy file that contains myString and myStringIndices
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/cube.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "cube.cob" ) ).read()
 		self.assertEqual( m.keys(), [ "P", "myString" ] )
 		self.assertTrue( m.isPrimitiveVariableValid( m["myString"] ) )
 		self.assertEqual( m["myString"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
@@ -533,8 +533,8 @@ class TestMeshPrimitive( unittest.TestCase ) :
 	def tearDown( self ) :
 
 		for f in (
-			"test/IECore/mesh.fio",
-			"test/IECore/mesh.cob",
+			os.path.join( "test", "IECore", "mesh.fio" ),
+			os.path.join( "test", "IECore", "mesh.cob" ),
 		) :
 			if os.path.isfile( f ) :
 				os.remove( f )

--- a/test/IECoreScene/MeshPrimitiveEvaluator.py
+++ b/test/IECoreScene/MeshPrimitiveEvaluator.py
@@ -36,6 +36,7 @@ import math
 import unittest
 import random
 import imath
+import os
 import IECore
 import IECoreScene
 
@@ -75,7 +76,7 @@ class TestMeshPrimitiveEvaluator( unittest.TestCase ) :
 
 	def testTangents( self ) :
 
-		reader = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" )
+		reader = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) )
 		m = reader.read()
 
 		self.assertTrue( m.isInstanceOf( "MeshPrimitive" ) )
@@ -164,7 +165,7 @@ class TestMeshPrimitiveEvaluator( unittest.TestCase ) :
 		""" Testing MeshPrimitiveEvaluator with sphere mesh"""
 
 		# File represents a sphere of radius 1.0 at the origin
-		reader = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" )
+		reader = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) )
 		m = reader.read()
 
 		self.assertTrue( m.isInstanceOf( "MeshPrimitive" ) )
@@ -280,7 +281,7 @@ class TestMeshPrimitiveEvaluator( unittest.TestCase ) :
 
 	def testCylinderMesh( self ) :
 		"""Testing special case of intersection query."""
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/cylinder3Mesh.cob" ) ()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "cylinder3Mesh.cob" ) ) ()
 		e = IECoreScene.MeshPrimitiveEvaluator( m )
 		res = e.createResult()
 		self.assertFalse( e.intersectionPoint( imath.V3f(0.5,0,0.5), imath.V3f(1,0,0), res ) )

--- a/test/IECoreScene/MeshPrimitiveShrinkWrapOp.py
+++ b/test/IECoreScene/MeshPrimitiveShrinkWrapOp.py
@@ -36,6 +36,7 @@ import math
 import unittest
 import random
 import imath
+import os
 import IECore
 import IECoreScene
 
@@ -49,7 +50,7 @@ class TestMeshPrimitiveShrinkWrapOp( unittest.TestCase ) :
 		random.seed( 1011 )
 
 		# Load poly sphere of radius 1
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 		radius = 1.0
 
 		# Duplicate and scale to radius 3, jitter slightly

--- a/test/IECoreScene/MeshVertexReorderOpTest.py
+++ b/test/IECoreScene/MeshVertexReorderOpTest.py
@@ -36,6 +36,7 @@ import IECoreScene
 import IECore
 
 import imath
+import os
 
 import unittest
 
@@ -273,7 +274,7 @@ class MeshVertexReorderOpTest( unittest.TestCase ) :
 
 	def testQuadSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 
 		op = IECoreScene.MeshVertexReorderOp()
 
@@ -284,13 +285,13 @@ class MeshVertexReorderOpTest( unittest.TestCase ) :
 
 		self.assertTrue( result.arePrimitiveVariablesValid() )
 
-		expected = IECore.Reader.create( "test/IECore/data/expectedResults/meshVertexReorderQuadSphere.cob" ).read()
+		expected = IECore.Reader.create( os.path.join( "test", "IECore", "data", "expectedResults", "meshVertexReorderQuadSphere.cob" ) ).read()
 
 		self.assertEqual( result, expected )
 
 	def testSphere( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 
 		op = IECoreScene.MeshVertexReorderOp()
 
@@ -301,13 +302,13 @@ class MeshVertexReorderOpTest( unittest.TestCase ) :
 
 		self.assertTrue( result.arePrimitiveVariablesValid() )
 
-		expected = IECore.Reader.create( "test/IECore/data/expectedResults/meshVertexReorderSphere.cob" ).read()
+		expected = IECore.Reader.create( os.path.join( "test", "IECore", "data", "expectedResults", "meshVertexReorderSphere.cob" ) ).read()
 
 		self.assertEqual( result, expected )
 
 	def testCube( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pCubeShape1.cob" ).read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 
 		op = IECoreScene.MeshVertexReorderOp()
 

--- a/test/IECoreScene/MotionPrimitive.py
+++ b/test/IECoreScene/MotionPrimitive.py
@@ -62,7 +62,7 @@ class TestMotionPrimitive( unittest.TestCase ) :
 		self.assertEqual( m.keys(), [ 0, 1 ] )
 		self.assertEqual( m.values(), [ IECoreScene.PointsPrimitive( 1 ), IECoreScene.PointsPrimitive( 1 ) ] )
 
-		iface = IECore.IndexedIO.create( "test/motionPrimitive.fio", IECore.IndexedIO.OpenMode.Write )
+		iface = IECore.IndexedIO.create( os.path.join( "test", "motionPrimitive.fio" ), IECore.IndexedIO.OpenMode.Write )
 		m.save( iface, "test" )
 
 		mm = IECore.Object.load( iface, "test" )
@@ -108,8 +108,8 @@ class TestMotionPrimitive( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/motionPrimitive.fio" ):
-			os.remove( "test/motionPrimitive.fio" )
+		if os.path.isfile( os.path.join( "test", "motionPrimitive.fio" ) ):
+			os.remove( os.path.join( "test", "motionPrimitive.fio" ) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/NParticleReader.py
+++ b/test/IECoreScene/NParticleReader.py
@@ -34,6 +34,7 @@
 
 import unittest
 import sys
+import os
 import IECore
 import IECoreScene
 
@@ -41,14 +42,14 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testConstruction( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleFrame2.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleFrame2.mc" ) )
 		self.assertTrue( r.isInstanceOf( "ParticleReader" ) )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
-		self.assertEqual( r["fileName"].getValue().value, "test/IECore/data/iffFiles/nParticleFrame2.mc" )
+		self.assertEqual( r["fileName"].getValue().value, os.path.join( "test", "IECore", "data", "iffFiles", "nParticleFrame2.mc" ) )
 
 	def testReadWithPrimVarConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleFrame2.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleFrame2.mc" ) )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
 		r.parameters()["realType"].setValue( "native" )
 
@@ -92,7 +93,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testReadNoPrimVarConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleFrame2.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleFrame2.mc" ) )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
 		r["convertPrimVarNames"].setValue( IECore.BoolData( False ) )
 		r["realType"].setValue( "native" )
@@ -130,7 +131,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testMultiFrameFiles( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleMultipleFrames.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleMultipleFrames.mc" ) )
 		r.parameters()["realType"].setValue( "native" )
 
 		self.assertTrue( r.parameters()["convertPrimVarNames"].getTypedValue() )
@@ -186,7 +187,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testFiltering( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleMultipleFrames.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleMultipleFrames.mc" ) )
 
 		r.parameters()['frameIndex'].setValue( 5 )
 		attributesToLoad = [ "testParticleShape_birthTime", "testParticleShape_position" ]
@@ -208,7 +209,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleMultipleFrames.mc"  )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleMultipleFrames.mc" )  )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
 
 		r.parameters()["realType"].setValue( "float" )
@@ -250,7 +251,7 @@ class TestNParticleReader( unittest.TestCase ) :
 		"""Now Readers are Ops, the filename can be changed and read() can be called
 		again. So we need to check that that works."""
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nParticleMultipleFrames.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleMultipleFrames.mc" ) )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
 
 		r.parameters()["realType"].setValue( "float" )
@@ -278,7 +279,7 @@ class TestNParticleReader( unittest.TestCase ) :
 			self.assertTrue( abs( p.y ) < 0.145 )
 			self.assertTrue( abs( p.z ) < 0.138 )
 
-		r["fileName"].setValue( IECore.StringData( "test/IECore/data/iffFiles/nParticleFrame2.mc" ) )
+		r["fileName"].setValue( IECore.StringData( os.path.join( "test", "IECore", "data", "iffFiles", "nParticleFrame2.mc" ) ) )
 
 		r.parameters()['frameIndex'].setValue( 0 )
 		self.assertEqual( r.numParticles(), 4 )
@@ -307,7 +308,7 @@ class TestNParticleReader( unittest.TestCase ) :
 
 	def testNClothAsParticles( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/iffFiles/nClothFrame3.mc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "iffFiles", "nClothFrame3.mc" ) )
 		self.assertEqual( type( r ), IECoreScene.NParticleReader )
 		r.parameters()["realType"].setValue( "native" )
 

--- a/test/IECoreScene/NURBS.py
+++ b/test/IECoreScene/NURBS.py
@@ -48,8 +48,8 @@ class TestNURBSPrimitive( unittest.TestCase ) :
 		self.assertEqual( n.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Vertex ), 16 )
 		self.assertEqual( n.variableSize( IECoreScene.PrimitiveVariable.Interpolation.Varying ), 4 )
 		self.assertEqual( n.variableSize( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying ), 4 )
-		IECore.ObjectWriter( n, "test/IECore/nurbs.fio" ).write()
-		nn = IECore.ObjectReader( "test/IECore/nurbs.fio" ).read()
+		IECore.ObjectWriter( n, os.path.join( "test", "IECore", "nurbs.fio" ) ).write()
+		nn = IECore.ObjectReader( os.path.join( "test", "IECore", "nurbs.fio" ) ).read()
 		self.assertEqual( n, nn )
 
 		n = IECoreScene.NURBSPrimitive( 3, IECore.FloatVectorData( [ 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4, 4 ] ), 0, 4,
@@ -67,8 +67,8 @@ class TestNURBSPrimitive( unittest.TestCase ) :
 		self.assertEqual( n.vKnot(), IECore.FloatVectorData( [ 0, 0, 1, 1 ] ) )
 		self.assertEqual( n.vMin(), 0 )
 		self.assertEqual( n.vMax(), 1 )
-		IECore.ObjectWriter( n, "test/IECore/nurbs.fio" ).write()
-		nn = IECore.ObjectReader( "test/IECore/nurbs.fio" ).read()
+		IECore.ObjectWriter( n, os.path.join( "test", "IECore", "nurbs.fio" ) ).write()
+		nn = IECore.ObjectReader( os.path.join( "test", "IECore", "nurbs.fio" ) ).read()
 		self.assertEqual( n, nn )
 		nnn = nn.copy()
 		self.assertEqual( nnn, n )
@@ -83,8 +83,8 @@ class TestNURBSPrimitive( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile("test/IECore/nurbs.fio"):
-			os.remove("test/IECore/nurbs.fio")
+		if os.path.isfile(os.path.join( "test", "IECore", "nurbs.fio" )):
+			os.remove(os.path.join( "test", "IECore", "nurbs.fio" ))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/OBJReaderTest.py
+++ b/test/IECoreScene/OBJReaderTest.py
@@ -34,6 +34,7 @@
 
 import unittest
 import sys
+import os
 import IECore
 import IECoreScene
 
@@ -41,7 +42,7 @@ class TestOBJReader( unittest.TestCase ) :
 
 	def testRead( self ) :
 
-		self.testfile = 'test/IECore/data/obj/triangle.obj'
+		self.testfile = os.path.join( "test", "IECore", "data", "obj", "triangle.obj" )
 
 		r = IECore.Reader.create(self.testfile)
 		self.assertEqual(type(r), IECoreScene.OBJReader)
@@ -55,7 +56,7 @@ class TestOBJReader( unittest.TestCase ) :
 
 	def testReadNormals( self ) :
 
-		self.testfile = 'test/IECore/data/obj/triangle_normals.obj'
+		self.testfile = os.path.join( "test", "IECore", "data", "obj", "triangle_normals.obj" )
 
 		r = IECore.Reader.create(self.testfile)
 		self.assertEqual(type(r), IECoreScene.OBJReader)
@@ -72,7 +73,7 @@ class TestOBJReader( unittest.TestCase ) :
 
 	def testReadNoTexture( self ) :
 
-		self.testfile = 'test/IECore/data/obj/triangle_no_texture.obj'
+		self.testfile = os.path.join( "test", "IECore", "data", "obj", "triangle_no_texture.obj" )
 
 		r = IECore.Reader.create(self.testfile)
 		self.assertEqual(type(r), IECoreScene.OBJReader)
@@ -87,7 +88,7 @@ class TestOBJReader( unittest.TestCase ) :
 
 	def testGroups( self ) :
 
-		self.testfile = 'test/IECore/data/obj/groups.obj'
+		self.testfile = os.path.join( "test", "IECore", "data", "obj", "groups.obj" )
 
 		r = IECore.Reader.create(self.testfile)
 		self.assertEqual(type(r), IECoreScene.OBJReader)

--- a/test/IECoreScene/OutputTest.py
+++ b/test/IECoreScene/OutputTest.py
@@ -39,7 +39,7 @@ import IECoreScene
 
 class OutputTest( unittest.TestCase ) :
 
-	fileName = "test/IECore/data/output.cob"
+	fileName = os.path.join( "test", "IECore", "data", "output.cob" )
 
 	def test( self ) :
 

--- a/test/IECoreScene/PDCReader.py
+++ b/test/IECoreScene/PDCReader.py
@@ -45,14 +45,14 @@ class TestPDCReader( unittest.TestCase ) :
 
 	def testConstruction( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		self.assertTrue( r.isInstanceOf( "ParticleReader" ) )
 		self.assertEqual( type( r ), IECoreScene.PDCParticleReader )
-		self.assertEqual( r["fileName"].getValue().value, "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		self.assertEqual( r["fileName"].getValue().value, os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 
 	def testReadWithPrimVarConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		r.parameters()["realType"].setValue( "native" )
 		self.assertEqual( type( r ), IECoreScene.PDCParticleReader )
 		self.assertTrue( r.parameters()["convertPrimVarNames"].getTypedValue() )
@@ -119,7 +119,7 @@ class TestPDCReader( unittest.TestCase ) :
 
 	def testReadNoPrimVarConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		self.assertEqual( type( r ), IECoreScene.PDCParticleReader )
 
 		r["realType"].setValue( "native" )
@@ -168,7 +168,7 @@ class TestPDCReader( unittest.TestCase ) :
 
 	def testFiltering( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 
 		attributesToLoad = [ "position", "age" ]
 		r.parameters()["percentage"].setValue( IECore.FloatData( 50 ) )
@@ -189,7 +189,7 @@ class TestPDCReader( unittest.TestCase ) :
 			self.assertEqual( p.numPoints, p[attr].data.size() )
 
 		# compare filtering with int ids
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.intId.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.intId.250.pdc" ) )
 
 		attributesToLoad = [ "position", "age" ]
 		r.parameters()["percentage"].setValue( IECore.FloatData( 50 ) )
@@ -199,7 +199,7 @@ class TestPDCReader( unittest.TestCase ) :
 		self.assertEqual( a, a2 )
 
 		# compare filtering with no ids at all
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.noId.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.noId.250.pdc" ) )
 
 		attributesToLoad = [ "position", "age" ]
 		r.parameters()["percentage"].setValue( IECore.FloatData( 50 ) )
@@ -215,7 +215,7 @@ class TestPDCReader( unittest.TestCase ) :
 
 	def testConversion( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		self.assertEqual( type( r ), IECoreScene.PDCParticleReader )
 
 		r.parameters()["realType"].setValue( "float" )
@@ -258,7 +258,7 @@ class TestPDCReader( unittest.TestCase ) :
 		"""Now Readers are Ops, the filename can be changed and read() can be called
 		again. So we need to check that that works."""
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		self.assertEqual( type( r ), IECoreScene.PDCParticleReader )
 
 		r.parameters()["realType"].setValue( "float" )
@@ -296,7 +296,7 @@ class TestPDCReader( unittest.TestCase ) :
 			self.assertTrue( abs( p.x ) < 1.1 )
 			self.assertTrue( abs( p.z ) < 1.1 )
 
-		r["fileName"].setValue( IECore.StringData( "test/IECore/data/pdcFiles/10Particles.pdc" ) )
+		r["fileName"].setValue( IECore.StringData( os.path.join( "test", "IECore", "data", "pdcFiles", "10Particles.pdc" ) ) )
 
 		self.assertEqual( r.numParticles(), 10 )
 		c = r.read()
@@ -322,9 +322,9 @@ class TestPDCReader( unittest.TestCase ) :
 
 		p = IECoreScene.PointsPrimitive( 3 )
 		p["d"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.DoubleVectorData( [ 1, 2, 3 ] ) )
-		IECore.Writer.create( p, "test/particleShape1.250.pdc" ).write()
+		IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) ).write()
 
-		r = IECoreScene.PDCParticleReader( "test/particleShape1.250.pdc" )
+		r = IECoreScene.PDCParticleReader( os.path.join( "test", "particleShape1.250.pdc" ) )
 
 		c = IECore.CapturingMessageHandler()
 		with c :
@@ -340,8 +340,8 @@ class TestPDCReader( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/particleShape1.250.pdc" ) :
-			os.remove( "test/particleShape1.250.pdc" )
+		if os.path.isfile( os.path.join( "test", "particleShape1.250.pdc" ) ) :
+			os.remove( os.path.join( "test", "particleShape1.250.pdc" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/PDCWriter.py
+++ b/test/IECoreScene/PDCWriter.py
@@ -43,23 +43,23 @@ class TestPDCWriter( unittest.TestCase ) :
 
 	def testBasics( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		p = r.read()
 
-		w = IECore.Writer.create( p, "test/particleShape1.250.pdc" )
+		w = IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) )
 		w.write()
 
-		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "particleShape1.250.pdc" ) )
 		p2 = r.read()
 
 		self.assertEqual( p, p2 )
 
 	def testFiltering( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		p = r.read()
 
-		w = IECore.Writer.create( p, "test/particleShape1.250.pdc" )
+		w = IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) )
 		w.parameters()["attributes"].setValue( IECore.StringVectorData( ["P"] ) )
 		w.write()
 
@@ -67,14 +67,14 @@ class TestPDCWriter( unittest.TestCase ) :
 			if k!="P" :
 				del p[k]
 
-		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "particleShape1.250.pdc" ) )
 		p2 = r.read()
 
 		self.assertEqual( p, p2 )
 
 	def testBadObjectException( self ) :
 
-		w = IECoreScene.PDCParticleWriter( IECore.IntData(10), "test/intData.pdc" )
+		w = IECoreScene.PDCParticleWriter( IECore.IntData(10), os.path.join( "test", "intData.pdc" ) )
 		self.assertRaises( RuntimeError, w.write )
 
 	def testWriteConstantData( self ) :
@@ -84,10 +84,10 @@ class TestPDCWriter( unittest.TestCase ) :
 		p["v3d"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.V3dData( imath.V3d( 1, 2, 3 ) ) )
 		p["i"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.IntData( 10 ) )
 
-		w = IECore.Writer.create( p, "test/particleShape1.250.pdc" )
+		w = IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) )
 		w.write()
 
-		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "particleShape1.250.pdc" ) )
 		r.parameters()["realType"].setValue( "native" )
 		p2 = r.read()
 
@@ -101,10 +101,10 @@ class TestPDCWriter( unittest.TestCase ) :
 		p["fVector"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData( [ 1, 2, 3 ] ) )
 		p["v3fVector"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.V3fVectorData( [ imath.V3f( 1, 2, 3 ), imath.V3f( 4, 5, 6 ), imath.V3f( 7, 8, 9 ) ] ) )
 
-		w = IECore.Writer.create( p, "test/particleShape1.250.pdc" )
+		w = IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) )
 		w.write()
 
-		r = IECore.Reader.create( "test/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "particleShape1.250.pdc" ) )
 		r.parameters()["realType"].setValue( "native" )
 		p2 = r.read()
 
@@ -120,9 +120,9 @@ class TestPDCWriter( unittest.TestCase ) :
 		p["color3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.Color3fData( imath.Color3f( 1 ) ) )
 		p["color3fVector"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.Color3fVectorData( [ imath.Color3f( 1 ), imath.Color3f( 2 ), imath.Color3f( 3 ) ] ) )
 
-		IECore.Writer.create( p, "test/particleShape1.250.pdc" ).write()
+		IECore.Writer.create( p, os.path.join( "test", "particleShape1.250.pdc" ) ).write()
 
-		p2 = IECore.Reader.create( "test/particleShape1.250.pdc" ).read()
+		p2 = IECore.Reader.create( os.path.join( "test", "particleShape1.250.pdc" ) ).read()
 
 		self.assertEqual( p.keys(), p2.keys() )
 
@@ -132,8 +132,8 @@ class TestPDCWriter( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/particleShape1.250.pdc" ) :
-			os.remove( "test/particleShape1.250.pdc" )
+		if os.path.isfile( os.path.join( "test", "particleShape1.250.pdc" ) ) :
+			os.remove( os.path.join( "test", "particleShape1.250.pdc" ) )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/PatchMeshPrimitiveTest.py
+++ b/test/IECoreScene/PatchMeshPrimitiveTest.py
@@ -77,9 +77,9 @@ class PatchMeshPrimitiveTest( unittest.TestCase ) :
 
 		p = IECoreScene.PatchMeshPrimitive( 10, 7, IECore.CubicBasisf.bezier(), IECore.CubicBasisf.bezier(), False, False )
 
-		IECore.Writer.create( p, "test/IECore/data/PatchMeshPrimitive.cob" ).write()
+		IECore.Writer.create( p, os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) ).write()
 
-		pp = IECore.Reader.create( "test/IECore/data/PatchMeshPrimitive.cob" ).read()
+		pp = IECore.Reader.create( os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) ).read()
 
 		self.assertEqual( pp, p )
 
@@ -103,13 +103,13 @@ class PatchMeshPrimitiveTest( unittest.TestCase ) :
 
 	def setUp( self ) :
 
-		if os.path.isfile( "test/IECore/data/PatchMeshPrimitive.cob" ) :
-			os.remove( "test/IECore/data/PatchMeshPrimitive.cob" )
+		if os.path.isfile( os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) ) :
+			os.remove( os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) )
 
 	def tearDown( self ) :
 
-		if os.path.isfile( "test/IECore/data/PatchMeshPrimitive.cob" ) :
-			os.remove( "test/IECore/data/PatchMeshPrimitive.cob" )
+		if os.path.isfile( os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) ) :
+			os.remove( os.path.join( "test", "IECore", "data", "PatchMeshPrimitive.cob" ) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/PrimitiveTest.py
+++ b/test/IECoreScene/PrimitiveTest.py
@@ -37,6 +37,9 @@ import unittest
 import time
 import threading
 import imath
+import tempfile
+import os
+import shutil
 
 import IECore
 import IECoreScene
@@ -79,10 +82,13 @@ class PrimitiveTest( unittest.TestCase ) :
 		m["a"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( [ 1, 2 ] ), IECore.IntVectorData( [ 1, 0, 1, 0, 1, 0 ] ) )
 		self.assertTrue( m.arePrimitiveVariablesValid() )
 
-		IECore.Writer.create( m, "/tmp/testPrimitiveLoad.cob" ).write()
-		m2 = IECore.Reader.create( "/tmp/testPrimitiveLoad.cob" ).read()
+		tempDir = tempfile.mkdtemp()
+		IECore.Writer.create( m, os.path.join( tempDir, "testPrimitiveLoad.cob" ) ).write()
+		m2 = IECore.Reader.create( os.path.join( tempDir, "testPrimitiveLoad.cob" ) ).read()
 		self.assertTrue( m2.arePrimitiveVariablesValid() )
 		self.assertEqual( m, m2 )
+
+		shutil.rmtree(tempDir)
 
 	def testHash( self ) :
 

--- a/test/IECoreScene/RemovePrimitiveVariables.py
+++ b/test/IECoreScene/RemovePrimitiveVariables.py
@@ -33,6 +33,7 @@
 ##########################################################################
 
 import unittest
+import os
 import IECore
 import IECoreScene
 
@@ -40,7 +41,7 @@ class TestRemovePrimVar( unittest.TestCase ) :
 
 	def test( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		p = r.read()
 		numPrimVars = len( p )
 

--- a/test/IECoreScene/RenamePrimitiveVariables.py
+++ b/test/IECoreScene/RenamePrimitiveVariables.py
@@ -33,6 +33,7 @@
 ##########################################################################
 
 import unittest
+import os
 import IECore
 import IECoreScene
 
@@ -40,7 +41,7 @@ class TestRenamePrimVar( unittest.TestCase ) :
 
 	def test( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/pdcFiles/particleShape1.250.pdc" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "pdcFiles", "particleShape1.250.pdc" ) )
 		r["convertPrimVarNames"].setValue( IECore.BoolData(False) )
 		self.assertFalse( r.parameters()["convertPrimVarNames"].getTypedValue() )
 		p = r.read()

--- a/test/IECoreScene/SWAReaderTest.py
+++ b/test/IECoreScene/SWAReaderTest.py
@@ -34,6 +34,9 @@
 
 import unittest
 import imath
+import tempfile
+import shutil
+import os
 import IECore
 import IECoreScene
 
@@ -44,16 +47,17 @@ class SWAReaderTest( unittest.TestCase ) :
 		r = IECoreScene.SWAReader()
 		self.assertEqual( r["fileName"].getTypedValue(), "" )
 
-		r = IECoreScene.SWAReader( "test/IECore/data/swaFiles/test.swa" )
-		self.assertEqual( r["fileName"].getTypedValue(), "test/IECore/data/swaFiles/test.swa" )
+		r = IECoreScene.SWAReader( os.path.join( "test", "IECore", "data", "swaFiles", "test.swa" ) )
+		self.assertEqual( r["fileName"].getTypedValue(), os.path.join( "test", "IECore", "data", "swaFiles", "test.swa" ) )
 
 	def testReading( self ) :
 
-		r = IECoreScene.SWAReader( "test/IECore/data/swaFiles/test.swa" )
+		r = IECoreScene.SWAReader( os.path.join( "test", "IECore", "data", "swaFiles", "test.swa" ) )
 
 		o = r.read()
 
-		IECore.ObjectWriter( o, "/tmp/trees4.cob" ).write()
+		tempDir = tempfile.mkdtemp()
+		IECore.ObjectWriter( o, os.path.join(tempDir, "trees4.cob" ) ).write()
 
 		self.assertTrue( o.isInstanceOf( IECoreScene.PointsPrimitive.staticTypeId() ) )
 		self.assertEqual( o.numPoints, 5 + 6 )
@@ -92,16 +96,18 @@ class SWAReaderTest( unittest.TestCase ) :
 		self.assertAlmostEqual( o["scale"].data[1], 6.7, 6 )
 		self.assertEqual( o["treeNameIndices"].data, IECore.IntVectorData( [ 0 ] * 5 + [ 1 ] * 6 ) )
 
+		shutil.rmtree( tempDir )
+
 	def testCanRead( self ) :
 
-		self.assertTrue( IECoreScene.SWAReader.canRead( "test/IECore/data/swaFiles/test.swa" ) )
-		self.assertFalse( IECoreScene.IDXReader.canRead( "test/IECore/data/cobFiles/ball.cob" ) )
-		self.assertFalse( IECoreScene.SWAReader.canRead( "test/IECore/data/idxFiles/test.idx" ) )
-		self.assertFalse( IECoreScene.SWAReader.canRead( "test/IECore/data/empty" ) )
+		self.assertTrue( IECoreScene.SWAReader.canRead( os.path.join( "test", "IECore", "data", "swaFiles", "test.swa" ) ) )
+		self.assertFalse( IECoreScene.IDXReader.canRead( os.path.join( "test", "IECore", "data", "cobFiles/ball.cob" ) ) )
+		self.assertFalse( IECoreScene.SWAReader.canRead( os.path.join( "test", "IECore", "data", "idxFiles", "test.idx" ) ) )
+		self.assertFalse( IECoreScene.SWAReader.canRead( os.path.join( "test", "IECore", "data", "empty" ) ) )
 
 	def testRegistration( self ) :
 
-		r = IECore.Reader.create( "test/IECore/data/swaFiles/test.swa" )
+		r = IECore.Reader.create( os.path.join( "test", "IECore", "data", "swaFiles", "test.swa" ) )
 		self.assertTrue( isinstance( r, IECoreScene.SWAReader ) )
 
 if __name__ == "__main__":

--- a/test/IECoreScene/SceneInterfaceTest.py
+++ b/test/IECoreScene/SceneInterfaceTest.py
@@ -37,18 +37,18 @@ import sys
 import math
 import unittest
 import imath
+import tempfile
+import os
+import shutil
 
 import IECore
 import IECoreScene
 
 class SceneInterfaceTest( unittest.TestCase ) :
 
-	__testFile = "/tmp/test.scc"
-	__testFileUpper = "/tmp/test.SCC"
-
 	def writeSCC( self ) :
 
-		m = IECoreScene.SceneCache( SceneInterfaceTest.__testFile, IECore.IndexedIO.OpenMode.Write )
+		m = IECoreScene.SceneCache( self.__testFile, IECore.IndexedIO.OpenMode.Write )
 		m.writeAttribute( "w", IECore.BoolData( True ), 1.0 )
 
 		t = m.createChild( "t" )
@@ -63,16 +63,16 @@ class SceneInterfaceTest( unittest.TestCase ) :
 
 		self.writeSCC()
 
-		instance1 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
-		instance2 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
-		instance1_upper = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFileUpper )
+		instance1 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
+		instance2 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
+		instance1_upper = IECoreScene.SharedSceneInterfaces.get( self.__testFileUpper )
 
 		self.assertTrue( instance1.isSame( instance2 ) )
 		self.assertTrue( instance1.isSame( instance1_upper ) )
 
-		instance3 = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFile, IECore.IndexedIO.OpenMode.Read )
-		instance4 = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFile, IECore.IndexedIO.OpenMode.Read )
-		instance3_upper = IECoreScene.SceneInterface.create( SceneInterfaceTest.__testFileUpper, IECore.IndexedIO.OpenMode.Read )
+		instance3 = IECoreScene.SceneInterface.create( self.__testFile, IECore.IndexedIO.OpenMode.Read )
+		instance4 = IECoreScene.SceneInterface.create( self.__testFile, IECore.IndexedIO.OpenMode.Read )
+		instance3_upper = IECoreScene.SceneInterface.create( self.__testFileUpper, IECore.IndexedIO.OpenMode.Read )
 
 		self.assertFalse( instance3.isSame( instance4 ) )
 		self.assertFalse( instance3.isSame( instance1 ) )
@@ -87,16 +87,16 @@ class SceneInterfaceTest( unittest.TestCase ) :
 
 		self.writeSCC()
 
-		instance1 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
-		instance2 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance1 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
+		instance2 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertTrue( instance1.isSame( instance2 ) )
 
-		IECoreScene.SharedSceneInterfaces.erase( SceneInterfaceTest.__testFile )
+		IECoreScene.SharedSceneInterfaces.erase( self.__testFile )
 
-		instance3 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance3 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertFalse( instance3.isSame( instance1 ) )
 
-		instance4 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance4 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertFalse( instance4.isSame( instance1 ) )
 		self.assertTrue( instance4.isSame( instance3 ) )
 
@@ -104,21 +104,29 @@ class SceneInterfaceTest( unittest.TestCase ) :
 
 		self.writeSCC()
 
-		instance1 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
-		instance2 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance1 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
+		instance2 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertTrue( instance1.isSame( instance2 ) )
 
 		IECoreScene.SharedSceneInterfaces.clear()
 
-		instance3 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance3 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertFalse( instance3.isSame( instance1 ) )
 
-		instance4 = IECoreScene.SharedSceneInterfaces.get( SceneInterfaceTest.__testFile )
+		instance4 = IECoreScene.SharedSceneInterfaces.get( self.__testFile )
 		self.assertFalse( instance4.isSame( instance1 ) )
 		self.assertTrue( instance4.isSame( instance3 ) )
 
 	def testVisibilityName( self ) :
 		self.assertEqual( IECoreScene.SceneInterface.visibilityName, "scene:visible" )
+
+	def setUp( self ) :
+		self.tempDir = tempfile.mkdtemp()
+		self.__testFile = os.path.join( self.tempDir, "test.scc" )
+		self.__testFileUpper = os.path.join( self.tempDir, "test.SCC" )
+
+	def tearDown( self ) :
+		shutil.rmtree( self.tempDir )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/SceneInterfaceTest.py
+++ b/test/IECoreScene/SceneInterfaceTest.py
@@ -59,6 +59,11 @@ class SceneInterfaceTest( unittest.TestCase ) :
 		s.writeObject( IECoreScene.SpherePrimitive( 1 ), 1.0 )
 		s.writeAttribute( "glah", IECore.BoolData( True ), 1.0 )
 
+		del s, t, m
+
+		if not os.path.exists( self.__testFileUpper ) :
+			shutil.copyfile( self.__testFile, self.__testFileUpper )
+
 	def testGet( self ) :
 
 		self.writeSCC()
@@ -68,7 +73,8 @@ class SceneInterfaceTest( unittest.TestCase ) :
 		instance1_upper = IECoreScene.SharedSceneInterfaces.get( self.__testFileUpper )
 
 		self.assertTrue( instance1.isSame( instance2 ) )
-		self.assertTrue( instance1.isSame( instance1_upper ) )
+
+		self.assertFalse( instance1.isSame( instance1_upper ) )
 
 		instance3 = IECoreScene.SceneInterface.create( self.__testFile, IECore.IndexedIO.OpenMode.Read )
 		instance4 = IECoreScene.SceneInterface.create( self.__testFile, IECore.IndexedIO.OpenMode.Read )

--- a/test/IECoreScene/SceneInterfaceTest.py
+++ b/test/IECoreScene/SceneInterfaceTest.py
@@ -132,6 +132,7 @@ class SceneInterfaceTest( unittest.TestCase ) :
 		self.__testFileUpper = os.path.join( self.tempDir, "test.SCC" )
 
 	def tearDown( self ) :
+		IECoreScene.SharedSceneInterfaces.clear()
 		shutil.rmtree( self.tempDir )
 
 if __name__ == "__main__":

--- a/test/IECoreScene/SharedSceneInterfacesTest.py
+++ b/test/IECoreScene/SharedSceneInterfacesTest.py
@@ -36,6 +36,7 @@
 
 import unittest
 import functools
+import os
 
 import IECoreScene
 
@@ -54,9 +55,9 @@ class SharedSceneInterfacesTest( unittest.TestCase ) :
 		# Get more files than there is room for in the cache.
 
 		files = [
-			"test/IECore/data/sccFiles/animatedSpheres.scc",
-			"test/IECore/data/sccFiles/attributeAtRoot.scc",
-			"test/IECore/data/sccFiles/cube_v6.scc",
+			os.path.join( "test", "IECore", "data", "sccFiles", "animatedSpheres.scc" ),
+			os.path.join( "test", "IECore", "data", "sccFiles", "attributeAtRoot.scc" ),
+			os.path.join( "test", "IECore", "data", "sccFiles", "cube_v6.scc" ),
 		]
 
 		IECoreScene.SharedSceneInterfaces.setMaxScenes( len( files ) - 1 )

--- a/test/IECoreScene/SmoothSkinningDataTest.py
+++ b/test/IECoreScene/SmoothSkinningDataTest.py
@@ -69,7 +69,7 @@ class TestSmoothSkinningData( unittest.TestCase ) :
         ok_piw = IECore.FloatVectorData( [0.5, 0.5, 0.2, 0.8, 1.0] )
 
         s = IECoreScene.SmoothSkinningData(ok_jn, ok_ip, ok_pio, ok_pic, ok_pii, ok_piw)
-        iface = IECore.IndexedIO.create( "test/IECore/ssd.fio", IECore.IndexedIO.OpenMode.Write )
+        iface = IECore.IndexedIO.create( os.path.join( "test", "IECore", "ssd.fio" ), IECore.IndexedIO.OpenMode.Write )
 
         s.save( iface, "test" )
         ss = IECore.Object.load( iface, "test" )
@@ -95,7 +95,7 @@ class TestSmoothSkinningData( unittest.TestCase ) :
         self.assertEqual( s, s )
         self.assertEqual( s, s.copy() )
 
-        iface = IECore.IndexedIO.create( "test/IECore/ssd.fio", IECore.IndexedIO.OpenMode.Write )
+        iface = IECore.IndexedIO.create( os.path.join( "test", "IECore", "ssd.fio" ), IECore.IndexedIO.OpenMode.Write )
         s.save( iface, "test" )
         ss = IECore.Object.load( iface, "test" )
         self.assertEqual( s, ss )
@@ -163,8 +163,8 @@ class TestSmoothSkinningData( unittest.TestCase ) :
 
     def tearDown( self ) :
 
-        if os.path.isfile("test/IECore/ssd.fio"):
-            os.remove("test/IECore/ssd.fio")
+        if os.path.isfile(os.path.join( "test", "IECore", "ssd.fio" )):
+            os.remove(os.path.join( "test", "IECore", "ssd.fio" ))
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/Transform.py
+++ b/test/IECoreScene/Transform.py
@@ -56,8 +56,8 @@ class TestTransform( unittest.TestCase ) :
 
 		self.assertEqual( m, mm )
 
-		IECore.Writer.create( mm, "test/transform.cob" ).write()
-		mmm = IECore.Reader.create( "test/transform.cob" ).read()
+		IECore.Writer.create( mm, os.path.join( "test", "transform.cob" ) ).write()
+		mmm = IECore.Reader.create( os.path.join( "test", "transform.cob" ) ).read()
 
 		self.assertEqual( mm, mmm )
 
@@ -97,8 +97,8 @@ class TestTransform( unittest.TestCase ) :
 
 		self.assertEqual( m, mm )
 
-		IECore.Writer.create( mm, "test/motionTransform.cob" ).write()
-		mmm = IECore.Reader.create( "test/motionTransform.cob" ).read()
+		IECore.Writer.create( mm, os.path.join( "test", "motionTransform.cob" ) ).write()
+		mmm = IECore.Reader.create( os.path.join( "test", "motionTransform.cob" ) ).read()
 
 		self.assertEqual( mm, mmm )
 
@@ -112,11 +112,11 @@ class TestTransform( unittest.TestCase ) :
 
 	def tearDown( self ) :
 
-		if os.path.isfile("test/motionTransform.cob"):
-			os.remove("test/motionTransform.cob")
+		if os.path.isfile(os.path.join( "test", "motionTransform.cob" )):
+			os.remove(os.path.join( "test", "motionTransform.cob" ))
 
-		if os.path.isfile("test/transform.cob"):
-			os.remove("test/transform.cob")
+		if os.path.isfile(os.path.join( "test", "transform.cob" )):
+			os.remove(os.path.join( "test", "transform.cob" ))
 
 if __name__ == "__main__":
 	unittest.main()

--- a/test/IECoreScene/TriangulateOp.py
+++ b/test/IECoreScene/TriangulateOp.py
@@ -110,7 +110,7 @@ class TestTriangulateOp( unittest.TestCase ) :
 	def testQuadrangulatedSphere( self ) :
 		""" Test TriangulateOp with a quadrangulated poly sphere"""
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 		P = m["P"].data
 
 		self.assertEqual ( len( m.vertexIds ), 1560 )
@@ -143,7 +143,7 @@ class TestTriangulateOp( unittest.TestCase ) :
 	def testTriangulatedSphere( self ) :
 		""" Test TriangulateOp with a triangulated poly sphere"""
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/pSphereShape1.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pSphereShape1.cob" ) ).read()
 
 		op = IECoreScene.TriangulateOp()
 
@@ -186,7 +186,7 @@ class TestTriangulateOp( unittest.TestCase ) :
 
 	def testConstantPrimVars( self ) :
 
-		m = IECore.Reader.create( "test/IECore/data/cobFiles/polySphereQuads.cob").read()
+		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "polySphereQuads.cob" ) ).read()
 
 		m["constantScalar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.FloatData( 1 ) )
 		m["constantArray"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringVectorData( [ "one", "two" ] ) )
@@ -232,7 +232,7 @@ class TestTriangulateOp( unittest.TestCase ) :
 	def testTriangulatePerformance( self ):
 
 		for i in range(10):
-			root = IECoreScene.SceneInterface.create( "/path/to/cache.scc", IECore.IndexedIO.OpenMode.Read )
+			root = IECoreScene.SceneInterface.create( os.path.sep + os.path.join( "path", "to", "cache.scc" ), IECore.IndexedIO.OpenMode.Read )
 			body = root.scene(['location', 'of', 'object'])
 
 			objects = []

--- a/test/IECoreScene/TypedPrimitiveOp.py
+++ b/test/IECoreScene/TypedPrimitiveOp.py
@@ -44,7 +44,7 @@ class TestTypedPrimitiveOp( unittest.TestCase ) :
 
 		def __init__( self ):
 
-			IECoreScene.MeshPrimitiveOp.__init__( self, "MeshCopyOp", "A simple op to copy meshes" )
+			IECoreScene.MeshPrimitiveOp.__init__( self, "MeshCopyOp : A simple op to copy meshes" )
 
 		def modifyTypedPrimitive( self, mesh, operands ) :
 


### PR DESCRIPTION
Adds passing tests for IECoreScene on Windows.

- LinkedScene : links are now stored platform-independent with forward slashes only. Reading the link attribute returns the path in OS-native format.


### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
- [X] If my code made breaking changes, I applied the **pr-majorVersion** label to this PR.
