### PR TITLE
ToGLStateConverter : Convert `render:displayColor` attribute to `Color` StateComponent

### DIFF
--- a/test/IECoreGL/ToGLStateConverterTest.py
+++ b/test/IECoreGL/ToGLStateConverterTest.py
@@ -47,6 +47,9 @@ class ToGLStateConverterTest( unittest.TestCase ) :
 
 		attributes = [
 			( "doubleSided", IECore.BoolData( True ), IECoreGL.DoubleSidedStateComponent( True ) ),
+			( "render:displayColor", IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ), IECoreGL.Color( imath.Color4f( 1, 2, 3, 1 ) ) ),
+			( "render:displayColor", IECore.Color4fData( imath.Color4f( 1, 2, 3, 4 ) ), IECoreGL.Color( imath.Color4f( 1, 2, 3, 4 ) ) ),
+			( "render:displayColor", IECore.Color3fVectorData( [ imath.Color3f( 1, 2, 3 ) ] ), IECoreGL.Color( imath.Color4f( 1, 2, 3, 1 ) ) ),
 			( "gl:primitive:wireframe", IECore.BoolData( True ), IECoreGL.Primitive.DrawWireframe( True ) ),
 			( "gl:primitive:wireframeWidth", IECore.FloatData( 2.5 ), IECoreGL.Primitive.WireframeWidth( 2.5 ) ),
 			( "gl:primitive:wireframeColor", IECore.Color4fData( imath.Color4f( 0.1, 0.25, 0.5, 1 ) ), IECoreGL.WireframeColorStateComponent( imath.Color4f( 0.1, 0.25, 0.5, 1 ) ) ),


### PR DESCRIPTION
This will then be picked up by the `Cs` parameter value for any GLSL shaders, unless overridden by a `Cs` primitive variable. We always should have supported an attribute for setting color, supporting it with the `render:displayColor` name matches how we now import USD ( and we expect displayColor to become our standard name in the future )

This is my version of #1208 with the updates John requested.

The tests pass, and I've confirmed that it works correctly with standard USD by viewing `UsdSkelExamples/HumanFemale/HumanFemale.usd` - everything appears to be getting correctly colored there now.