### PR TITLE
ShaderNetworkAlgo : Fix shadowing of local variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1186,7 +1186,7 @@ else:
 				"/wd4506",  # suppress warning about no definition for inline function. Needed for USD::Glf
 				# suppress warning about exported class deriving from non-exported class.
 				# Microsoft states (in https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-2-c4275?view=msvc-170)
-				# that "C4275 can be ignored if you are deriving from a type in the 
+				# that "C4275 can be ignored if you are deriving from a type in the
 				# C++ Standard Library", which is the case
 				"/wd4275",
 				"/D_CRT_SECURE_NO_WARNINGS",  # suppress warnings about getenv and similar
@@ -1217,7 +1217,7 @@ else:
 				"-MD",	# create multithreaded DLL
 				"-DBOOST_DISABLE_ASSERTS",
 				"-Ox",
-				# -Og optimization (included via -Ox) generates lots of unreachable 
+				# -Og optimization (included via -Ox) generates lots of unreachable
 				# code warnings from boost::intrusive_ptr. Disabled in release build only.
 				"/wd4702"
 			]
@@ -2545,7 +2545,7 @@ nukeEnvAppends = {
 
 	"CXXFLAGS" : [
 		systemIncludeArgument, "$NUKE_ROOT/include",
-		systemIncludeArgument, "$GLEW_INCLUDE_PATH" 
+		systemIncludeArgument, "$GLEW_INCLUDE_PATH"
 	]
 
 }

--- a/src/IECoreScene/ShaderNetworkAlgo.cpp
+++ b/src/IECoreScene/ShaderNetworkAlgo.cpp
@@ -594,13 +594,13 @@ IECore::ConstCompoundDataPtr ShaderNetworkAlgo::expandSplineParameters( const IE
 
 	for( const auto &i : parameters->readable() )
 	{
-		if( const SplinefColor3fData *spline = runTimeCast<const SplinefColor3fData>( i.second.get() ) )
+		if( const SplinefColor3fData *colorSpline = runTimeCast<const SplinefColor3fData>( i.second.get() ) )
 		{
-			expandSpline( i.first, spline->readable(), newParameters );
+			expandSpline( i.first, colorSpline->readable(), newParameters );
 		}
-		else if( const SplineffData *spline = runTimeCast<const SplineffData>( i.second.get() ) )
+		else if( const SplineffData *floatSpline = runTimeCast<const SplineffData>( i.second.get() ) )
 		{
-			expandSpline( i.first, spline->readable(), newParameters );
+			expandSpline( i.first, floatSpline->readable(), newParameters );
 		}
 		else
 		{

--- a/src/IECoreScene/ShaderNetworkAlgo.cpp
+++ b/src/IECoreScene/ShaderNetworkAlgo.cpp
@@ -487,7 +487,7 @@ IECore::DataPtr loadSpline(
 		result.points.insert( typename SplineData::ValueType::Point( positions[i], values[i] ) );
 	}
 
-	return resultData;	
+	return resultData;
 }
 
 } // namespace
@@ -514,7 +514,7 @@ IECore::ConstCompoundDataPtr ShaderNetworkAlgo::collapseSplineParameters( const 
 		IECore::InternedString positionsName = prefix + "Positions";
 		const auto positionsIter = parms.find( positionsName );
 		const FloatVectorData *floatPositions = nullptr;
-	
+
 		if( positionsIter != parms.end() )
 		{
 			floatPositions = runTimeCast<const FloatVectorData>( positionsIter->second.get() );
@@ -527,7 +527,7 @@ IECore::ConstCompoundDataPtr ShaderNetworkAlgo::collapseSplineParameters( const 
 
 		IECore::InternedString valuesName = prefix + "Values";
 		const auto valuesIter = parms.find( valuesName );
-	
+
 		IECore::DataPtr foundSpline;
 		if( valuesIter != parms.end() )
 		{
@@ -550,7 +550,7 @@ IECore::ConstCompoundDataPtr ShaderNetworkAlgo::collapseSplineParameters( const 
 			if( !newParametersData )
 			{
 				newParametersData = new IECore::CompoundData();
-				newParametersData->writable() = parameters->readable();	
+				newParametersData->writable() = parameters->readable();
 			}
 			auto &newParameters = newParametersData->writable();
 


### PR DESCRIPTION
This fixes a conflict between #1217, which introduced stricter warnings for MSVC and #1218, which inadvertently shadowed a local variable. I've fixed it by removing the shadowing, but I do think there's a debate to be had about whether the benefits of the warning outweigh the costs. Here's the earlier commit that fixed the original warnings in the first place :

https://github.com/ImageEngine/cortex/pull/1217/commits/5e05fc1c1260df5d35cb742e0441ce14911f105f

Of those fixes, there are certainly some which have improved clarity considerable - e.g. https://github.com/ImageEngine/cortex/pull/1217/commits/5e05fc1c1260df5d35cb742e0441ce14911f105f#diff-a25b89bbcc00ca5dc86f7fa4c1b193d92a51c97bd52718617d98604e3e3deaf1L165-R167. But there are also others that have resulted in more contrived or less accurate naming, e.g. https://github.com/ImageEngine/cortex/pull/1217/commits/3916634d0566431423cbd44f0b4b4852e4314b97 (actually a different warning, but the same concept).

I looked into adding the equivalent warning (`-Wshadow`) for GCC so we could catch problems sooner when developing on Linux,  but that produces even more pedantic output, which I don't think I'll be able to tolerate. Is everyone happy to keep the Windows warning alive, or do we think on balance we might be better to treat GCC's `-Wall` as our benchmark? @ericmehl, I can't add you as a reviewer but I am interested in your thoughts here too.
