### PR TITLE
Initial Usd Shader Network Support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2973,6 +2973,7 @@ else :
 		"usd",
 		"usdGeom",
 		"usdSkel",
+		"usdShade",
 		"sdf",
 		"tf",
 		"pcp",

--- a/contrib/IECoreUSD/include/IECoreUSD/AttributeAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/AttributeAlgo.h
@@ -41,6 +41,8 @@
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/base/tf/token.h"
+#include "pxr/usd/usd/attribute.h"
+#include "pxr/usd/usd/prim.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
 // AttributeAlgo is suite of utilities for loading/writing Cortex/USD Attributes.
@@ -51,12 +53,29 @@ namespace IECoreUSD
 namespace AttributeAlgo
 {
 
+
+
+// Find a UsdAttribute under the given prim which matches the given cortex name.  This UsdAttribute
+// could be either a constant primvar or a custom attribute with an appropriate name.  If no matching
+// UsdAttribute is found, returns an invalid UsdAttribute
+IECOREUSD_API pxr::UsdAttribute findUSDAttribute( const pxr::UsdPrim &prim, std::string cortexName );
+
+// Return the cortex attribute corresponding to a UsdAttribute.  There will be a corresponding Cortex
+// name if the UsdAttribute corresponds to a constant primvar which should be loaded as an attribute,
+// or a custom UsdAttribute.  If the UsdAttribute corresponds to a primvar that we load as a primvar,
+// or a non-custom primvar, then an empty string is returned.
+IECOREUSD_API IECore::InternedString cortexAttributeName( const pxr::UsdAttribute &attribute );
+
+struct Name
+{
+	pxr::TfToken name;
+	bool isPrimvar;
+};
+
+IECOREUSD_API Name nameToUSD( std::string name );
+IECOREUSD_API IECore::InternedString nameFromUSD( Name name );
+
 IECOREUSD_API pxr::TfToken cortexPrimitiveVariableMetadataToken();
-IECOREUSD_API pxr::TfToken toUSD( const std::string& name );
-IECOREUSD_API IECore::InternedString fromUSD( const std::string& name );
-IECOREUSD_API IECore::InternedString primVarPrefix();
-IECOREUSD_API std::string userPrefix();
-IECOREUSD_API std::string renderPrefix();
 
 } // namespace AttributeAlgo
 

--- a/contrib/IECoreUSD/include/IECoreUSD/ShaderAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/ShaderAlgo.h
@@ -1,0 +1,68 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREUSD_SHADERALGO_H
+#define IECOREUSD_SHADERALGO_H
+
+#include "IECoreUSD/Export.h"
+
+#include "IECoreScene/ShaderNetwork.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "pxr/usd/usdShade/material.h"
+#include "pxr/usd/usdShade/output.h"
+IECORE_POP_DEFAULT_VISIBILITY
+
+namespace IECoreUSD
+{
+
+namespace ShaderAlgo
+{
+
+/// Write ShaderNetwork to USD, placing the shaders under the Prim `shaderContainer`
+IECOREUSD_API pxr::UsdShadeOutput writeShaderNetwork( const IECoreScene::ShaderNetwork *shaderNetwork, pxr::UsdPrim shaderContainer );
+
+/// Read ShaderNetwork from a USD node ( and its connected inputs )
+/// `anchorPath` is the ancestor path that shaders will be named relative to
+/// `outputHandle` specifies which output of the USD node is being used ( the ShaderNetwork must have
+/// a corresponding output set )
+IECoreScene::ShaderNetworkPtr readShaderNetwork( const pxr::SdfPath &anchorPath, const pxr::UsdShadeShader &outputShader, const pxr::TfToken &outputHandle );
+
+
+
+} // namespace ShaderAlgo
+
+} // namespace IECoreUSD
+
+#endif // IECOREUSD_SHADERALGO_H

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -368,20 +368,16 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 		loadAttributes( currentPath, properties, typeName );
 
 		// visibility
-		properties.push_back( UsdGeomTokens->visibility );
-		addProperty( primPath, UsdGeomTokens->visibility, SdfValueTypeNames->Token, false, SdfVariabilityVarying );
+		addProperty( properties, primPath, UsdGeomTokens->visibility, SdfValueTypeNames->Token, false, SdfVariabilityVarying );
 
 		// extent
-		properties.push_back( UsdGeomTokens->extent );
-		addProperty( primPath, UsdGeomTokens->extent, SdfValueTypeNames->Float3Array, false, SdfVariabilityVarying );
+		addProperty( properties, primPath, UsdGeomTokens->extent, SdfValueTypeNames->Float3Array, false, SdfVariabilityVarying );
 
 		// xformOpOrder
-		properties.push_back( UsdGeomTokens->xformOpOrder );
-		addProperty( primPath, UsdGeomTokens->xformOpOrder, SdfValueTypeNames->TokenArray, false, SdfVariabilityUniform, &g_xformTransform );
+		addProperty( properties, primPath, UsdGeomTokens->xformOpOrder, SdfValueTypeNames->TokenArray, false, SdfVariabilityUniform, &g_xformTransform );
 
 		// xformOp:transform
-		properties.push_back( g_xformTransform );
-		addProperty( primPath, g_xformTransform, SdfValueTypeNames->Matrix4d, false, SdfVariabilityVarying );
+		addProperty( properties, primPath, g_xformTransform, SdfValueTypeNames->Matrix4d, false, SdfVariabilityVarying );
 
 		// build map for collections
 		SceneInterface::NameList tags;
@@ -398,12 +394,11 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 				typeName = g_camera;
 
 				// focal length
-				properties.push_back( UsdGeomTokens->focalLength );
-				addProperty( primPath, UsdGeomTokens->focalLength, SdfValueTypeNames->Float, false, SdfVariabilityVarying );
+				addProperty( properties, primPath, UsdGeomTokens->focalLength, SdfValueTypeNames->Float, false, SdfVariabilityVarying );
 
 				// horizontal aperture
-				properties.push_back( UsdGeomTokens->horizontalAperture );
 				addProperty(
+					properties,
 					primPath,
 					UsdGeomTokens->horizontalAperture,
 					SdfValueTypeNames->Float,
@@ -411,12 +406,11 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					SdfVariabilityVarying
 				);
 				// vertical aperture
-				properties.push_back( UsdGeomTokens->verticalAperture );
-				addProperty( primPath, UsdGeomTokens->verticalAperture, SdfValueTypeNames->Float, false, SdfVariabilityVarying );
+				addProperty( properties, primPath, UsdGeomTokens->verticalAperture, SdfValueTypeNames->Float, false, SdfVariabilityVarying );
 
 				// horizontal aperture offset
-				properties.push_back( UsdGeomTokens->horizontalApertureOffset );
 				addProperty(
+					properties,
 					primPath,
 					UsdGeomTokens->horizontalApertureOffset,
 					SdfValueTypeNames->Float,
@@ -425,8 +419,8 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 				);
 
 				// vertical aperture offset
-				properties.push_back( UsdGeomTokens->verticalApertureOffset );
 				addProperty(
+					properties,
 					primPath,
 					UsdGeomTokens->verticalApertureOffset,
 					SdfValueTypeNames->Float,
@@ -443,8 +437,8 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					// topology
 
 					// verticesPerFace
-					properties.push_back( UsdGeomTokens->faceVertexCounts );
 					addProperty(
+						properties,
 						primPath,
 						UsdGeomTokens->faceVertexCounts,
 						SdfValueTypeNames->IntArray,
@@ -453,16 +447,14 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					);
 
 					// vertexIds
-					properties.push_back( UsdGeomTokens->faceVertexIndices );
-					addProperty( primPath, UsdGeomTokens->faceVertexIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
+					addProperty( properties, primPath, UsdGeomTokens->faceVertexIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
 
 					// cornerIndices
-					properties.push_back( UsdGeomTokens->cornerIndices );
-					addProperty( primPath, UsdGeomTokens->cornerIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
+					addProperty( properties, primPath, UsdGeomTokens->cornerIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
 
 					// cornerSharpness
-					properties.push_back( UsdGeomTokens->cornerSharpnesses );
 					addProperty(
+						properties,
 						primPath,
 						UsdGeomTokens->cornerSharpnesses,
 						SdfValueTypeNames->FloatArray,
@@ -471,16 +463,14 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					);
 
 					// creaseIndices
-					properties.push_back( UsdGeomTokens->creaseIndices );
-					addProperty( primPath, UsdGeomTokens->creaseIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
+					addProperty( properties, primPath, UsdGeomTokens->creaseIndices, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
 
 					// creaseLengths
-					properties.push_back( UsdGeomTokens->creaseLengths );
-					addProperty( primPath, UsdGeomTokens->creaseLengths, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
+					addProperty( properties, primPath, UsdGeomTokens->creaseLengths, SdfValueTypeNames->IntArray, false, SdfVariabilityVarying );
 
 					// creaseSharpness
-					properties.push_back( UsdGeomTokens->creaseSharpnesses );
 					addProperty(
+						properties,
 						primPath,
 						UsdGeomTokens->creaseSharpnesses,
 						SdfValueTypeNames->FloatArray,
@@ -497,16 +487,14 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					typeName = g_curves;
 
 					// curve type
-					properties.push_back( UsdGeomTokens->type );
-					addProperty( primPath, UsdGeomTokens->type, SdfValueTypeNames->Token, false, SdfVariabilityVarying, &UsdGeomTokens->linear, false );
+					addProperty( properties, primPath, UsdGeomTokens->type, SdfValueTypeNames->Token, false, SdfVariabilityVarying, &UsdGeomTokens->linear, false );
 
 					// curve basis
-					properties.push_back( UsdGeomTokens->basis );
-					addProperty( primPath, UsdGeomTokens->basis, SdfValueTypeNames->Token, false, SdfVariabilityVarying );
+					addProperty( properties, primPath, UsdGeomTokens->basis, SdfValueTypeNames->Token, false, SdfVariabilityVarying );
 
 					// curve wrap
-					properties.push_back( UsdGeomTokens->wrap );
 					addProperty(
+						properties,
 						primPath,
 						UsdGeomTokens->wrap,
 						SdfValueTypeNames->Token,
@@ -517,8 +505,8 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 					);
 
 					// verticesPerCurve
-					properties.push_back( UsdGeomTokens->curveVertexCounts );
 					addProperty(
+						properties,
 						primPath,
 						UsdGeomTokens->curveVertexCounts,
 						SdfValueTypeNames->IntArray,
@@ -531,8 +519,8 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 				loadPrimVars( currentPath, properties, typeName );
 
 				// orientation
-				properties.push_back( UsdGeomTokens->orientation );
 				addProperty(
+					properties,
 					primPath,
 					UsdGeomTokens->orientation,
 					SdfValueTypeNames->Token,
@@ -626,7 +614,6 @@ void SceneCacheData::loadAttributes( const SceneInterface::Path& currentPath, Tf
 
 			// find the usd type corresponding to our cortex one
 			SdfValueTypeName usdType;
-			TfToken attributeName = AttributeAlgo::toUSD( attr );
 
 			auto object = Object::create( dataTypeValue );
 			if( auto data = runTimeCast<Data>( object.get() ) )
@@ -651,9 +638,8 @@ void SceneCacheData::loadAttributes( const SceneInterface::Path& currentPath, Tf
 				continue;
 			}
 			
-			properties.push_back( attributeName );
-
 			addProperty(
+				properties,
 				primPath,
 				TfToken( attr ),
 				usdType,
@@ -791,9 +777,9 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 					continue;
 				}
 			}
-			properties.push_back( primVarName );
 
 			addProperty(
+				properties,
 				primPath,
 				primVarName,
 				usdType,
@@ -810,9 +796,9 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 			if( variableIO && variableIO->hasEntry( g_ioIndices ) )
 			{
 				TfToken primVarIndicesName = TfToken( boost::str( boost::format( "%s:indices" ) % primVarName ) );
-				properties.push_back( primVarIndicesName );
 
 				addProperty(
+					properties,
 					primPath,
 					primVarIndicesName,
 					SdfValueTypeNames->IntArray,
@@ -891,6 +877,7 @@ void SceneCacheData::addIncludeRelationship(
 }
 
 void SceneCacheData::addProperty(
+	TfTokenVector& properties,
 	const SdfPath& primPath,
 	const TfToken& attributeName,
 	const SdfValueTypeName& typeName,
@@ -907,10 +894,13 @@ void SceneCacheData::addProperty(
 	SdfPath attributePath;
 	if ( isCortexAttribute )
 	{
-		attributePath = primPath.AppendProperty( AttributeAlgo::toUSD( attributeName.GetString() ) );
+		TfToken usdName = AttributeAlgo::toUSD( attributeName.GetString() );
+		properties.push_back( usdName );
+		attributePath = primPath.AppendProperty( usdName );
 	}
 	else
 	{
+		properties.push_back( attributeName );
 		attributePath = primPath.AppendProperty( attributeName );
 	}
 
@@ -1118,8 +1108,8 @@ void SceneCacheData::addCollections( SpecData& spec, TfTokenVector& properties, 
 
 		// expansion rule
 		TfToken expansionRuleName( boost::str( boost::format( "collection:%s:%s" ) % safeCollectionName % UsdTokens->expansionRule.GetString() ) );
-		properties.push_back( expansionRuleName );
 		addProperty(
+			properties,
 			primPath,
 			expansionRuleName,
 			SdfValueTypeNames->Token,

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -693,7 +693,6 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 	{
 		IndexedIO::EntryIDList variableLists;
 		variables->entryIds( variableLists );
-		bool custom;
 		for( auto& var: variableLists )
 		{
 			auto it = find( g_defaultPrimVars.cbegin(), g_defaultPrimVars.cend(), var.value() );
@@ -737,7 +736,6 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 			// find the usd type corresponding to our cortex one
 			SdfValueTypeName usdType;
 			TfToken primVarName;
-			custom = false;
 			if ( var == g_pointPrimVar )
 			{
 				primVarName = UsdGeomTokens->points;
@@ -751,19 +749,13 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 			else if ( var == g_widthPrimVar )
 			{
 				primVarName = UsdGeomTokens->widths;
-				if ( PrimTypeName == g_mesh )
-				{
-					custom = true;
-				}
 			}
 			else if ( var == UsdGeomTokens->accelerations.GetText() && PrimTypeName == g_points )
 			{
-				custom = false;
 				usdType = SdfValueTypeNames->Vector3fArray;
 			}
 			else if ( var == UsdGeomTokens->velocities.GetText() && PrimTypeName == g_points )
 			{
-				custom = false;
 				usdType = SdfValueTypeNames->Vector3fArray;
 			}
 			else if ( var == g_uvPrimVar )
@@ -777,7 +769,6 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 			}
 			else
 			{
-				custom = true;
 				primVarName = TfToken( boost::str( boost::format( "primvars:%s" ) % var ) );
 				auto object = Object::create( dataTypeValue );
 				if( auto data = runTimeCast<Data>( object.get() ) )
@@ -806,7 +797,8 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 				primPath,
 				primVarName,
 				usdType,
-				custom,
+				false, // As far as I can tell from USD documentation and examples, "custom" means "not matching
+				       // any schema".  There is a schema for primvars, therefore no primvars are custom
 				SdfVariabilityVarying,
 				/*default value=*/nullptr,
 				/* default value is array=*/false,
@@ -824,7 +816,7 @@ void SceneCacheData::loadPrimVars( const SceneInterface::Path& currentPath, TfTo
 					primPath,
 					primVarIndicesName,
 					SdfValueTypeNames->IntArray,
-					custom,
+					false, // Indices are definitely part of the primvar schema, not a custom attribute
 					SdfVariabilityVarying,
 					/*default value=*/nullptr,
 					/*default value is array=*/false,

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
@@ -129,6 +129,7 @@ private:
 	void loadAttributes(const IECoreScene::SceneInterface::Path& currentPath, TfTokenVector& properties, TfToken& PrimTypeName);
 
 	void addProperty(
+		TfTokenVector& properties,
 		const SdfPath& primPath,
 		const TfToken& attributeName,
 		const SdfValueTypeName& typeName,

--- a/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
@@ -1,0 +1,244 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2021, Image Engine Design. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "IECoreUSD/ShaderAlgo.h"
+
+#include "IECoreUSD/DataAlgo.h"
+
+#include "IECore/MessageHandler.h"
+
+#include "boost/algorithm/string/replace.hpp"
+
+namespace
+{
+
+	IECore::InternedString readShaderNetworkWalk( const pxr::SdfPath &anchorPath, const pxr::UsdShadeShader &usdShader, IECoreScene::ShaderNetwork &shaderNetwork )
+	{
+		IECore::InternedString handle( usdShader.GetPath().MakeRelativePath( anchorPath ).GetAsString() );
+
+		if( shaderNetwork.getShader( handle ) )
+		{
+			return handle;
+		}
+
+		IECoreScene::ShaderPtr r = new IECoreScene::Shader();
+
+		pxr::TfToken id;
+		if( usdShader.GetShaderId( &id ) )
+		{
+			std::string name = id.GetString();
+			size_t colonPos = name.find( ":" );
+			if( colonPos != std::string::npos )
+			{
+				std::string prefix = name.substr( 0, colonPos );
+				name = name.substr( colonPos + 1 );
+				if( prefix == "arnold" )
+				{
+					prefix = "ai";
+				}
+				r->setType( prefix + ":shader" );
+			}
+			r->setName( name );
+		}
+
+		std::vector< std::tuple< IECore::InternedString, pxr::UsdShadeConnectableAPI, IECore::InternedString > > connections;
+		std::vector< pxr::UsdShadeInput > inputs = usdShader.GetInputs();
+		for( pxr::UsdShadeInput &i : usdShader.GetInputs() )
+		{
+			pxr::UsdShadeConnectableAPI usdSource;
+			pxr::TfToken usdSourceName;
+			pxr::UsdShadeAttributeType usdSourceType;
+
+			if( IECore::DataPtr d = IECoreUSD::DataAlgo::fromUSD( pxr::UsdAttribute( i ) ) )
+			{
+				r->parameters()[ i.GetBaseName().GetString() ] = d;
+			}
+
+			if( i.GetConnectedSource( &usdSource, &usdSourceName, &usdSourceType ) )
+			{
+				connections.push_back( { i.GetBaseName().GetString(), usdSource, usdSourceName.GetString() } );
+			}
+		}
+
+		shaderNetwork.addShader( handle, std::move( r ) );
+
+		for( const auto &c : connections )
+		{
+			IECore::InternedString attributeName;
+			pxr::UsdShadeConnectableAPI usdSource;
+			IECore::InternedString sourceAttributeName;
+			std::tie( attributeName, usdSource, sourceAttributeName ) = c;
+			IECore::InternedString sourceHandle = readShaderNetworkWalk( anchorPath, pxr::UsdShadeShader( usdSource.GetPrim() ), shaderNetwork );
+
+			if( sourceAttributeName == "DEFAULT_OUTPUT" )
+			{
+				shaderNetwork.addConnection( IECoreScene::ShaderNetwork::Connection(
+						{ sourceHandle, "" },
+						{ handle, attributeName }
+				) );
+			}
+			else
+			{
+				shaderNetwork.addConnection( IECoreScene::ShaderNetwork::Connection(
+						{ sourceHandle, sourceAttributeName },
+						{ handle, attributeName }
+				) );
+			}
+		}
+
+		return handle;
+	}
+
+} // namespace
+
+pxr::UsdShadeOutput IECoreUSD::ShaderAlgo::writeShaderNetwork( const IECoreScene::ShaderNetwork *shaderNetwork, pxr::UsdPrim shaderContainer )
+{
+	IECoreScene::ShaderNetwork::Parameter networkOutput = shaderNetwork->getOutput();
+	if( networkOutput.shader.string() == "" )
+	{
+		// This could theoretically happen, but a shader network with no output is not useful in any way
+		IECore::msg(
+			IECore::Msg::Warning, "IECoreUSD::ShaderAlgo::writeShaderNetwork",
+			"No output shader in network"
+		);
+	}
+
+	pxr::UsdShadeOutput networkOutUsd;
+	for( const auto &shader : shaderNetwork->shaders() )
+	{
+		pxr::SdfPath usdShaderPath = shaderContainer.GetPath().AppendChild( pxr::TfToken( pxr::TfMakeValidIdentifier( shader.first.string() ) ) );
+		pxr::UsdShadeShader usdShader = pxr::UsdShadeShader::Define( shaderContainer.GetStage(), usdShaderPath );
+		if( !usdShader )
+		{
+			throw IECore::Exception( "Could not create shader at: " + shaderContainer.GetPath().GetString() + " / " + shader.first.string() );
+		}
+		std::string type = shader.second->getType();
+		std::string typePrefix;
+		size_t typeColonPos = type.find( ":" );
+		if( typeColonPos != std::string::npos )
+		{
+			typePrefix = type.substr( 0, typeColonPos ) + ":";
+			if( typePrefix == "ai:" )
+			{
+				typePrefix = "arnold:";
+			}
+		}
+		usdShader.SetShaderId( pxr::TfToken( typePrefix + shader.second->getName() ) );
+
+
+		for( const auto &p : shader.second->parameters() )
+		{
+			pxr::UsdShadeInput input = usdShader.CreateInput(
+				pxr::TfToken( p.first.string() ),
+				DataAlgo::valueTypeName( p.second.get() )
+			);
+			input.Set( DataAlgo::toUSD( p.second.get() ) );
+		}
+
+		if( networkOutput.shader == shader.first )
+		{
+			pxr::TfToken outName( networkOutput.name.string() );
+			if( outName.GetString().size() == 0 )
+			{
+				outName = pxr::TfToken( "DEFAULT_OUTPUT" );
+			}
+
+			// \todo - we should probably be correctly tracking the output type if it is typed?
+			// Currently, we don't really track output types in Gaffer.
+			networkOutUsd = usdShader.CreateOutput( outName, pxr::SdfValueTypeNames->Token );
+		}
+
+	}
+
+	for( const auto &shader : shaderNetwork->shaders() )
+	{
+		pxr::UsdShadeShader usdShader = pxr::UsdShadeShader::Get( shaderContainer.GetStage(), shaderContainer.GetPath().AppendChild( pxr::TfToken( pxr::TfMakeValidIdentifier( shader.first.string() ) ) ) );
+		for( const auto &c : shaderNetwork->inputConnections( shader.first ) )
+		{
+			pxr::UsdShadeInput dest = usdShader.GetInput( pxr::TfToken( c.destination.name.string() ) );
+			if( ! dest.GetPrim().IsValid() )
+			{
+				dest = usdShader.CreateInput( pxr::TfToken( c.destination.name.string() ), pxr::SdfValueTypeNames->Token );
+			}
+
+			pxr::UsdShadeShader sourceUsdShader = pxr::UsdShadeShader::Get( shaderContainer.GetStage(), shaderContainer.GetPath().AppendChild( pxr::TfToken( pxr::TfMakeValidIdentifier( c.source.shader.string() ) ) ) );
+			std::string sourceOutputName = c.source.name.string();
+			if( sourceOutputName.size() == 0 )
+			{
+				sourceOutputName = "DEFAULT_OUTPUT";
+			}
+			pxr::UsdShadeOutput source = sourceUsdShader.CreateOutput( pxr::TfToken( sourceOutputName ), dest.GetTypeName() );
+			dest.ConnectToSource( source );
+		}
+
+	}
+
+	return networkOutUsd;
+}
+
+IECoreScene::ShaderNetworkPtr IECoreUSD::ShaderAlgo::readShaderNetwork( const pxr::SdfPath &anchorPath, const pxr::UsdShadeShader &outputShader, const pxr::TfToken &outputParameter )
+{
+	IECoreScene::ShaderNetworkPtr result = new IECoreScene::ShaderNetwork();
+	IECore::InternedString outputHandle = readShaderNetworkWalk( anchorPath, outputShader, *result );
+
+	// For the output shader, set the type to "ai:surface" if it is "ai:shader".
+	// This is complete nonsense - there is nothing to suggest that this shader is
+	// of type surface - it could be a simple texture or noise, or even a
+	// displacement or volume shader.
+	//
+	// But arbitrarily setting the type on the output to "ai:surface" matches our
+	// current Gaffer convention, so it allows round-tripping.
+	// In the long run, the fact this is working at all appears to indicate that we
+	// don't use the suffix of the shader type for anything, and we should just set
+	// everything to prefix:shader ( aside from lights, which are a bit of a
+	// different question )
+	if( result->getShader( outputHandle )->getType() == "ai:shader" )
+	{
+		IECoreScene::ShaderPtr o = result->getShader( outputHandle )->copy();
+		o->setType( "ai:surface" );
+		result->setShader( outputHandle, std::move( o ) );
+	}
+
+	// handles[0] is the handle of the first shader added, which is always the output shader
+	if( outputParameter.GetString() != "DEFAULT_OUTPUT" )
+	{
+		result->setOutput( IECoreScene::ShaderNetwork::Parameter( outputHandle, outputParameter.GetString() ) );
+	}
+	else
+	{
+		result->setOutput( IECoreScene::ShaderNetwork::Parameter( outputHandle ) );
+	}
+
+	return result;
+}

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -820,6 +820,27 @@ void USDScene::writeAttribute( const SceneInterface::Name &name, const Object *a
 			}
 		}
 	}
+	else if( name.string() == "gaffer:globals" )
+	{
+		// This is some very preliminary support for globals - we just support Arnold options, and don't read
+		// them yet.  But this is already enough to test out some stuff with reading Gaffer's USD's in Arnold
+		if( const IECore::CompoundObject *globals = runTimeCast<const CompoundObject>( attribute ) )
+		{
+			for( const auto &g : globals->members() )
+			{
+				const IECore::Data *d = IECore::runTimeCast<const Data>( g.second.get() );
+				if( d && boost::algorithm::starts_with( g.first.string(), "option:ai:" ) )
+				{
+					pxr::UsdPrim options = m_root->getStage()->DefinePrim( pxr::SdfPath( "/options" ), pxr::TfToken( "ArnoldOptions" ) );
+					pxr::UsdAttribute attribute = options.CreateAttribute(
+						pxr::TfToken( g.first.string().substr( 10 ) ),
+						DataAlgo::valueTypeName( d )
+					);
+					attribute.Set( DataAlgo::toUSD( d ) );
+				}
+			}
+		}
+	}
 	else if( name.string().find( ':' ) != std::string::npos )
 	{
 		if( const Data *data = runTimeCast<const Data>( attribute ) )

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -38,6 +38,7 @@
 #include "TypeIds.h"
 
 #include "IECoreScene/SceneInterface.h"
+#include "IECoreScene/ShaderNetwork.h"
 
 #include "IECore/PathMatcherData.h"
 
@@ -113,6 +114,8 @@ class USDScene : public IECoreScene::SceneInterface
 
 		IOPtr m_root;
 		LocationPtr m_location;
+
+		std::map< const IECore::InternedString, IECoreScene::ConstShaderNetworkPtr > m_shaders;
 };
 
 IE_CORE_DECLAREPTR( USDScene )

--- a/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
@@ -535,8 +535,8 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		prim = root.GetPrimAtPath( "{}/box".format( IECoreUSD.SceneCacheDataAlgo.internalRootName() ) )
 
 		customPoint = prim.GetAttribute( "primvars:customPoint" )
-		# custom
-		self.assertTrue( customPoint.GetMetadata( "custom" ) )
+		# All primvars match the primvar schema, and therefore are not custom
+		self.assertFalse( customPoint.GetMetadata( "custom" ) )
 
 		# type
 		self.assertEqual( customPoint.GetMetadata( "typeName" ), pxr.Sdf.ValueTypeNames.Point3fArray )
@@ -1194,7 +1194,8 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 
 		self.assertTrue( attribute.GetMetadata( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" ) )
 		self.assertEqual( attribute.GetMetadata( "interpolation" ), "constant" )
-		self.assertTrue( attribute.GetMetadata( "custom" ) )
+		# All primvars match the primvar schema, and therefore are not custom
+		self.assertFalse( attribute.GetMetadata( "custom" ) )
 
 		# round trip
 		exportPath = "{}/testUSDExportCustomAttribute.scc".format( self.temporaryDirectory() )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2526,6 +2526,297 @@ class USDSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( set( root.child( "loc" ).attributeNames() ), set( ['ai:testAttribute' ] ) )
 		self.assertEqual( root.child( "loc" ).readAttribute( 'ai:testAttribute', 0 ), IECore.FloatData( 9 ) )
-		
+
+	def testShaders( self ) :
+
+		# Write shaders
+
+		fileName = os.path.join( self.temporaryDirectory(), "shaders.usda" )
+
+		surface = IECoreScene.Shader( "standardsurface", "ai:surface" )
+		surface.parameters["a"] = IECore.FloatData( 42.0 )
+		surface.parameters["b"] = IECore.IntData( 42 )
+		surface.parameters["c"] = IECore.StringData( "42" )
+		surface.parameters["d"] = IECore.Color3fData( imath.Color3f( 3 ) )
+		surface.parameters["e"] = IECore.V3fVectorData( [ imath.V3f( 7 ) ] )
+
+		add1 = IECoreScene.Shader( "add", "ai:shader" )
+		add1.parameters["b"] = IECore.FloatData( 3.0 )
+
+		add2 = IECoreScene.Shader( "add", "osl:shader" )
+		add2.parameters["b"] = IECore.FloatData( 7.0 )
+
+		texture = IECoreScene.Shader( "texture", "ai:shader" )
+		texture.parameters["filename"] = IECore.StringData( "sometexture.tx" )
+
+		oneShaderNetwork = IECoreScene.ShaderNetwork()
+		oneShaderNetwork.addShader( "foo", surface )
+		oneShaderNetwork.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "" ) )
+
+		# A network with no output can be written out, but it will read back in as empty
+		noOutputNetwork = IECoreScene.ShaderNetwork()
+		noOutputNetwork.addShader( "foo", surface )
+
+		# Test picking a specific output
+		pickOutputNetwork = IECoreScene.ShaderNetwork()
+		pickOutputNetwork.addShader( "foo", surface )
+		pickOutputNetwork.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "test" ) )
+
+		# A more complicated example.  Try some different kinds of connections, and make sure that we only
+		# output one shader when it's referenced multiple times
+		complexNetwork = IECoreScene.ShaderNetwork()
+		complexNetwork.addShader( "foo", surface )
+		complexNetwork.addShader( "add1", add1 )
+		complexNetwork.addShader( "add2", add2 )
+		complexNetwork.addShader( "texture", texture )
+		complexNetwork.addConnection( IECoreScene.ShaderNetwork.Connection(
+			IECoreScene.ShaderNetwork.Parameter( "add1", "" ),
+			IECoreScene.ShaderNetwork.Parameter( "foo", "a" )
+		) )
+		complexNetwork.addConnection( IECoreScene.ShaderNetwork.Connection(
+			IECoreScene.ShaderNetwork.Parameter( "add2", "sum" ),
+			IECoreScene.ShaderNetwork.Parameter( "foo", "new" )
+		) )
+		complexNetwork.addConnection( IECoreScene.ShaderNetwork.Connection(
+			IECoreScene.ShaderNetwork.Parameter( "texture", "" ),
+			IECoreScene.ShaderNetwork.Parameter( "add1", "a" )
+		) )
+		complexNetwork.addConnection( IECoreScene.ShaderNetwork.Connection(
+			IECoreScene.ShaderNetwork.Parameter( "texture", "" ),
+			IECoreScene.ShaderNetwork.Parameter( "add2", "a" )
+		) )
+		complexNetwork.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "" ) )
+
+		writerRoot = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		shaderLocation = writerRoot.createChild( "shaderLocation" )
+		shaderLocation.writeAttribute( "ai:surface", oneShaderNetwork, 0 )
+		shaderLocation.writeAttribute( "ai:disp_map", pickOutputNetwork, 0 )
+		shaderLocation.writeAttribute( "testBad:surface", noOutputNetwork, 0 )
+		shaderLocation.writeAttribute( "complex:surface", complexNetwork, 0 )
+
+		shaderLocation.writeAttribute( "volume", oneShaderNetwork, 0 ) # USD supports shaders without a prefix
+
+		# A shader type that doesn't correspond to anything in USD won't be written out,
+		# but make sure it doesn't crash anything
+		shaderLocation.writeAttribute( "testBad:badShaderType", oneShaderNetwork, 0 )
+
+		del writerRoot, shaderLocation
+
+		# Read via USD API
+
+		stage = pxr.Usd.Stage.Open( fileName )
+
+		mat = pxr.UsdShade.MaterialBindingAPI.ComputeBoundMaterials( [ stage.GetPrimAtPath( "/shaderLocation" ) ] )[0][0]
+
+		oneShaderSource = mat.GetOutput( "arnold:surface" ).GetConnectedSource()
+		self.assertEqual( oneShaderSource[1], "DEFAULT_OUTPUT" )
+		oneShaderUsd = pxr.UsdShade.Shader( oneShaderSource[0].GetPrim() )
+		self.assertEqual( oneShaderUsd.GetShaderId(), "arnold:standardsurface" )
+		self.assertEqual( oneShaderUsd.GetInput( "a" ).Get(), 42.0 )
+		self.assertEqual( oneShaderUsd.GetInput( "b" ).Get(), 42 )
+		self.assertEqual( oneShaderUsd.GetInput( "c" ).Get(), "42" )
+		self.assertEqual( oneShaderUsd.GetInput( "d" ).Get(), pxr.Gf.Vec3f( 3 ) )
+		self.assertEqual( oneShaderUsd.GetInput( "e" ).Get(), pxr.Vt.Vec3fArray( [ pxr.Gf.Vec3f( 7 ) ] ) )
+
+		pickOutputSource = mat.GetOutput( "arnold:displacement" ).GetConnectedSource()
+		self.assertEqual( pickOutputSource[1], "test" )
+		pickOutputUsd = pxr.UsdShade.Shader( pickOutputSource[0].GetPrim() )
+		self.assertEqual( pickOutputUsd.GetShaderId(), "arnold:standardsurface" )
+		self.assertEqual( pickOutputUsd.GetInput( "c" ).Get(), "42" )
+
+		self.assertEqual( mat.GetOutput( "testBad:surface" ).GetConnectedSource(), None )
+
+		complexShaderSource = mat.GetOutput( "complex:surface" ).GetConnectedSource()
+		self.assertEqual( complexShaderSource[1], "DEFAULT_OUTPUT" )
+		complexShaderUsd = pxr.UsdShade.Shader( complexShaderSource[0].GetPrim() )
+		self.assertEqual( complexShaderUsd.GetShaderId(), "arnold:standardsurface" )
+		self.assertEqual( complexShaderUsd.GetInput( "c" ).Get(), "42" )
+		self.assertEqual( complexShaderUsd.GetInput( "a" ).Get(), 42.0 )
+
+		aSource = complexShaderUsd.GetInput( "a" ).GetConnectedSource()
+		self.assertEqual( aSource[1], "DEFAULT_OUTPUT" )
+		add1Usd = pxr.UsdShade.Shader( aSource[0].GetPrim() )
+		self.assertEqual( add1Usd.GetShaderId(), "arnold:add" )
+		self.assertEqual( add1Usd.GetInput( "b" ).Get(), 3.0 )
+
+		newSource = complexShaderUsd.GetInput( "new" ).GetConnectedSource()
+		self.assertEqual( newSource[1], "sum" )
+		add2Usd = pxr.UsdShade.Shader( newSource[0].GetPrim() )
+		self.assertEqual( add2Usd.GetShaderId(), "osl:add" )
+		self.assertEqual( add2Usd.GetInput( "b" ).Get(), 7.0 )
+
+		add1Source = add1Usd.GetInput( "a" ).GetConnectedSource()
+		add2Source = add2Usd.GetInput( "a" ).GetConnectedSource()
+
+		self.assertEqual( add1Source[0].GetPrim(), add2Source[0].GetPrim() )
+		self.assertEqual( add1Source[1], "DEFAULT_OUTPUT" )
+		textureUsd = pxr.UsdShade.Shader( add1Source[0].GetPrim() )
+		self.assertEqual( textureUsd.GetShaderId(), "arnold:texture" )
+		self.assertEqual( textureUsd.GetInput( "filename" ).Get(), "sometexture.tx" )
+
+
+		# Read via SceneInterface, and check that we've round-tripped successfully.
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( set( root.child( "shaderLocation" ).attributeNames() ), set( ['ai:disp_map', 'ai:surface', 'complex:surface', 'testBad:surface', 'volume' ] ) )
+
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:surface", 0 ), oneShaderNetwork )
+		self.assertTrue( root.child( "shaderLocation" ).hasAttribute( "testBad:surface" ) )
+
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "testBad:surface", 0 ), IECoreScene.ShaderNetwork() )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:disp_map", 0 ), pickOutputNetwork )
+		self.assertEqual( root.child( "shaderLocation" ).hasAttribute( "ai:volume" ), False )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "volume", 0 ), oneShaderNetwork )
+		self.assertEqual( root.child( "shaderLocation" ).hasAttribute( "volume" ), True )
+		self.assertEqual( root.child( "shaderLocation" ).hasAttribute( "surface" ), False )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "surface", 0 ), None )
+		self.assertEqual( root.child( "shaderLocation" ).hasAttribute( "displacement" ), False )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "displacement", 0 ), None )
+
+		# Reading a shader type that we didn't write
+		self.assertFalse( root.child( "shaderLocation" ).hasAttribute( "ai:volume" ) )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:volume", 0 ), None )
+
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "complex:surface", 0 ), complexNetwork )
+
+	def testManyShaders( self ) :
+
+		# Write shaders
+
+		fileName = os.path.join( self.temporaryDirectory(), "manyShaders.usda" )
+
+		surfaceA = IECoreScene.Shader( "standardsurface", "ai:surface" )
+		surfaceA.parameters["a"] = IECore.FloatData( 42.0 )
+
+		surfaceB = IECoreScene.Shader( "standardsurface", "ai:surface" )
+		surfaceB.parameters["a"] = IECore.FloatData( 43.0 )
+
+		texture = IECoreScene.Shader( "texture", "ai:shader" )
+
+		networkA = IECoreScene.ShaderNetwork()
+		networkA.addShader( "foo", surfaceA )
+		networkA.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "" ) )
+
+		networkB = IECoreScene.ShaderNetwork()
+		networkB.addShader( "foo", surfaceB )
+		networkB.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "" ) )
+
+		networkDisp = IECoreScene.ShaderNetwork()
+		networkDisp.addShader( "foo", texture )
+		networkDisp.setOutput( IECoreScene.ShaderNetwork.Parameter( "foo", "" ) )
+
+		writerRoot = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		topLevel = writerRoot.createChild( "topLevel" )
+
+		for i in range( 20 ):
+			shaderLocation = topLevel.createChild( "shaderLocation%i" % i )
+			if i >= 10:
+				shaderLocation.writeAttribute( "surface", networkB, 0 )
+			else:
+				shaderLocation.writeAttribute( "surface", networkA, 0 )
+
+			if i == 9 or i == 18 or i == 19:
+				shaderLocation.writeAttribute( "displacement", networkDisp, 0 )
+
+			del shaderLocation
+
+		del topLevel, writerRoot
+
+		# Read via USD API
+
+		stage = pxr.Usd.Stage.Open( fileName )
+
+		materials = [ pxr.UsdShade.MaterialBindingAPI.ComputeBoundMaterials( [ stage.GetPrimAtPath( "/topLevel/shaderLocation%i" % i ) ] )[0][0] for i in range( 20 ) ]
+
+		m1 = materials[0]
+		m2 = materials[9]
+		m3 = materials[10]
+		m4 = materials[18]
+		self.assertEqual(
+			[ i.GetPrim() for i in materials ],
+			[ i.GetPrim() for i in
+				[ m1, m1, m1, m1, m1, m1, m1, m1, m1, m2, m3, m3, m3, m3, m3, m3, m3, m3, m4, m4 ]
+			]
+		)
+
+		for m in [ m1, m2, m3, m4 ]:
+			o = set( [i.GetName() for i in m.GetPrim().GetAuthoredAttributes() ] )
+			if m == m1 or m == m3:
+				self.assertEqual( o, set( ["outputs:surface"] ) )
+			else:
+				self.assertEqual( o, set( ["outputs:surface", "outputs:displacement"] ) )
+
+		m1Source = m1.GetOutput( "surface" ).GetConnectedSource()
+		self.assertEqual( pxr.UsdShade.Shader( m1Source[0].GetPrim() ).GetInput( "a" ).Get(), 42.0 )
+		m2Source = m2.GetOutput( "surface" ).GetConnectedSource()
+		self.assertEqual( pxr.UsdShade.Shader( m2Source[0].GetPrim() ).GetInput( "a" ).Get(), 42.0 )
+		m3Source = m3.GetOutput( "surface" ).GetConnectedSource()
+		self.assertEqual( pxr.UsdShade.Shader( m3Source[0].GetPrim() ).GetInput( "a" ).Get(), 43.0 )
+		m4Source = m4.GetOutput( "surface" ).GetConnectedSource()
+		self.assertEqual( pxr.UsdShade.Shader( m4Source[0].GetPrim() ).GetInput( "a" ).Get(), 43.0 )
+
+		# Read via SceneInterface, and check that we've round-tripped successfully.
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		topLevel = root.child( "topLevel" )
+
+		for i in range( 20 ):
+			a = set( topLevel.child( "shaderLocation%i" % i ).attributeNames() )
+			if i == 9 or i == 18 or i == 19:
+				self.assertEqual( a, set( ['surface', 'displacement'] ) )
+			else:
+				self.assertEqual( a, set( ['surface' ] ) )
+
+			p = topLevel.child( "shaderLocation%i" % i ).readAttribute( "surface", 0 ).outputShader().parameters["a"]
+			self.assertEqual( p, IECore.FloatData( 43.0 if i >= 10 else 42.0 ) )
+
+	def testShaderNameConflict( self ):
+		root = IECoreScene.SceneInterface.create( os.path.dirname( __file__ ) + "/data/shaderNameConflict.usda", IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( set( root.child( "shaderLocation" ).attributeNames() ), set( ['ai:surface' ] ) )
+
+		# The attribute "arnold:surface" has won out over the actual surface shader.  This behaviour is probably
+		# unimportant, since it should never happen, but it feels worth having a test for
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:surface", 0 ), IECore.FloatData( 7 ) )
+
+	def testShadersAcrossDifferentScopes( self ):
+		# This test case serves to test two different things:
+		# A) Shaders with connections to shaders within scopes
+		# B) Shaders with connections to shaders outside their scope
+		# Case A is definitely valid.  It's unclear if Case B can actually occur, but we should probably do
+		# something reasonable here anyway
+		root = IECoreScene.SceneInterface.create( os.path.dirname( __file__ ) + "/data/shaderParentLoc.usda", IECore.IndexedIO.OpenMode.Read )
+
+		self.assertEqual( set( root.child( "shaderLocation" ).attributeNames() ), set( ['surface' ] ) )
+		shaderFoo = IECoreScene.Shader( "standardsurface", "ai:surface" )
+		shaderFoo.parameters["a"] = IECore.FloatData( 42 )
+		shaderBar = IECoreScene.Shader( "image", "ai:shader" )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "surface", 0 ).getShader( "foo" ), shaderFoo )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "surface", 0 ).getShader( "../scopeB/bar" ), shaderBar )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "surface", 0 ).inputConnections( "foo" ),
+			[ IECoreScene.ShaderNetwork.Connection(
+					IECoreScene.ShaderNetwork.Parameter( "../scopeB/bar", "" ),
+					IECoreScene.ShaderNetwork.Parameter( "foo", "b" )
+			) ]
+		)
+
+		rewriteFileName = os.path.join( self.temporaryDirectory(), "shaders.usda" )
+		writerRoot = IECoreScene.SceneInterface.create( rewriteFileName, IECore.IndexedIO.OpenMode.Write )
+		writeLocation = writerRoot.createChild( "shaderLocation" )
+		writeLocation.writeAttribute( "surface", root.child( "shaderLocation" ).readAttribute( "surface", 0 ), 0 )
+
+		del writerRoot, writeLocation
+
+		rereadRoot = IECoreScene.SceneInterface.create( rewriteFileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( rereadRoot.child( "shaderLocation" ).readAttribute( "surface", 0 ).getShader( "foo" ), shaderFoo )
+		self.assertEqual( rereadRoot.child( "shaderLocation" ).readAttribute( "surface", 0 ).getShader( "___scopeB_bar" ), shaderBar )
+		self.assertEqual( rereadRoot.child( "shaderLocation" ).readAttribute( "surface", 0 ).inputConnections( "foo" ),
+			[ IECoreScene.ShaderNetwork.Connection(
+					IECoreScene.ShaderNetwork.Parameter( "___scopeB_bar", "" ),
+					IECoreScene.ShaderNetwork.Parameter( "foo", "b" )
+			) ]
+		)
+
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/data/attributeBadPrefix.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/attributeBadPrefix.usda
@@ -1,0 +1,6 @@
+#usda 1.0
+def Xform "loc"
+{
+    custom float ai:foo = 7
+}
+

--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -29,6 +29,11 @@ def Xform "a"
 		)
 		string primvars:user:baz = "white"
 		string primvars:notUserPrefixAttribute = "orange"
+		float[] primvars:withIndices = [ 1, 2, 3 ] (
+			interpolation = "vertex"
+		)
+		int[] primvars:withIndices:indices = [1]
+
 		def Sphere "c"
 		{
 		}

--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -18,6 +18,8 @@ def Sphere "sphere"
 	string primvars:user:notAConstantPrimVar = "pink"(
 		IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = false
 	)
+	float primvars:arnold:disp_height = 0.5
+	int primvars:arnold:poly_mesh:subdiv_iterations = 3
 }
 def Xform "a"
 {

--- a/contrib/IECoreUSD/test/IECoreUSD/data/shaderNameConflict.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/shaderNameConflict.usda
@@ -1,0 +1,26 @@
+#usda 1.0
+
+def Xform "shaderLocation"
+{
+    rel material:binding = </shaderLocation/materials/testMat>
+    custom float arnold:surface = 7
+
+    def Scope "materials"
+    {
+        def Material "testMat"
+        {
+            token outputs:arnold:surface.connect = </shaderLocation/materials/testMat/scopeA/foo.outputs:DEFAULT_OUTPUT>
+
+            def Scope "scopeA"
+            {
+                def Shader "foo"
+                {
+                    uniform token info:id = "arnold:standardsurface"
+                    float inputs:a = 42
+                    token outputs:DEFAULT_OUTPUT
+                }
+            }
+        }
+    }
+}
+

--- a/contrib/IECoreUSD/test/IECoreUSD/data/shaderParentLoc.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/shaderParentLoc.usda
@@ -1,0 +1,35 @@
+#usda 1.0
+
+def Xform "shaderLocation"
+{
+    rel material:binding = </shaderLocation/materials/testMat>
+
+    def Scope "materials"
+    {
+        def Material "testMat"
+        {
+            token outputs:surface.connect = </shaderLocation/materials/testMat/scopeA/foo.outputs:DEFAULT_OUTPUT>
+
+            def Scope "scopeA"
+            {
+                def Shader "foo"
+                {
+                    uniform token info:id = "arnold:standardsurface"
+                    float inputs:a = 42
+                    token inputs:b.connect = </shaderLocation/materials/testMat/scopeB/bar.outputs:DEFAULT_OUTPUT>
+                    token outputs:DEFAULT_OUTPUT
+                }
+            }
+
+            def Scope "scopeB"
+            {
+                def Shader "bar"
+                {
+                    uniform token info:id = "arnold:image"
+                    token outputs:DEFAULT_OUTPUT
+                }
+            }
+        }
+    }
+}
+

--- a/src/IECoreScene/SceneInterface.cpp
+++ b/src/IECoreScene/SceneInterface.cpp
@@ -114,7 +114,7 @@ SceneInterfacePtr SceneInterface::create( const std::string &path, IndexedIO::Op
 	CreatorMap::const_iterator it = createFns.find(key);
 	if (it == createFns.end())
 	{
-		throw IOException(path);
+		throw IOException( path + " : No SceneInterface file handler registered for extension \"" + extension + "\" in mode " + std::to_string( mode ) );
 	}
 
 	return (it->second)(path, mode);


### PR DESCRIPTION
Still needs some more testing, both in test cases, and production testing, but I think the code is about right, so it's probably reasonable to look at this now if you want to.

Next up is to unify this handling of attribute names ( using `attributeNameFromUsd` ) with handling of actual attributes ( using  `AttributeAlgo::toUsd` ).

There are also a few changes currently required to actually use this in Gaffer ( mostly adding a mutex lock to ~LocationWriter, and changing Shader to write parameters for connected parameters, so we can get the type ).

There seem to be lots of tricky details between how Usd works and how Gaffer works, but this does appear to basically allow round-tripping.