### PR TITLE
Clean Up Bogus Location "materials" Created By New USDShade Support

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -480,6 +480,7 @@ if targetApp :
 	INSTALL_RMANLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 	INSTALL_APPLESEEDLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 	INSTALL_ALEMBICLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
+	INSTALL_USDLIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 	# we don't want to build the renderman procedurals when we build apps, as otherwise they end
 	# up causing linking conflicts at rendertime. this is because the procedural would be linking to the
 	# boost version an app needs, whereas the other libraries are linking to the correct boost version for
@@ -502,6 +503,7 @@ else :
 	INSTALL_APPLESEEDLIB_NAME = os.path.join( basePrefix, "appleseed", appleseedVersion, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 	INSTALL_APPLESEEDOUTPUTDRIVER_NAME = os.path.join( basePrefix, "appleseed", appleseedVersion, "plugins", compiler, compilerVersion, "$IECORE_NAME" )
 	INSTALL_ALEMBICLIB_NAME = os.path.join( basePrefix, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
+	INSTALL_USDLIB_NAME = os.path.join( basePrefix, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 
 	# only installing for the base installation as the CORTEX_STARTUP_PATHS will load these within target apps as well
 	INSTALL_CORESCENE_POST_COMMAND = "scons -i -f config/ie/postCoreSceneInstall INSTALLPREFIX={prefix} install".format( prefix = basePrefix )

--- a/contrib/IECoreUSD/include/IECoreUSD/AttributeAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/AttributeAlgo.h
@@ -76,6 +76,7 @@ IECOREUSD_API Name nameToUSD( std::string name );
 IECOREUSD_API IECore::InternedString nameFromUSD( Name name );
 
 IECOREUSD_API pxr::TfToken cortexPrimitiveVariableMetadataToken();
+IECOREUSD_API pxr::TfToken cortexPrimitiveVariableMetadataTokenDeprecated();
 
 } // namespace AttributeAlgo
 

--- a/contrib/IECoreUSD/resources/plugInfo.json
+++ b/contrib/IECoreUSD/resources/plugInfo.json
@@ -18,6 +18,14 @@
 					}
 				},
 				"SdfMetadata": {
+					"cortex_isConstantPrimitiveVariable": {
+						"type": "bool",
+						"appliesTo": "attributes"
+					},
+					# An early version of our constant primitive variable support
+					# used this tag which does not match our naming convention.
+					# We need to continue listing it here for a while so that USD
+					# will let us read it.
 					"IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE": {
 						"type": "bool",
 						"appliesTo": "attributes"

--- a/contrib/IECoreUSD/resources/plugInfo.json
+++ b/contrib/IECoreUSD/resources/plugInfo.json
@@ -29,6 +29,13 @@
 					"IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE": {
 						"type": "bool",
 						"appliesTo": "attributes"
+					},
+					# Label a location that was created automatically to hold
+					# materials - these locations usually aren't useful to
+					# import
+					"cortex_autoMaterials": {
+						"type": "bool",
+						"appliesTo": "prims"
 					}
 				}
 			},

--- a/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
@@ -48,7 +48,8 @@ using namespace pxr;
 
 namespace
 {
-static const pxr::TfToken g_cortexPrimitiveVariableMetadataToken( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" );
+static const pxr::TfToken g_cortexPrimitiveVariableMetadataToken( "cortex_isConstantPrimitiveVariable" );
+static const pxr::TfToken g_cortexPrimitiveVariableMetadataTokenDeprecated( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" );
 static const std::string g_primVarPrefix = "primvars:";
 static const std::string g_primVarUserPrefix = "primvars:user:";
 static const std::string g_renderPrefix = "render:";
@@ -58,11 +59,15 @@ static const std::string g_userPrefix = "user:";
 // so we ignore non constant primvar as well as constant primvar that are "tagged" with a special metadata `IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE`
 bool isCortexAttribute( const pxr::UsdGeomPrimvar &primVar )
 {
-	if ( primVar.GetInterpolation() == pxr::UsdGeomTokens->constant )
+	if( primVar.GetInterpolation() == pxr::UsdGeomTokens->constant )
 	{
 		// skip any non const prim vars or with metadata for Cortex const Primitive Variable
 		pxr::VtValue metadataValue;
-		if ( primVar.GetAttr().GetMetadata( AttributeAlgo::cortexPrimitiveVariableMetadataToken(), &metadataValue ) )
+		if( primVar.GetAttr().GetMetadata( AttributeAlgo::cortexPrimitiveVariableMetadataToken(), &metadataValue ) )
+		{
+			return !metadataValue.Get<bool>();
+		}
+		else if( primVar.GetAttr().GetMetadata( AttributeAlgo::cortexPrimitiveVariableMetadataTokenDeprecated(), &metadataValue ) )
 		{
 			return !metadataValue.Get<bool>();
 		}
@@ -81,6 +86,11 @@ bool isCortexAttribute( const pxr::UsdGeomPrimvar &primVar )
 pxr::TfToken IECoreUSD::AttributeAlgo::cortexPrimitiveVariableMetadataToken()
 {
 	return g_cortexPrimitiveVariableMetadataToken;
+}
+
+pxr::TfToken IECoreUSD::AttributeAlgo::cortexPrimitiveVariableMetadataTokenDeprecated()
+{
+	return g_cortexPrimitiveVariableMetadataTokenDeprecated;
 }
 
 IECoreUSD::AttributeAlgo::Name IECoreUSD::AttributeAlgo::nameToUSD( std::string name )

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -449,6 +449,13 @@ void IECoreUSD::PrimitiveAlgo::readPrimitiveVariables( const pxr::UsdGeomPrimvar
 					continue;
 				}
 			}
+			else if ( primVar.GetAttr().GetMetadata( AttributeAlgo::cortexPrimitiveVariableMetadataTokenDeprecated(), &metadataValue ) )
+			{
+				if ( !metadataValue.Get<bool>() )
+				{
+					continue;
+				}
+			}
 			// constant prim var without the metadata then it's a Cortex Attribute so we skip it as PrimitiveVariable.
 			else
 			{

--- a/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
@@ -1158,7 +1158,7 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		def testCustomAttribute( attribute ):
 			self.assertTrue( attribute )
 
-			self.assertFalse( attribute.GetMetadata( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" ) )
+			self.assertFalse( attribute.GetMetadata( "cortex_isConstantPrimitiveVariable" ) )
 			self.assertEqual( attribute.GetMetadata( "interpolation" ), "constant" )
 			self.assertTrue( attribute.GetMetadata( "custom" ) )
 
@@ -1193,7 +1193,7 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		# constant prim var
 		attribute = uPrim.GetAttribute( "primvars:customConstant" )
 
-		self.assertTrue( attribute.GetMetadata( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" ) )
+		self.assertTrue( attribute.GetMetadata( "cortex_isConstantPrimitiveVariable" ) )
 		self.assertEqual( attribute.GetMetadata( "interpolation" ), "constant" )
 		# All primvars match the primvar schema, and therefore are not custom
 		self.assertFalse( attribute.GetMetadata( "custom" ) )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2772,7 +2772,9 @@ class USDSceneTest( unittest.TestCase ) :
 		# Read via SceneInterface, and check that we've round-tripped successfully.
 
 		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertEqual( root.childNames(), ["topLevel"] )
 		topLevel = root.child( "topLevel" )
+		self.assertEqual( set( topLevel.childNames() ), set( [ "shaderLocation%i"%i for i in range( 20 ) ] ) )
 
 		for i in range( 20 ):
 			a = set( topLevel.child( "shaderLocation%i" % i ).attributeNames() )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -346,6 +346,7 @@ class USDSceneTest( unittest.TestCase ) :
 			'test_vector3d_Scalar_constant' : IECore.V3dData (imath.V3d( 0.1, 0.2, 0.3 ), IECore.GeometricData.Interpretation.Vector ),
 			'test_vector3f_Array_constant' : IECore.V3fVectorData([imath.V3f( 1.1, 1.2, 1.3 ), imath.V3f( 2.1, 2.2, 2.3 ), imath.V3f( 3.1, 3.2, 3.3 )], IECore.GeometricData.Interpretation.Vector ),
 			'test_vector3f_Scalar_constant' : IECore.V3fData (imath.V3f( 0.1, 0.2, 0.3 ), IECore.GeometricData.Interpretation.Vector ),
+			'test_deprecated_Scalar_constant' : IECore.BoolData( 0 ),
 		}
 
 
@@ -2372,7 +2373,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 		def assertExpectedAttributes( sphere ) :
 			# test expected attributes names
-			self.assertEqual( sorted( sphere.attributeNames() ), sorted( [ "user:notAConstantPrimVar", "user:test", "studio:foo", "customNamespaced:testAnimated", "user:bongo", "render:test", "ai:disp_height", "ai:poly_mesh:subdiv_iterations" ] ) )
+			self.assertEqual( sorted( sphere.attributeNames() ), sorted( [ "user:notAConstantPrimVar", "user:notAConstantPrimVarDeprecated", "user:test", "studio:foo", "customNamespaced:testAnimated", "user:bongo", "render:test", "ai:disp_height", "ai:poly_mesh:subdiv_iterations" ] ) )
 
 			# test incompatible primvars hasAttribute/readAttribute
 			for name in [
@@ -2396,6 +2397,7 @@ class USDSceneTest( unittest.TestCase ) :
 			# Animation not yet supported
 			self.assertEqual( sphere.readAttribute( "customNamespaced:testAnimated", 0 ), IECore.DoubleData( 0 ) )
 			self.assertEqual( sphere.readAttribute( "user:notAConstantPrimVar", 0 ), IECore.StringData( "pink" ) )
+			self.assertEqual( sphere.readAttribute( "user:notAConstantPrimVarDeprecated", 0 ), IECore.StringData( "pink" ) )
 			self.assertEqual( sphere.readAttribute( "ai:disp_height", 0 ), IECore.FloatData( 0.5 ) )
 			self.assertEqual( sphere.readAttribute( "ai:poly_mesh:subdiv_iterations", 0 ), IECore.IntData( 3 ) )
 
@@ -2417,6 +2419,7 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertFalse( b.hasAttribute( "primvars:withIndices" ) )
 		self.assertFalse( b.hasAttribute( "primvars:withIndices:indices" ) )
 		self.assertFalse( b.hasAttribute( "render:bar" ) )
+		self.assertFalse( b.hasAttribute( "render:barDeprecated" ) )
 		self.assertFalse( b.hasAttribute( "user:foo" ) )
 		self.assertTrue( b.hasAttribute( "user:baz" ) )
 		self.assertEqual( b.readAttribute( "user:baz", 0 ), IECore.StringData( "white" ) )
@@ -2425,10 +2428,12 @@ class USDSceneTest( unittest.TestCase ) :
 		# constant primvar non attribute
 		bObj = b.readObject( 0 )
 		self.assertTrue( bObj["bar"] )
+		self.assertTrue( bObj["barDeprecated"] )
 		# make sure no other PrimitiveVariables are creeping in
 		# Having a primvar with indices here makes sure we don't read the indices themselves as a primvar or attribute
-		self.assertEqual( bObj.keys(), ["bar", "withIndices"] )
+		self.assertEqual( bObj.keys(), ["bar", "barDeprecated", "withIndices"] )
 		self.assertEqual( bObj["bar"].data, IECore.StringData( "black" ) )
+		self.assertEqual( bObj["barDeprecated"].data, IECore.StringData( "black" ) )
 		self.assertEqual( bObj["withIndices"], IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.FloatVectorData([ 1, 2, 3 ]), IECore.IntVectorData( [1] ) ) )
 
 		# check primvars from USD API
@@ -2445,7 +2450,7 @@ class USDSceneTest( unittest.TestCase ) :
 			primVar = primVarAPI.FindPrimvarWithInheritance( "primvars:{}".format( primVarName ) )
 			self.assertTrue( primVar )
 			self.assertEqual( primVar.Get( 0 ), expectedValue[primVarName] )
-			self.assertEqual( bool( primVar.GetAttr().GetMetadata( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" ) ), primVarName == "bar" )
+			self.assertEqual( bool( primVar.GetAttr().GetMetadata( "cortex_isConstantPrimitiveVariable" ) ), primVarName == "bar" )
 
 		# Check that we can round-trip the supported attributes.
 
@@ -2474,7 +2479,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 		abUsd = pxr.UsdGeom.Imageable( stage.GetPrimAtPath( "/ab" ) )
 		self.assertEqual( abUsd.GetPrimvar( "bar" ).Get( 0 ), "black" )
-		self.assertEqual( abUsd.GetPrimvar( "bar" ).GetAttr().GetMetadata( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" ), True )
+		self.assertEqual( abUsd.GetPrimvar( "bar" ).GetAttr().GetMetadata( "cortex_isConstantPrimitiveVariable" ), True )
 		self.assertEqual( abUsd.GetPrimvar( "notUserPrefixAttribute" ).Get( 0 ), "orange" )
 		self.assertEqual( abUsd.GetPrimvar( "user:baz" ).Get( 0 ), "white" )
 		self.assertEqual( abUsd.GetPrim().GetAttribute( "radius" ).Get( 0 ), 1 )

--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -16,6 +16,9 @@ def Sphere "sphere"
 		24: 1
 	}
 	string primvars:user:notAConstantPrimVar = "pink"(
+		cortex_isConstantPrimitiveVariable = false
+	)
+	string primvars:user:notAConstantPrimVarDeprecated = "pink"(
 		IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = false
 	)
 	float primvars:arnold:disp_height = 0.5
@@ -27,6 +30,9 @@ def Xform "a"
 	def Sphere "b"
 	{
 		string primvars:bar = "black"(
+			cortex_isConstantPrimitiveVariable = true
+		)
+		string primvars:barDeprecated = "black"(
 			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
 		)
 		string primvars:user:baz = "white"

--- a/contrib/IECoreUSD/test/IECoreUSD/data/primVars.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/primVars.usda
@@ -5,357 +5,360 @@ def Xform "root"
 	def Points "sphere"
 	{
 		bool[] primvars:test_Bool_Array_constant = [0, 1] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		bool primvars:test_Bool_Scalar_constant = 0 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3d[] primvars:test_color3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3d primvars:test_color3d_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3f[] primvars:test_color3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3f primvars:test_color3f_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3h[] primvars:test_color3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color3h primvars:test_color3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4d[] primvars:test_color4d_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4d primvars:test_color4d_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4f[] primvars:test_color4f_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4f primvars:test_color4f_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4h[] primvars:test_color4h_Array_constant = [(1.09961, 1.2002, 1.2998, 1.40039), (2.09961, 2.19922, 2.30078, 2.40039), (3.09961, 3.19922, 3.30078, 3.40039)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		color4h primvars:test_color4h_Scalar_constant = (0.0999756, 0.199951, 0.300049, 0.399902) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double2[] primvars:test_Double2_Array_constant = [(1.1, 1.2), (2.1, 2.2), (3.1, 3.2)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double2 primvars:test_Double2_Scalar_constant = (0.1, 0.2) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double3[] primvars:test_Double3_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double3 primvars:test_Double3_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double4[] primvars:test_Double4_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double4 primvars:test_Double4_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double[] primvars:test_Double_Array_constant = [1.2, 1.3, 1.4] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		double primvars:test_Double_Scalar_constant = 1.1 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float2[] primvars:test_Float2_Array_constant = [(1.1, 1.2), (2.1, 2.2), (3.1, 3.2)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float2 primvars:test_Float2_Scalar_constant = (0.1, 0.2) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float3[] primvars:test_Float3_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float3 primvars:test_Float3_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float4[] primvars:test_Float4_Array_constant = [(1.1, 1.2, 1.3, 1.4), (2.1, 2.2, 2.3, 2.4), (3.1, 3.2, 3.3, 3.4)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float4 primvars:test_Float4_Scalar_constant = (0.1, 0.2, 0.3, 0.4) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float[] primvars:test_Float_Array_constant = [0.7, 0.8, 0.9] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		float primvars:test_Float_Scalar_constant = 0.6 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half2[] primvars:test_Half2_Array_constant = [(1.09961, 1.2002), (2.09961, 2.19922), (3.09961, 3.19922)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half2 primvars:test_Half2_Scalar_constant = (0.0999756, 0.199951) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half3[] primvars:test_Half3_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half3 primvars:test_Half3_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half4[] primvars:test_Half4_Array_constant = [(1.09961, 1.2002, 1.2998, 1.40039), (2.09961, 2.19922, 2.30078, 2.40039), (3.09961, 3.19922, 3.30078, 3.40039)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half4 primvars:test_Half4_Scalar_constant = (0.0999756, 0.199951, 0.300049, 0.399902) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half[] primvars:test_Half_Array_constant = [0.0999756, 0.199951, 0.300049] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		half primvars:test_Half_Scalar_constant = 0.5 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int2[] primvars:test_Int2_Array_constant = [(3, 4), (5, 6), (7, 8)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int2 primvars:test_Int2_Scalar_constant = (1, 2) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int3[] primvars:test_Int3_Array_constant = [(3, 4, 5), (5, 6, 7), (7, 8, 9)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int3 primvars:test_Int3_Scalar_constant = (1, 2, 3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int4[] primvars:test_Int4_Array_constant = [(3, 4, 5, 6), (5, 6, 7, 8), (7, 8, 9, 10)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int4 primvars:test_Int4_Scalar_constant = (1, 2, 3, 4) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int64[] primvars:test_Int64_Array_constant = [9223372036854775805, 9223372036854775806, 9223372036854775807] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int64 primvars:test_Int64_Scalar_constant = -9223372036854775808 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int[] primvars:test_Int_Array_constant = [0, -1, -2] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		int primvars:test_Int_Scalar_constant = -1 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix2d[] primvars:test_matrix2d_Array_constant = [( (0, 1), (0, 0) ), ( (0, 0), (2, 0) ), ( (0, 0), (3, 0) )] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix2d primvars:test_matrix2d_Scalar_constant = ( (1, 0), (0, 0) ) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix3d[] primvars:test_matrix3d_Array_constant = [( (0, 0, 0), (0, 1, 0), (0, 0, 0) ), ( (0, 0, 0), (0, 0, 0), (0, 0, 2) ), ( (0, 0, 4), (0, 0, 0), (0, 0, 0) )] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix3d primvars:test_matrix3d_Scalar_constant = ( (0, 0, 0), (0, 0, 0), (0, 0, 0) ) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix4d[] primvars:test_matrix4d_Array_constant = [( (1, 0, 0, 0), (0, 0, 0, 0), (9, 0, 0, 0), (0, 0, 0, 0) ), ( (1, 0, 0, 0), (0, 3, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0) ), ( (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 2, 0) )] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		matrix4d primvars:test_matrix4d_Scalar_constant = ( (1, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0), (0, 0, 0, 0) ) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3d[] primvars:test_normal3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3d primvars:test_normal3d_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3f[] primvars:test_normal3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3f primvars:test_normal3f_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3h[] primvars:test_normal3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		normal3h primvars:test_normal3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3d[] primvars:test_point3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3d primvars:test_point3d_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3f[] primvars:test_point3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3f primvars:test_point3f_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3h[] primvars:test_point3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		point3h primvars:test_point3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quatd[] primvars:test_quatd_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quatd primvars:test_quatd_Scalar_constant = (0, 0, 0, 1) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quatf[] primvars:test_quatf_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quatf primvars:test_quatf_Scalar_constant = (0, 0, 0, 1) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quath[] primvars:test_quath_Array_constant = [(1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		quath primvars:test_quath_Scalar_constant = (0, 0, 0, 1) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		string[] primvars:test_String_Array_constant = ["is", "a", "test"] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		string primvars:test_String_Scalar_constant = "this" (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		token[] primvars:test_Token_Array_constant = ["t-is", "t-a", "t-test"] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		token primvars:test_Token_Scalar_constant = "t-this" (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uchar[] primvars:test_UChar_Array_constant = [0, 1, 2] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uchar primvars:test_UChar_Scalar_constant = 0 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uint64[] primvars:test_UInt64_Array_constant = [18446744073709551613, 18446744073709551614, 18446744073709551615] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uint64 primvars:test_UInt64_Scalar_constant = 18446744073709551615 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uint[] primvars:test_UInt_Array_constant = [4294967293, 4294967294, 4294967295] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		uint primvars:test_UInt_Scalar_constant = 4294967295 (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3d[] primvars:test_vector3d_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3d primvars:test_vector3d_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3f[] primvars:test_vector3f_Array_constant = [(1.1, 1.2, 1.3), (2.1, 2.2, 2.3), (3.1, 3.2, 3.3)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3f primvars:test_vector3f_Scalar_constant = (0.1, 0.2, 0.3) (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3h[] primvars:test_vector3h_Array_constant = [(1.09961, 1.2002, 1.2998), (2.09961, 2.19922, 2.30078), (3.09961, 3.19922, 3.30078)] (
-			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
+			cortex_isConstantPrimitiveVariable = true
 			interpolation = "constant"
 		)
 		vector3h primvars:test_vector3h_Scalar_constant = (0.0999756, 0.199951, 0.300049) (
+			cortex_isConstantPrimitiveVariable = true
+			interpolation = "constant"
+		)
+		bool primvars:test_deprecated_Scalar_constant = 0 (
 			IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE = true
 			interpolation = "constant"
 		)
 	}
 }
-


### PR DESCRIPTION
I added the metadata "cortex_isLocation" which can be set false on locations which are not really locations, like the "materials" container we use for holding shaders.

The name is because colons appear to be illegal.

I also switched from IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE to cortex_isConstantPrimitiveVariable to match this naming convention, and added a bunch of annoying compatibility shims.