### PR TITLE
CancellerTest - Add margin of error for elapsed time

### DIFF
--- a/test/IECore/CancellerTest.py
+++ b/test/IECore/CancellerTest.py
@@ -136,7 +136,9 @@ class CancellerTest( unittest.TestCase ) :
 		c.cancel()
 		time.sleep( 0.25 )
 		t = c.elapsedTime()
-		self.assertGreaterEqual( t, 0.25 )
+		# Windows potentially sleeps less than the requested amount of time.
+		# Testing indicates 1 millisecond should be enough margin to pass.
+		self.assertGreaterEqual( t, 0.25 - 0.001 )
 		# We'd like to `assertAlmostEqual( t, 0.25 )` as well, to check that are
 		# units are seconds. But the load on CI machines is sometimes such that
 		# we couldn't do that with any kind of reasonable epsilon. Instead, just


### PR DESCRIPTION
This adds a slight margin of error in the CancellerTest because Windows does not guarantee the sleep time requested will be met. More information is available starting with https://github.com/ImageEngine/cortex/pull/1190#issuecomment-932014866

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
