### PR TITLE
UsdShade Support for Splines

### DIFF
--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ShaderNetworkAlgo.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ShaderNetworkAlgo.cpp
@@ -89,7 +89,11 @@ renderer::ShaderGroup *convert( const IECoreScene::ShaderNetwork *shaderNetwork 
 				shaderType += 4;
 			}
 
-			asr::ParamArray params( ParameterAlgo::convertShaderParameters( shader->parameters() ) );
+			IECore::ConstCompoundDataPtr expandedParameters = IECoreScene::ShaderNetworkAlgo::expandSplineParameters(
+				shader->parametersData()
+			);
+
+			asr::ParamArray params( ParameterAlgo::convertShaderParameters( expandedParameters->readable() ) );
 			shaderGroup->add_shader( shaderType, shader->getName().c_str(), handle.c_str(), params );
 
 			for( const auto &c : shaderNetwork->inputConnections( handle ) )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2539,6 +2539,12 @@ class USDSceneTest( unittest.TestCase ) :
 		surface.parameters["c"] = IECore.StringData( "42" )
 		surface.parameters["d"] = IECore.Color3fData( imath.Color3f( 3 ) )
 		surface.parameters["e"] = IECore.V3fVectorData( [ imath.V3f( 7 ) ] )
+		surface.parameters["f"] = IECore.SplineffData( IECore.Splineff( IECore.CubicBasisf.bSpline(),
+			( ( 0, 1 ), ( 10, 2 ), ( 20, 0 ), ( 21, 2 ) ) )
+		)
+		surface.parameters["g"] = IECore.SplinefColor3fData( IECore.SplinefColor3f( IECore.CubicBasisf.linear(),
+			( ( 0, imath.Color3f(1) ), ( 10, imath.Color3f(2) ), ( 20, imath.Color3f(0) ) ) )
+		)
 
 		add1 = IECoreScene.Shader( "add", "ai:shader" )
 		add1.parameters["b"] = IECore.FloatData( 3.0 )
@@ -2661,6 +2667,8 @@ class USDSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( set( root.child( "shaderLocation" ).attributeNames() ), set( ['ai:disp_map', 'ai:surface', 'complex:surface', 'testBad:surface', 'volume' ] ) )
 
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:surface", 0 ).outputShader().parameters, oneShaderNetwork.outputShader().parameters )
+		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:surface", 0 ).outputShader(), oneShaderNetwork.outputShader() )
 		self.assertEqual( root.child( "shaderLocation" ).readAttribute( "ai:surface", 0 ), oneShaderNetwork )
 		self.assertTrue( root.child( "shaderLocation" ).hasAttribute( "testBad:surface" ) )
 

--- a/include/IECore/CompoundData.inl
+++ b/include/IECore/CompoundData.inl
@@ -52,8 +52,9 @@ T *CompoundData::member( const InternedString &name, bool throwExceptions )
 template<typename T>
 const T *CompoundData::member( const InternedString &name, bool throwExceptions ) const
 {
-	CompoundDataMap::const_iterator it = readable().find( name );
-	if( it!=readable().end() )
+	const CompoundDataMap &map = readable();
+	CompoundDataMap::const_iterator it = map.find( name );
+	if( it != map.end() )
 	{
 		const T *result = runTimeCast<const T>( it->second.get() );
 		if( result )
@@ -89,8 +90,9 @@ const T *CompoundData::member( const InternedString &name, bool throwExceptions 
 template<typename T>
 T *CompoundData::member( const InternedString &name, bool throwExceptions, bool createIfMissing )
 {
-	CompoundDataMap::const_iterator it = readable().find( name );
-	if( it!=readable().end() )
+	const CompoundDataMap &map = readable();
+	CompoundDataMap::const_iterator it = map.find( name );
+	if( it != map.end() )
 	{
 		T *result = runTimeCast<T>( it->second.get() );
 		if( result )

--- a/include/IECoreScene/Shader.h
+++ b/include/IECoreScene/Shader.h
@@ -48,6 +48,12 @@ class IECORESCENE_API Shader : public StateRenderable
 	public:
 
 		Shader( const std::string &name="defaultsurface", const std::string &type="surface", const IECore::CompoundDataMap &parameters = IECore::CompoundDataMap() );
+
+		// Special constructor if you already have a CompoundData allocated.  We usually don't expect shaders
+		// to share parameter data, so if you use this form you need to be careful about avoiding reuse of this
+		// CompoundData
+		Shader( const std::string &name, const std::string &type, const IECore::CompoundDataPtr &parametersData );
+
 		~Shader() override;
 
 		IE_CORE_DECLAREEXTENSIONOBJECT( Shader, ShaderTypeId, StateRenderable );

--- a/include/IECoreScene/ShaderNetworkAlgo.h
+++ b/include/IECoreScene/ShaderNetworkAlgo.h
@@ -75,6 +75,22 @@ IECORESCENE_API void convertOSLComponentConnections( ShaderNetwork *network, int
 /// Converts from the legacy ObjectVector format previously used to represent shader networks.
 IECORESCENE_API ShaderNetworkPtr convertObjectVector( const IECore::ObjectVector *network );
 
+/// We use a convention where ramps are represented by a single SplineData in Cortex, but must be expanded
+/// out into basic types when being passed to a renderer.  We need two functions to convert back and forth.
+
+/// Look for parameters matching our spline convention, for any possible <prefix> :
+/// <prefix>Positions, a float vector parameter
+/// <prefix>Values, a vector of a value type, such as float or color
+/// <prefix>Basis, a string parameter
+/// For each set of parameters found matching this convention, the 3 parameters will be replaced with one
+/// spline parameter named <prefix>.  If none are found, the input is passed through unchanged.
+IECORESCENE_API IECore::ConstCompoundDataPtr collapseSplineParameters( const IECore::ConstCompoundDataPtr& parameters );
+
+/// Look for spline parameters.  If any are found, they will be expanded out into 3 parameters named
+/// <name>Positions, <name>Values and <name>Basis.  If none are found, the input is passed through unchanged.
+IECORESCENE_API IECore::ConstCompoundDataPtr expandSplineParameters( const IECore::ConstCompoundDataPtr& parameters );
+
+
 } // namespace ShaderNetworkAlgo
 
 } // namespace IECoreScene

--- a/src/IECoreScene/Shader.cpp
+++ b/src/IECoreScene/Shader.cpp
@@ -49,8 +49,13 @@ static IndexedIO::EntryID g_parametersEntry("parameters");
 const unsigned int Shader::m_ioVersion = 0;
 IE_CORE_DEFINEOBJECTTYPEDESCRIPTION( Shader );
 
-Shader::Shader(  const std::string &name, const std::string &type, const CompoundDataMap &parameters )
+Shader::Shader( const std::string &name, const std::string &type, const CompoundDataMap &parameters )
 	: m_name( name ), m_type( type ), m_parameters( new CompoundData( parameters ) )
+{
+}
+
+Shader::Shader( const std::string &name, const std::string &type, const CompoundDataPtr &parameters )
+	: m_name( name ), m_type( type ), m_parameters( parameters )
 {
 }
 

--- a/src/IECoreScene/ShaderNetworkAlgo.cpp
+++ b/src/IECoreScene/ShaderNetworkAlgo.cpp
@@ -37,6 +37,8 @@
 #include "IECoreScene/ShaderNetworkAlgo.h"
 
 #include "IECore/SimpleTypedData.h"
+#include "IECore/SplineData.h"
+#include "IECore/VectorTypedData.h"
 
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/algorithm/string/replace.hpp"
@@ -382,4 +384,229 @@ ShaderNetworkPtr ShaderNetworkAlgo::convertObjectVector( const ObjectVector *net
 	}
 
 	return result;
+}
+
+namespace
+{
+
+template<typename Spline>
+void expandSpline( const InternedString &name, const Spline &spline, CompoundDataMap &newParameters )
+{
+	const char *basis = "catmull-rom";
+	bool duplicateEndPoints = false;
+	if( spline.basis == Spline::Basis::bezier() )
+	{
+		basis = "bezier";
+	}
+	else if( spline.basis == Spline::Basis::bSpline() )
+	{
+		basis = "bspline";
+	}
+	else if( spline.basis == Spline::Basis::linear() )
+	{
+		// OSL discards the first and last segment of linear curves
+		// "To maintain consistency with the other spline types"
+		// so we need to duplicate the end points to preserve all provided segments
+		duplicateEndPoints = true;
+		basis = "linear";
+	}
+
+	typedef TypedData< vector<typename Spline::XType> > XTypedVectorData;
+	typename XTypedVectorData::Ptr positionsData = new XTypedVectorData();
+	auto &positions = positionsData->writable();
+	positions.reserve( spline.points.size() );
+	typedef TypedData< vector<typename Spline::YType> > YTypedVectorData;
+	typename YTypedVectorData::Ptr valuesData = new YTypedVectorData();
+	auto &values = valuesData->writable();
+	values.reserve( spline.points.size() + 2 * duplicateEndPoints );
+
+	if( duplicateEndPoints && spline.points.size() )
+	{
+		positions.push_back( spline.points.begin()->first );
+		values.push_back( spline.points.begin()->second );
+	}
+	for( typename Spline::PointContainer::const_iterator it = spline.points.begin(), eIt = spline.points.end(); it != eIt; ++it )
+	{
+		positions.push_back( it->first );
+		values.push_back( it->second );
+	}
+	if( duplicateEndPoints && spline.points.size() )
+	{
+		positions.push_back( spline.points.rbegin()->first );
+		values.push_back( spline.points.rbegin()->second );
+	}
+
+	newParameters[ name.string() + "Positions" ] = positionsData;
+	newParameters[ name.string() + "Values" ] = valuesData;
+	newParameters[ name.string() + "Basis" ] = new StringData( basis );
+}
+
+template<typename SplineData>
+IECore::DataPtr loadSpline(
+	const StringData *basisData,
+	const IECore::TypedData< std::vector< typename SplineData::ValueType::XType > > *positionsData,
+	const IECore::TypedData< std::vector< typename SplineData::ValueType::YType > > *valuesData
+)
+{
+	typename SplineData::Ptr resultData = new SplineData();
+	auto &result = resultData->writable();
+
+	bool unduplicateEndPoints = false;
+
+	const std::string &basis = basisData->readable();
+	if( basis == "bezier" )
+	{
+		result.basis = SplineData::ValueType::Basis::bezier();
+	}
+	if( basis == "bspline" )
+	{
+		result.basis = SplineData::ValueType::Basis::bSpline();
+	}
+	else if( basis == "linear" )
+	{
+		// Reverse the duplication we do when expanding splines
+		unduplicateEndPoints = true;
+		result.basis = SplineData::ValueType::Basis::linear();
+	}
+	else
+	{
+		result.basis = SplineData::ValueType::Basis::catmullRom();
+	}
+
+	const auto &positions = positionsData->readable();
+	const auto &values = valuesData->readable();
+
+	size_t n = std::min( positions.size(), values.size() );
+	for( size_t i = 0; i < n; ++i )
+	{
+		if( unduplicateEndPoints && ( i == 0 || i == n - 1 ) )
+		{
+			continue;
+		}
+
+		result.points.insert( typename SplineData::ValueType::Point( positions[i], values[i] ) );
+	}
+
+	return resultData;	
+}
+
+} // namespace
+
+IECore::ConstCompoundDataPtr ShaderNetworkAlgo::collapseSplineParameters( const IECore::ConstCompoundDataPtr &parameters )
+{
+	CompoundDataPtr newParametersData;
+
+	const auto &parms = parameters->readable();
+	for( const auto &maybeBasis : parameters->readable() )
+	{
+		if( !boost::ends_with( maybeBasis.first.string(), "Basis" ) )
+		{
+			continue;
+		}
+		const StringData *basis = runTimeCast<const StringData>( maybeBasis.second.get() );
+		if( !basis )
+		{
+			continue;
+		}
+
+
+		std::string prefix = maybeBasis.first.string().substr( 0, maybeBasis.first.string().size() - 5 );
+		IECore::InternedString positionsName = prefix + "Positions";
+		const auto positionsIter = parms.find( positionsName );
+		const FloatVectorData *floatPositions = nullptr;
+	
+		if( positionsIter != parms.end() )
+		{
+			floatPositions = runTimeCast<const FloatVectorData>( positionsIter->second.get() );
+		}
+
+		if( !floatPositions )
+		{
+			continue;
+		}
+
+		IECore::InternedString valuesName = prefix + "Values";
+		const auto valuesIter = parms.find( valuesName );
+	
+		IECore::DataPtr foundSpline;
+		if( valuesIter != parms.end() )
+		{
+			if( const FloatVectorData *floatValues = runTimeCast<const FloatVectorData>( valuesIter->second.get() ) )
+			{
+				foundSpline = loadSpline<SplineffData>( basis, floatPositions, floatValues );
+			}
+			else if( const Color3fVectorData *color3Values = runTimeCast<const Color3fVectorData>( valuesIter->second.get() ) )
+			{
+				foundSpline = loadSpline<SplinefColor3fData>( basis, floatPositions, color3Values );
+			}
+			else if( const Color4fVectorData *color4Values = runTimeCast<const Color4fVectorData>( valuesIter->second.get() ) )
+			{
+				foundSpline = loadSpline<SplinefColor4fData>( basis, floatPositions, color4Values );
+			}
+		}
+
+		if( foundSpline )
+		{
+			if( !newParametersData )
+			{
+				newParametersData = new IECore::CompoundData();
+				newParametersData->writable() = parameters->readable();	
+			}
+			auto &newParameters = newParametersData->writable();
+
+			newParameters[prefix] = foundSpline;
+			newParameters.erase( maybeBasis.first );
+			newParameters.erase( positionsName );
+			newParameters.erase( valuesName );
+		}
+	}
+
+	if( newParametersData )
+	{
+		return newParametersData;
+	}
+	else
+	{
+		return parameters;
+	}
+}
+
+IECore::ConstCompoundDataPtr ShaderNetworkAlgo::expandSplineParameters( const IECore::ConstCompoundDataPtr &parameters )
+{
+	bool hasSplines = false;
+	for( const auto &i : parameters->readable() )
+	{
+		if( runTimeCast<const SplinefColor3fData>( i.second.get() ) ||
+			runTimeCast<const SplineffData>( i.second.get() ) )
+		{
+			hasSplines = true;
+			break;
+		}
+	}
+
+	if( !hasSplines )
+	{
+		return parameters;
+	}
+
+	CompoundDataPtr newParametersData = new CompoundData();
+	CompoundDataMap &newParameters = newParametersData->writable();
+
+	for( const auto &i : parameters->readable() )
+	{
+		if( const SplinefColor3fData *spline = runTimeCast<const SplinefColor3fData>( i.second.get() ) )
+		{
+			expandSpline( i.first, spline->readable(), newParameters );
+		}
+		else if( const SplineffData *spline = runTimeCast<const SplineffData>( i.second.get() ) )
+		{
+			expandSpline( i.first, spline->readable(), newParameters );
+		}
+		else
+		{
+			newParameters[ i.first ] = i.second;
+		}
+	}
+
+	return newParametersData;
 }

--- a/src/IECoreScene/bindings/ShaderNetworkAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/ShaderNetworkAlgoBinding.cpp
@@ -33,6 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 
 #include "boost/python.hpp"
+#include "boost/pointer_cast.hpp"
 
 #include "ShaderNetworkAlgoBinding.h"
 
@@ -50,6 +51,16 @@ void convertOSLComponentConnectionsWrapper( ShaderNetwork *network, int oslVersi
 	ShaderNetworkAlgo::convertOSLComponentConnections( network, oslVersion );
 }
 
+CompoundDataPtr collapseSplineParametersWrapper( CompoundDataPtr parameters )
+{
+	return boost::const_pointer_cast< CompoundData >( ShaderNetworkAlgo::collapseSplineParameters( parameters ) );
+}
+
+CompoundDataPtr expandSplineParametersWrapper( CompoundDataPtr parameters )
+{
+	return boost::const_pointer_cast< CompoundData >( ShaderNetworkAlgo::expandSplineParameters( parameters ) );
+}
+
 } // namespace
 
 void IECoreSceneModule::bindShaderNetworkAlgo()
@@ -62,5 +73,7 @@ void IECoreSceneModule::bindShaderNetworkAlgo()
 	def( "removeUnusedShaders", &ShaderNetworkAlgo::removeUnusedShaders );
 	def( "convertOSLComponentConnections", &convertOSLComponentConnectionsWrapper, ( arg( "network" ), arg( "oslVersion" ) = 10900 ) );
 	def( "convertObjectVector", &ShaderNetworkAlgo::convertObjectVector );
+	def( "collapseSplineParameters", &collapseSplineParametersWrapper );
+	def( "expandSplineParameters", &expandSplineParametersWrapper );
 
 }

--- a/test/IECoreScene/ShaderNetworkAlgoTest.py
+++ b/test/IECoreScene/ShaderNetworkAlgoTest.py
@@ -284,5 +284,37 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( IECoreScene.ShaderNetworkAlgo.convertObjectVector( objectVector ), shaderNetwork )
 
+	def testSplineConversion( self ):
+		parms = IECore.CompoundData()
+		parms["testffbSpline"] = IECore.SplineffData( IECore.Splineff( IECore.CubicBasisf.bSpline(),
+			( ( 0, 1 ), ( 10, 2 ), ( 20, 0 ), ( 21, 2 ) ) ) )
+		parms["testffbezier"] = IECore.SplineffData( IECore.Splineff( IECore.CubicBasisf.bSpline(),
+			( ( 0, 1 ), ( 0.2, 6 ), ( 0.3, 7 ), ( 0.4, 4 ), ( 0.5, 5 ) ) ) )
+		parms["testfColor3fcatmullRom"] = IECore.SplinefColor3fData( IECore.SplinefColor3f( IECore.CubicBasisf.catmullRom(),
+( ( 0, imath.Color3f(1) ), ( 10, imath.Color3f(2) ), ( 20, imath.Color3f(0) ), ( 30, imath.Color3f(5) ), ( 40, imath.Color3f(2) ), ( 50, imath.Color3f(6) ) ) ) )
+		parms["testfColor3flinear"] = IECore.SplinefColor3fData( IECore.SplinefColor3f( IECore.CubicBasisf.linear(),
+( ( 0, imath.Color3f(1) ), ( 10, imath.Color3f(2) ), ( 20, imath.Color3f(0) ) ) ) )
+
+		parmsExpanded = IECoreScene.ShaderNetworkAlgo.expandSplineParameters( parms )
+
+		self.assertEqual( set( parmsExpanded.keys() ), set( [ i + suffix for suffix in [ "Basis", "Values", "Positions" ] for i in parms.keys() ] ) )
+		self.assertEqual( type( parmsExpanded["testffbSplineBasis"] ), IECore.StringData )
+		self.assertEqual( type( parmsExpanded["testffbSplinePositions"] ), IECore.FloatVectorData )
+		self.assertEqual( type( parmsExpanded["testffbSplineValues"] ), IECore.FloatVectorData )
+		self.assertEqual( type( parmsExpanded["testfColor3fcatmullRomValues"] ), IECore.Color3fVectorData )
+
+		parmsCollapsed = IECoreScene.ShaderNetworkAlgo.collapseSplineParameters( parmsExpanded )
+
+		self.assertEqual( parmsCollapsed, parms )
+
+		del parmsExpanded["testffbSplineBasis"]
+		del parmsExpanded["testffbezierValues"]
+		del parmsExpanded["testfColor3fcatmullRomPositions"]
+		del parmsExpanded["testfColor3flinearBasis"]
+
+		parmsCollapsed = IECoreScene.ShaderNetworkAlgo.collapseSplineParameters( parmsExpanded )
+
+		self.assertEqual( parmsCollapsed, parmsExpanded )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
On top of #1214, add support for Cortex's format for splines.  The goal is to also provide a central place for this logic in ShaderNetworkAlgo that can also replace the multiple places in Gaffer where this logic is duplicated.

Still needs some more explicit testing, rather than just adding a few tests in the USD suite, but my first concern is to figure out an API that works.  The first version has a nice symmetric API, but requires write access to the m_parameters pointer in Shader.  The second version fixes this up, but the API is no longer symmetric ... not sure if this bothers us.

The other API consideration is that if we want to replace all duplicated logic in Gaffer with this, there is currently a place where we collapse spline parameters in OSLShader where we convert directly from OSL parameters to Gaffer plugs without going through Cortex Data, which doesn't really fit with this.  I'm wondering if maybe it would be reasonable to convert to Cortex data as an intermediate step though - we could potentially leverage some existing code for converting Data to Plugs, and reduce code duplication in another way?  I started looking at this, and I think it could be reasonable.