### PR TITLE
Windows test cleanup

### DIFF
--- a/test/IECore/All.py
+++ b/test/IECore/All.py
@@ -159,7 +159,7 @@ unittest.TestProgram(
 		stream = IECore.CompoundStream(
 			[
 				sys.stderr,
-				open( "test/IECore/resultsPython.txt", "w" )
+				open( os.path.join( "test", "IECore", "resultsPython.txt" ), "w" )
 			]
 		),
 		verbosity = 2

--- a/test/IECoreImage/All.py
+++ b/test/IECoreImage/All.py
@@ -64,7 +64,7 @@ unittest.TestProgram(
 		stream = IECore.CompoundStream(
 			[
 				sys.stderr,
-				open( "test/IECoreImage/results.txt", "w" )
+				open( os.path.join( "test", "IECoreImage", "results.txt" ), "w" )
 			]
 		),
 		verbosity = 2

--- a/test/IECoreScene/All.py
+++ b/test/IECoreScene/All.py
@@ -119,7 +119,7 @@ unittest.TestProgram(
 		stream = IECore.CompoundStream(
 			[
 				sys.stderr,
-				open( "test/IECore/resultsPython.txt", "w" )
+				open( os.path.join( "test", "IECore", "resultsPython.txt" ), "w" )
 			]
 		),
 		verbosity = 2

--- a/test/IECoreScene/All.py
+++ b/test/IECoreScene/All.py
@@ -119,7 +119,7 @@ unittest.TestProgram(
 		stream = IECore.CompoundStream(
 			[
 				sys.stderr,
-				open( os.path.join( "test", "IECore", "resultsPython.txt" ), "w" )
+				open( os.path.join( "test", "IECoreScene", "resultsPython.txt" ), "w" )
 			]
 		),
 		verbosity = 2

--- a/test/IECoreVDB/All.py
+++ b/test/IECoreVDB/All.py
@@ -35,6 +35,7 @@
 
 import unittest
 import sys
+import os
 
 import IECore
 
@@ -46,7 +47,7 @@ unittest.TestProgram(
 		stream = IECore.CompoundStream(
 			[
 				sys.stderr,
-				open( "test/IECoreVDB/resultsPython.txt", "w" )
+				open( os.path.join( "test", "IECoreVDB", "resultsPython.txt" ), "w" )
 			]
 		),
 		verbosity = 2


### PR DESCRIPTION
This makes the directories for saving the test results cross-platform as in other locations. It's not strictly needed for Windows tests to save correctly, but submitted as a formatting improvement.

It also changes what looks to be a typo where the path for the IECoreScene results were saved in IECore, instead of it's own directory.

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
