### PR TITLE
IECoreUSD : Fix builds using USD 20.08

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
@@ -48,7 +48,7 @@ namespace
 
 	IECore::InternedString readShaderNetworkWalk( const pxr::SdfPath &anchorPath, const pxr::UsdShadeShader &usdShader, IECoreScene::ShaderNetwork &shaderNetwork )
 	{
-		IECore::InternedString handle( usdShader.GetPath().MakeRelativePath( anchorPath ).GetAsString() );
+		IECore::InternedString handle( usdShader.GetPath().MakeRelativePath( anchorPath ).GetString() );
 
 		if( shaderNetwork.getShader( handle ) )
 		{


### PR DESCRIPTION
This version is required by Houdini 18.5 and does not have `SdfPath::GetAsString`
