### PR TITLE
USDScene : Ignore attributes without authored values

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -762,9 +762,9 @@ bool USDScene::hasAttribute( const SceneInterface::Name &name ) const
 		pxr::TfToken kind;
 		return model.GetKind( &kind );
 	}
-	else if( AttributeAlgo::findUSDAttribute( m_location->prim, name.string() ) )
+	else if( auto attribute = AttributeAlgo::findUSDAttribute( m_location->prim, name.string() ) )
 	{
-		return true;
+		return attribute.HasAuthoredValue();
 	}
 	else
 	{
@@ -813,6 +813,10 @@ void USDScene::attributeNames( SceneInterface::NameList &attrs ) const
 	std::vector<pxr::UsdAttribute> attributes = m_location->prim.GetAuthoredAttributes();
 	for( const auto &attribute : attributes )
 	{
+		if( !attribute.HasAuthoredValue() )
+		{
+			continue;
+		}
 		IECore::InternedString name = IECoreUSD::AttributeAlgo::cortexAttributeName( attribute );
 		if( name.string().size() )
 		{

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -2388,6 +2388,7 @@ class USDSceneTest( unittest.TestCase ) :
 				"namespaced:test",
 				"nonexistent",
 				"radius",
+				"test:noAuthoredValue",
 			] :
 				self.assertFalse( sphere.hasAttribute( name ) )
 				self.assertIsNone( sphere.readAttribute( name, 0 ) )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -73,10 +73,9 @@ class USDSceneTest( unittest.TestCase ) :
 
 	def assertSetNamesEqual( self, setNames1, setNames2 ) :
 
-		# Order isn't guaranteed, so sort before comparing
 		self.assertEqual(
-			sorted( [ str( x ) for x in setNames1 ] ),
-			sorted( [ str( x ) for x in setNames2 ] )
+			{ str( x ) for x in setNames1 },
+			{ str( x ) for x in setNames2 }
 		)
 		# Duplicates are not allowed
 		self.assertEqual( len( set( setNames1 ) ), len( setNames1 ) )
@@ -2373,7 +2372,14 @@ class USDSceneTest( unittest.TestCase ) :
 
 		def assertExpectedAttributes( sphere ) :
 			# test expected attributes names
-			self.assertEqual( sorted( sphere.attributeNames() ), sorted( [ "user:notAConstantPrimVar", "user:notAConstantPrimVarDeprecated", "user:test", "studio:foo", "customNamespaced:testAnimated", "user:bongo", "render:test", "ai:disp_height", "ai:poly_mesh:subdiv_iterations" ] ) )
+			self.assertEqual(
+				set( sphere.attributeNames() ),
+				{
+					"user:notAConstantPrimVar", "user:notAConstantPrimVarDeprecated", "user:test",
+					"studio:foo", "customNamespaced:testAnimated", "user:bongo", "render:test",
+					"ai:disp_height", "ai:poly_mesh:subdiv_iterations"
+				}
+			)
 
 			# test incompatible primvars hasAttribute/readAttribute
 			for name in [
@@ -2412,7 +2418,7 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertEqual( a.readAttribute( "user:foo", 0 ), IECore.StringData( "yellow" ) )
 
 		b = a.child( "b" )
-		self.assertEqual( sorted( b.attributeNames() ), ["render:notUserPrefixAttribute", "user:baz"] )
+		self.assertEqual( set( b.attributeNames() ), { "render:notUserPrefixAttribute", "user:baz" } )
 		for n in b.attributeNames():
 			self.assertTrue( b.hasAttribute( n ) )
 		# Make sure primvars and indices not loaded as attributes

--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -23,6 +23,7 @@ def Sphere "sphere"
 	)
 	float primvars:arnold:disp_height = 0.5
 	int primvars:arnold:poly_mesh:subdiv_iterations = 3
+	custom string[] test:noAuthoredValue
 }
 def Xform "a"
 {


### PR DESCRIPTION
This prevents us from having to later return a null attribute from `readAttribute()`, which in turn becomes a warning in Gaffer.