### PR TITLE
IgnoredExceptions : Clear `__traceback__`

### DIFF
--- a/python/IECore/IgnoredExceptions.py
+++ b/python/IECore/IgnoredExceptions.py
@@ -60,6 +60,9 @@ class IgnoredExceptions :
 	def __exit__( self, type, value, traceBack ) :
 
 		if isinstance( value, self.__toIgnore ) :
+			# Remove circular references which would cause everything in the
+			# calling stack frame to exist far longer than necessary.
+			value.__traceback__ = None
 			return True
 
 		if type is not None and issubclass( type, self.__toIgnore ) :


### PR DESCRIPTION
In Python 3, the new `__traceback__` attribute on exceptions means that the exception contains a circular reference to itself (because the traceback references the stack frame where the exception exists as a local variable). And worse, the traceback keeps all the calling stack frames and all their local variables alive too.

This was causing problems in Gaffer, by keeping `GafferUI.Widgets` alive well after the underlying QWidget was destroyed, leading to the dreaded `C++ object already deleted` error.

Since the purpose of IgnoredExceptions is to hide the exception, it is fine erase the traceback (since nobody will see it anyway).
