### PR TITLE
CachedReader : clean `ifdef` indentation

### DIFF
--- a/src/IECore/CachedReader.cpp
+++ b/src/IECore/CachedReader.cpp
@@ -123,11 +123,11 @@ struct CachedReader::MemberData
 				{
 					string pathList;
 
-					#ifdef _WIN32
-						const std::string separator = ";";
-					#else
-						const std::string separator = ":";
-					#endif
+#ifdef _WIN32
+					const std::string separator = ";";
+#else
+					const std::string separator = ":";
+#endif
 
 					for( list<path>::const_iterator it =  data->m_searchPaths.paths.begin(); it!= data->m_searchPaths.paths.end(); it++ )
 					{


### PR DESCRIPTION
This fixes the formatting pointed out in https://github.com/ImageEngine/cortex/pull/1183#discussion_r699460613, making the `#ifdef` block unindented as elsewhere in Cortex.

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
