### PR TITLE
USDScene : Fix compatibility with USD 21.08

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -92,6 +92,10 @@ using namespace IECoreUSD;
 #define HasAuthoredValue HasAuthoredValueOpinion
 #endif
 
+#if USD_VERSION < 2011
+#define GetPrimInPrototype GetPrimInMaster
+#endif
+
 namespace
 {
 
@@ -104,7 +108,7 @@ void appendPrimOrMasterPath( const pxr::UsdPrim &prim, IECore::MurmurHash &h )
 {
 	if( prim.IsInstanceProxy() )
 	{
-		append( prim.GetPrimInMaster().GetPrimPath(), h );
+		append( prim.GetPrimInPrototype().GetPrimPath(), h );
 	}
 	else
 	{


### PR DESCRIPTION
`GetPrimInMaster()` was deprecated in USD 20.11, when `GetPrimInPrototype()` was added. It was removed in USD 21.08.