### PR TITLE
Build 3Delight / RenderMan display driver

### DIFF
--- a/.github/workflows/main/installDelight.py
+++ b/.github/workflows/main/installDelight.py
@@ -75,5 +75,16 @@ elif sys.platform == "darwin" :
 
 
 elif sys.platform == "win32":
-	print( "3Delight on Windows is not currently supported." )
+    package = "3DelightNSI-{}-setup.exe".format( delightVersion )
+
+    url = "{baseUrl}/{delightDirectory}/{package}".format(
+        baseUrl = baseUrl,
+        delightDirectory = delightDirectory,
+        package = package
+    )
+
+    print( "Downloading 3Delight \"{}\"".format( url ) )
+    archiveFileName, headers = urlretrieve( url )
+
+    subprocess.check_call( [ archiveFileName, "/VERYSILENT", "/DIR=3delight" ] )
 

--- a/.github/workflows/main/options.windows
+++ b/.github/workflows/main/options.windows
@@ -58,7 +58,7 @@ DOXYGEN = deps + "\\doxygen\\doxygen.exe"
 # Renderers
 # =========
 
-RMAN_ROOT = ""
+RMAN_ROOT = os.environ["DELIGHT"]
 
 APPLESEED_ROOT = deps + "\\appleseed"
 APPLESEED_INCLUDE_PATH = deps + "\\appleseed\\include"


### PR DESCRIPTION
Add support for 3Delight for Windows, required for Gaffer to use 3Delight renderer backend.

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
