### PR TITLE
Avoid functionality deprecated in TBB 2020

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/RendererController.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/RendererController.h
@@ -35,9 +35,9 @@
 #ifndef IECOREAPPLESEED_RENDERERCONTROLLER_H
 #define IECOREAPPLESEED_RENDERERCONTROLLER_H
 
-#include "tbb/atomic.h"
-
 #include "renderer/api/rendering.h"
+
+#include <atomic>
 
 namespace IECoreAppleseed
 {
@@ -63,7 +63,7 @@ class RendererController : public renderer::DefaultRendererController
 
 	private :
 
-		tbb::atomic<Status> m_status;
+		std::atomic<Status> m_status;
 };
 
 } // namespace IECoreAppleseed

--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -282,7 +282,7 @@ class Parallel
 
 		typedef typename LRUCache::CacheEntry CacheEntry;
 		typedef typename LRUCache::KeyType Key;
-		typedef tbb::atomic<typename LRUCache::Cost> AtomicCost;
+		typedef std::atomic<typename LRUCache::Cost> AtomicCost;
 
 		struct Item
 		{
@@ -295,7 +295,7 @@ class Parallel
 			typedef tbb::spin_rw_mutex Mutex;
 			mutable Mutex mutex;
 			// Flag used in second-chance algorithm.
-			mutable tbb::atomic<bool> recentlyUsed;
+			mutable std::atomic<bool> recentlyUsed;
 		};
 
 		// We would love to use one of TBB's concurrent containers as

--- a/include/IECore/LRUCache.inl
+++ b/include/IECore/LRUCache.inl
@@ -46,10 +46,10 @@
 
 #include "tbb/spin_mutex.h"
 #include "tbb/spin_rw_mutex.h"
-#include "tbb/tbb_thread.h"
 
 #include <cassert>
 #include <iostream>
+#include <thread>
 #include <tuple>
 #include <vector>
 
@@ -341,7 +341,7 @@ class Parallel
 
 		Parallel()
 		{
-			m_bins.resize( tbb::tbb_thread::hardware_concurrency() );
+			m_bins.resize( std::thread::hardware_concurrency() );
 			m_popBinIndex = 0;
 			m_popIterator = m_bins[0].map.begin();
 			currentCost = 0;

--- a/include/IECore/RefCounted.h
+++ b/include/IECore/RefCounted.h
@@ -43,8 +43,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/noncopyable.hpp"
 
-#include "tbb/atomic.h"
-
+#include <atomic>
 #include <cassert>
 
 namespace IECore
@@ -157,7 +156,7 @@ class IECORE_API RefCounted : private boost::noncopyable
 
 	private :
 
-		mutable tbb::atomic<RefCount> m_numRefs;
+		mutable std::atomic<RefCount> m_numRefs;
 
 };
 

--- a/include/IECore/StreamIndexedIO.h
+++ b/include/IECore/StreamIndexedIO.h
@@ -43,11 +43,10 @@
 #include "boost/iostreams/filtering_stream.hpp"
 #include "boost/optional.hpp"
 
-#include "tbb/recursive_mutex.h"
-
 #include <fstream>
 #include <iostream>
 #include <map>
+#include <mutex>
 
 namespace IECore
 {
@@ -188,8 +187,8 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 				IndexedIO::OpenMode openMode() const;
 
 				// returns a read lock, when thread-safety is required.
-				typedef tbb::recursive_mutex Mutex;
-				typedef Mutex::scoped_lock MutexLock;
+				typedef std::recursive_mutex Mutex;
+				typedef std::lock_guard<Mutex> MutexLock;
 				Mutex & mutex();
 
 				// utility function that returns a temporary buffer for io operations (not thread safe).

--- a/include/IECoreGL/Group.h
+++ b/include/IECoreGL/Group.h
@@ -44,10 +44,8 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathMatrix.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
-#include "tbb/recursive_mutex.h"
-
 #include <list>
-
+#include <mutex>
 
 namespace IECoreGL
 {
@@ -59,7 +57,7 @@ class IECOREGL_API Group : public Renderable
 
 	public :
 
-		typedef tbb::recursive_mutex Mutex;
+		typedef std::recursive_mutex Mutex;
 		typedef std::list<RenderablePtr> ChildContainer;
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( IECoreGL::Group, GroupTypeId, Renderable );

--- a/include/IECoreMaya/MessageHandler.h
+++ b/include/IECoreMaya/MessageHandler.h
@@ -35,11 +35,11 @@
 #ifndef IE_COREMAYA_MESSAGEHANDLER_H
 #define IE_COREMAYA_MESSAGEHANDLER_H
 
-#include "tbb/mutex.h"
-
 #include "IECore/MessageHandler.h"
 
 #include "IECoreMaya/Export.h"
+
+#include <mutex>
 
 namespace IECoreMaya
 {
@@ -55,7 +55,7 @@ class IECOREMAYA_API MessageHandler : public IECore::MessageHandler
 
 	private :
 
-		typedef tbb::mutex MsgMutex;
+		typedef std::mutex MsgMutex;
 		mutable MsgMutex m_mutex;
 
 };

--- a/include/IECoreScene/CurvesPrimitiveEvaluator.h
+++ b/include/IECoreScene/CurvesPrimitiveEvaluator.h
@@ -40,7 +40,7 @@
 
 #include "IECore/BoundedKDTree.h"
 
-#include "tbb/mutex.h"
+#include <mutex>
 
 namespace IECoreScene
 {
@@ -186,7 +186,7 @@ class IECORESCENE_API CurvesPrimitiveEvaluator : public PrimitiveEvaluator
 
 		void buildTree();
 		bool m_haveTree;
-		typedef tbb::mutex TreeMutex;
+		typedef std::mutex TreeMutex;
 		TreeMutex m_treeMutex;
 		IECore::Box3fTree m_tree;
 		std::vector<Imath::Box3f> m_treeBounds;

--- a/include/IECoreScene/MeshPrimitiveEvaluator.h
+++ b/include/IECoreScene/MeshPrimitiveEvaluator.h
@@ -41,8 +41,7 @@
 
 #include "IECore/BoundedKDTree.h"
 
-#include "tbb/mutex.h"
-
+#include <mutex>
 #include <vector>
 
 namespace IECoreScene
@@ -206,7 +205,7 @@ class IECORESCENE_API MeshPrimitiveEvaluator : public PrimitiveEvaluator
 		mutable bool m_haveSurfaceArea;
 		mutable float m_surfaceArea;
 
-		typedef tbb::mutex NormalsMutex;
+		typedef std::mutex NormalsMutex;
 		mutable NormalsMutex m_normalsMutex;
 		mutable bool m_haveAverageNormals;
 		typedef int VertexIndex;

--- a/include/IECoreScene/PointsPrimitiveEvaluator.h
+++ b/include/IECoreScene/PointsPrimitiveEvaluator.h
@@ -40,7 +40,7 @@
 
 #include "IECore/KDTree.h"
 
-#include "tbb/mutex.h"
+#include <mutex>
 
 namespace IECoreScene
 {
@@ -147,7 +147,7 @@ class IECORESCENE_API PointsPrimitiveEvaluator : public PrimitiveEvaluator
 
 		void buildTree();
 		bool m_haveTree;
-		typedef tbb::mutex TreeMutex;
+		typedef std::mutex TreeMutex;
 		TreeMutex m_treeMutex;
 		IECore::V3fTree m_tree;
 

--- a/include/IECoreVDB/VDBObject.h
+++ b/include/IECoreVDB/VDBObject.h
@@ -108,7 +108,7 @@ class IECOREVDB_API VDBObject : public IECoreScene::VisibleRenderable
 			{}
 
 			std::unique_ptr<openvdb::io::File> file;
-			tbb::recursive_mutex mutex;
+			std::recursive_mutex mutex;
 		};
 
 		class HashedGrid

--- a/src/IECore/CachedReader.cpp
+++ b/src/IECore/CachedReader.cpp
@@ -43,7 +43,8 @@
 #include "boost/lexical_cast.hpp"
 
 #include "tbb/concurrent_hash_map.h"
-#include "tbb/mutex.h"
+
+#include <mutex>
 
 // Windows defines SearchPath
 #ifdef SearchPath
@@ -76,7 +77,7 @@ struct CachedReader::MemberData
 		SearchPath m_searchPaths;
 		Cache m_cache;
 		ConstModifyOpPtr m_postProcessor;
-		tbb::mutex m_postProcessorMutex;
+		std::mutex m_postProcessorMutex;
 		typedef tbb::concurrent_hash_map< std::string, std::string > FileErrors;
 		FileErrors m_fileErrors;
 
@@ -163,7 +164,7 @@ struct CachedReader::MemberData
 					/// This means adding an overloaded operate() method but more importantly making sure
 					/// that all Ops only use their operands to access arguments and not go getting them
 					/// from the Parameters directly.
-					tbb::mutex::scoped_lock l( data->m_postProcessorMutex );
+					std::lock_guard<std::mutex> l( data->m_postProcessorMutex );
 					ModifyOpPtr postProcessor = boost::const_pointer_cast<ModifyOp>( data->m_postProcessor );
 					postProcessor->inputParameter()->setValue( result );
 					postProcessor->copyParameter()->setTypedValue( false );

--- a/src/IECore/IndexedIOAlgo.cpp
+++ b/src/IECore/IndexedIOAlgo.cpp
@@ -34,7 +34,6 @@
 
 #include "IECore/IndexedIOAlgo.h"
 
-#include "tbb/task_scheduler_init.h"
 #include "tbb/task.h"
 
 #include <atomic>

--- a/src/IECore/RunTimeTyped.cpp
+++ b/src/IECore/RunTimeTyped.cpp
@@ -38,9 +38,8 @@
 
 #include "boost/format.hpp"
 
-#include "tbb/mutex.h"
-
 #include <cassert>
+#include <mutex>
 
 using namespace IECore;
 

--- a/src/IECoreGL/DeferredRendererImplementation.cpp
+++ b/src/IECoreGL/DeferredRendererImplementation.cpp
@@ -47,7 +47,6 @@
 
 #include "boost/noncopyable.hpp"
 
-#include "tbb/atomic.h"
 #include "tbb/task.h"
 #include "tbb/task_scheduler_init.h"
 
@@ -411,7 +410,7 @@ class DeferredRendererImplementation::ProceduralTask : public tbb::task, private
 
 	private :
 
-		tbb::atomic<unsigned int> m_numSubtasks;
+		std::atomic<unsigned int> m_numSubtasks;
 		RenderContextPtr m_proceduralContext;
 		DeferredRendererImplementation &m_renderer;
 		IECoreScene::Renderer::ProceduralPtr m_procedural;

--- a/src/IECoreGL/DeferredRendererImplementation.cpp
+++ b/src/IECoreGL/DeferredRendererImplementation.cpp
@@ -131,7 +131,7 @@ void DeferredRendererImplementation::transformBegin()
 	GroupPtr g = new Group;
 	g->setTransform( curContext->localTransform );
 	{
-		IECoreGL::Group::Mutex::scoped_lock lock( curContext->groupStack.top()->mutex() );
+		std::lock_guard<IECoreGL::Group::Mutex> lock( curContext->groupStack.top()->mutex() );
 		curContext->groupStack.top()->addChild( g );
 	}
 	curContext->groupStack.push( g );
@@ -188,7 +188,7 @@ void DeferredRendererImplementation::attributeBegin()
 	g->setTransform( curContext->localTransform );
 	g->setState( new State( **(curContext->stateStack.rbegin()) ) );
 	{
-		IECoreGL::Group::Mutex::scoped_lock lock( curContext->groupStack.top()->mutex() );
+		std::lock_guard<IECoreGL::Group::Mutex> lock( curContext->groupStack.top()->mutex() );
 		curContext->groupStack.top()->addChild( g );
 	}
 	curContext->groupStack.push( g );
@@ -281,7 +281,7 @@ void DeferredRendererImplementation::addPrimitive( ConstPrimitivePtr primitive )
 	g->addChild( boost::const_pointer_cast<Primitive>( primitive ) );
 
 	{
-		IECoreGL::Group::Mutex::scoped_lock lock( curContext->groupStack.top()->mutex() );
+		std::lock_guard<IECoreGL::Group::Mutex> lock( curContext->groupStack.top()->mutex() );
 		curContext->groupStack.top()->addChild( g );
 	}
 }
@@ -302,7 +302,7 @@ void DeferredRendererImplementation::addInstance( GroupPtr grp )
 	g->addChild( grp );
 
 	{
-		IECoreGL::Group::Mutex::scoped_lock lock( curContext->groupStack.top()->mutex() );
+		std::lock_guard<IECoreGL::Group::Mutex> lock( curContext->groupStack.top()->mutex() );
 		curContext->groupStack.top()->addChild( g );
 	}
 }

--- a/src/IECoreGL/Renderer.cpp
+++ b/src/IECoreGL/Renderer.cpp
@@ -82,6 +82,11 @@
 #include <mutex>
 #include <stack>
 
+// Windows defines SearchPath, breaking our use of `IECore::SearchPath`.
+#ifdef SearchPath
+#undef SearchPath
+#endif
+
 using namespace IECore;
 using namespace IECoreScene;
 using namespace IECoreGL;

--- a/src/IECoreGL/bindings/GroupBinding.cpp
+++ b/src/IECoreGL/bindings/GroupBinding.cpp
@@ -47,32 +47,32 @@ namespace IECoreGL
 
 Imath::Box3f bound( Group &g )
 {
-	Group::Mutex::scoped_lock lock( g.mutex() );
+	std::lock_guard<Group::Mutex> lock( g.mutex() );
 	return g.bound();
 }
 
 void addChild( Group &g, RenderablePtr child )
 {
-	Group::Mutex::scoped_lock lock( g.mutex() );
+	std::lock_guard<Group::Mutex> lock( g.mutex() );
 	g.addChild( child );
 }
 
 void removeChild( Group &g, Renderable *child )
 {
-	Group::Mutex::scoped_lock lock( g.mutex() );
+	std::lock_guard<Group::Mutex> lock( g.mutex() );
 	g.removeChild( child );
 }
 
 void clearChildren( Group &g )
 {
-	Group::Mutex::scoped_lock lock( g.mutex() );
+	std::lock_guard<Group::Mutex> lock( g.mutex() );
 	g.clearChildren();
 }
 
 list children( const Group &g )
 {
 	list result;
-	Group::Mutex::scoped_lock lock( g.mutex() );
+	std::lock_guard<Group::Mutex> lock( g.mutex() );
 	Group::ChildContainer::const_iterator it;
 	for( it=g.children().begin(); it!=g.children().end(); it++ )
 	{

--- a/src/IECoreImage/DisplayDriverServer.cpp
+++ b/src/IECoreImage/DisplayDriverServer.cpp
@@ -48,7 +48,7 @@
 
 #include "boost/bind.hpp"
 
-#include "tbb/tbb_thread.h"
+#include <thread>
 
 #include <fcntl.h>
 #ifndef _MSC_VER
@@ -119,7 +119,7 @@ class DisplayDriverServer::PrivateData : public RefCounted
 		boost::asio::ip::tcp::endpoint m_endpoint;
 		boost::asio::io_service m_service;
 		boost::asio::ip::tcp::acceptor m_acceptor;
-		tbb::tbb_thread m_thread;
+		std::thread m_thread;
 
 		PrivateData( DisplayDriverServer::Port portNumber ) :
 			m_service(),
@@ -195,7 +195,7 @@ DisplayDriverServer::DisplayDriverServer( DisplayDriverServer::Port portNumber )
 			boost::bind( &DisplayDriverServer::handleAccept, this, newSession,
 			boost::asio::placeholders::error));
 	fixSocketFlags( m_data->m_acceptor.native_handle() );
-	tbb::tbb_thread newThread( boost::bind(&DisplayDriverServer::serverThread, this) );
+	std::thread newThread( boost::bind(&DisplayDriverServer::serverThread, this) );
 	m_data->m_thread.swap( newThread );
 }
 

--- a/src/IECoreImage/ImageDisplayDriver.cpp
+++ b/src/IECoreImage/ImageDisplayDriver.cpp
@@ -36,7 +36,7 @@
 
 #include "boost/algorithm/string/predicate.hpp"
 
-#include "tbb/mutex.h"
+#include <mutex>
 
 using namespace std;
 using namespace boost;
@@ -50,7 +50,7 @@ const DisplayDriver::DisplayDriverDescription<ImageDisplayDriver> ImageDisplayDr
 
 typedef std::map<std::string, ConstImagePrimitivePtr> ImagePool;
 static ImagePool g_pool;
-static tbb::mutex g_poolMutex;
+static std::mutex g_poolMutex;
 
 ImageDisplayDriver::ImageDisplayDriver( const Box2i &displayWindow, const Box2i &dataWindow, const vector<string> &channelNames, ConstCompoundDataPtr parameters ) :
 		DisplayDriver( displayWindow, dataWindow, channelNames, parameters ),
@@ -78,7 +78,7 @@ ImageDisplayDriver::ImageDisplayDriver( const Box2i &displayWindow, const Box2i 
 		ConstStringDataPtr handle = parameters->member<StringData>( "handle" );
 		if( handle )
 		{
-			tbb::mutex::scoped_lock lock( g_poolMutex );
+			std::lock_guard<std::mutex> lock( g_poolMutex );
 			g_pool[handle->readable()] = m_image;
 		}
 	}
@@ -155,7 +155,7 @@ ConstImagePrimitivePtr ImageDisplayDriver::image() const
 
 ConstImagePrimitivePtr ImageDisplayDriver::storedImage( const std::string &handle )
 {
-	tbb::mutex::scoped_lock lock( g_poolMutex );
+	std::lock_guard<std::mutex> lock( g_poolMutex );
 	ImagePool::const_iterator it = g_pool.find( handle );
 	if( it != g_pool.end() )
 	{
@@ -167,7 +167,7 @@ ConstImagePrimitivePtr ImageDisplayDriver::storedImage( const std::string &handl
 ConstImagePrimitivePtr ImageDisplayDriver::removeStoredImage( const std::string &handle )
 {
 	ConstImagePrimitivePtr result = nullptr;
-	tbb::mutex::scoped_lock lock( g_poolMutex );
+	std::lock_guard<std::mutex> lock( g_poolMutex );
 	ImagePool::iterator it = g_pool.find( handle );
 	if( it != g_pool.end() )
 	{

--- a/src/IECoreMaya/MessageHandler.cpp
+++ b/src/IECoreMaya/MessageHandler.cpp
@@ -42,7 +42,7 @@ void MessageHandler::handle( Level level, const std::string &context, const std:
 {
 
 	// MGlobal.display* seemingly is not thread safe.
-	MsgMutex::scoped_lock lock( m_mutex );
+	std::lock_guard<MsgMutex> lock( m_mutex );
 
 	MString m = MString( context.c_str() ) + " : " + message.c_str();
 	switch( level )

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -47,6 +47,8 @@
 
 #include "tbb/tbb.h"
 
+#include <mutex>
+
 using namespace boost::python;
 using namespace IECore;
 using namespace tbb;
@@ -133,17 +135,17 @@ class PythonLRUCache : public LRUCache<object, object>
 			//
 			// see test/IECore/LRUCache.py, in particular testYieldGILInGetter().
 
-			Mutex::scoped_lock lock;
+			std::unique_lock<Mutex> lock( m_getMutex, std::defer_lock );
 			{
 				IECorePython::ScopedGILRelease gilRelease;
-				lock.acquire( m_getMutex );
+				lock.lock();
 			}
 			return LRUCache<object, object>::get( key );
 		}
 
 	private :
 
-		typedef tbb::mutex Mutex;
+		typedef std::mutex Mutex;
 		Mutex m_getMutex;
 
 };

--- a/src/IECorePython/LRUCacheBinding.cpp
+++ b/src/IECorePython/LRUCacheBinding.cpp
@@ -45,7 +45,7 @@
 
 #include "boost/format.hpp"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <mutex>
 

--- a/src/IECorePythonModule/TBBBinding.cpp
+++ b/src/IECorePythonModule/TBBBinding.cpp
@@ -43,6 +43,8 @@
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #include "tbb/global_control.h"
 
+#include <thread>
+
 using namespace boost::python;
 
 namespace
@@ -138,7 +140,7 @@ void IECorePythonModule::bindTBB()
 		.staticmethod( "active_value" )
 	;
 
-	def( "hardwareConcurrency", &tbb::tbb_thread::hardware_concurrency );
+	def( "hardwareConcurrency", &std::thread::hardware_concurrency );
 
 }
 

--- a/src/IECorePythonModule/TBBBinding.cpp
+++ b/src/IECorePythonModule/TBBBinding.cpp
@@ -38,7 +38,7 @@
 
 #include "TBBBinding.h"
 
-#include "tbb/tbb.h"
+#include "tbb/task_scheduler_init.h"
 
 #define TBB_PREVIEW_GLOBAL_CONTROL 1
 #include "tbb/global_control.h"

--- a/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
@@ -649,7 +649,7 @@ void CurvesPrimitiveEvaluator::buildTree()
 		return;
 	}
 
-	TreeMutex::scoped_lock lock( m_treeMutex );
+	std::lock_guard<TreeMutex> lock( m_treeMutex );
 	if( m_haveTree )
 	{
 		// another thread may have built the tree while we waited for the mutex

--- a/src/IECoreScene/MeshAlgoDistributePoints.cpp
+++ b/src/IECoreScene/MeshAlgoDistributePoints.cpp
@@ -40,7 +40,8 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/TriangleAlgo.h"
 
-#include "tbb/tbb.h"
+#include "tbb/blocked_range.h"
+#include "tbb/parallel_reduce.h"
 
 using namespace Imath;
 using namespace IECore;

--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -474,7 +474,7 @@ void MeshPrimitiveEvaluator::calculateAverageNormals() const
 		return;
 	}
 
-	NormalsMutex::scoped_lock lock( m_normalsMutex );
+	std::lock_guard<NormalsMutex> lock( m_normalsMutex );
 	if( m_haveAverageNormals )
 	{
 		// another thread may have calculated the normals while we waited for the mutex

--- a/src/IECoreScene/PointSmoothSkinningOp.cpp
+++ b/src/IECoreScene/PointSmoothSkinningOp.cpp
@@ -52,7 +52,7 @@
 
 #include "boost/format.hpp"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/IECoreScene/PointsPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/PointsPrimitiveEvaluator.cpp
@@ -257,7 +257,7 @@ void PointsPrimitiveEvaluator::buildTree()
 		return;
 	}
 
-	TreeMutex::scoped_lock lock( m_treeMutex );
+	std::lock_guard<TreeMutex> lock( m_treeMutex );
 	if( m_haveTree )
 	{
 		// another thread may have built the tree while we waited for the mutex

--- a/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
+++ b/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
@@ -44,7 +44,7 @@
 
 #include "OpenEXR/ImathRandom.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 using namespace tbb;
 using namespace Imath;

--- a/src/IECoreScene/bindings/IECoreScene.cpp
+++ b/src/IECoreScene/bindings/IECoreScene.cpp
@@ -116,8 +116,6 @@
 #include "VisibleRenderableBinding.h"
 #include "SceneAlgoBinding.h"
 
-#include "tbb/tbb_thread.h"
-
 using namespace IECoreSceneModule;
 using namespace boost::python;
 

--- a/src/IECoreScene/bindings/SceneCacheBinding.cpp
+++ b/src/IECoreScene/bindings/SceneCacheBinding.cpp
@@ -43,7 +43,8 @@
 
 #include "IECorePython/RunTimeTypedBinding.h"
 
-#include "tbb/tbb.h"
+#include "tbb/blocked_range.h"
+#include "tbb/parallel_reduce.h"
 
 using namespace tbb;
 using namespace boost::python;

--- a/src/IECoreScene/bindings/SceneCacheBinding.cpp
+++ b/src/IECoreScene/bindings/SceneCacheBinding.cpp
@@ -131,8 +131,6 @@ struct TestSceneCache
 
 void testSceneCacheParallelAttributeRead()
 {
-	task_scheduler_init scheduler( 100 );
-
 	TestSceneCache task( "w" );
 
 	parallel_reduce( blocked_range<size_t>( 0, 100 ), task );
@@ -144,8 +142,6 @@ void testSceneCacheParallelAttributeRead()
 
 void testSceneCacheParallelFakeAttributeRead()
 {
-	task_scheduler_init scheduler( 100 );
-
 	TestSceneCache task( "fake" );
 
 	parallel_reduce( blocked_range<size_t>( 0, 100 ), task );

--- a/src/IECoreVDB/VDBObject.cpp
+++ b/src/IECoreVDB/VDBObject.cpp
@@ -402,7 +402,7 @@ openvdb::GridBase::Ptr VDBObject::HashedGrid::grid() const
 	auto tmp = m_lockedFile;
 	if ( tmp && tmp->file )
 	{
-		tbb::recursive_mutex::scoped_lock l( tmp->mutex );
+		std::lock_guard<std::recursive_mutex> l( tmp->mutex );
 
 		m_grid = tmp->file->readGrid( m_grid->getName() );
 		m_lockedFile.reset();

--- a/test/IECore/ComputationCacheTest.cpp
+++ b/test/IECore/ComputationCacheTest.cpp
@@ -37,7 +37,7 @@
 #include "IECore/ComputationCache.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <iostream>
 

--- a/test/IECore/InternedStringTest.cpp
+++ b/test/IECore/InternedStringTest.cpp
@@ -40,7 +40,7 @@
 
 #include "boost/lexical_cast.hpp"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <iostream>
 

--- a/test/IECore/LRUCacheThreadingTest.cpp
+++ b/test/IECore/LRUCacheThreadingTest.cpp
@@ -37,7 +37,7 @@
 #include "IECore/LRUCache.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <iostream>
 

--- a/test/IECore/ParameterThreadingTest.cpp
+++ b/test/IECore/ParameterThreadingTest.cpp
@@ -44,7 +44,7 @@
 
 #include "OpenEXR/ImathRandom.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <iostream>
 #include <set>

--- a/test/IECore/RefCountedThreadingTest.cpp
+++ b/test/IECore/RefCountedThreadingTest.cpp
@@ -36,7 +36,7 @@
 
 #include "IECore/RefCounted.h"
 
-#include "tbb/tbb.h"
+#include "tbb/parallel_for.h"
 
 #include <iostream>
 #include <vector>


### PR DESCRIPTION
This is the little rabbit hole that innocently upgrading TBB to match VFXPlatform 2021 took me down. There are a few unexplored tunnels still but TBB is using `pragma message` rather than a true warning, so everything still compiles and we can explore those at a later date.