### PR TITLE
Update for Nuke 13

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2630,7 +2630,7 @@ if doConfigure :
 					os.path.basename( glEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				]	)
 
-				nukeEnv.Append( LIBS = [ nukeLibName, "boost_python$BOOST_LIB_SUFFIX" ] )
+				nukeEnv.Append( LIBS = [ nukeLibName, "boost_python" + boostPythonLibSuffix ] )
 
 				nukeEnv.Append(
 					CPPFLAGS = [

--- a/SConstruct
+++ b/SConstruct
@@ -2727,7 +2727,7 @@ if doConfigure :
 
 				# nuke tests
 
-				nukeTest = nukeTestEnv.Command( "test/IECoreNuke/resultsPython.txt", nukeLibrary, "echo \"execfile( '$TEST_NUKE_SCRIPT' )\" | $NUKE_ROOT/Nuke${NUKE_MAJOR_VERSION}.${NUKE_MINOR_VERSION} -t" )
+				nukeTest = nukeTestEnv.Command( "test/IECoreNuke/resultsPython.txt", nukeLibrary, "$NUKE_ROOT/Nuke${NUKE_MAJOR_VERSION}.${NUKE_MINOR_VERSION} -t $TEST_NUKE_SCRIPT" )
 				NoCache( nukeTest )
 				nukeTestEnv.Depends( nukeTest, glob.glob( "test/IECoreNuke/*.py" ) )
 				nukeTestEnv.Depends( nukeTest, nukePythonModule )

--- a/config/ie/options
+++ b/config/ie/options
@@ -329,12 +329,6 @@ if targetApp=="nuke" :
 
 	nukeVersion = targetAppVersion
 	nukeReg = IEEnv.registry["apps"]["nuke"][nukeVersion][platform]
-
-	# nuke 12.2 ships its own USD so we link against that
-	if distutils.version.LooseVersion(nukeVersion) >= distutils.version.LooseVersion("12.2") :
-		USD_INCLUDE_PATH = os.path.join( nukeReg["location"], "include" )
-		USD_LIB_PATH = os.path.join( nukeReg["location"], nukeReg["libPaths"][0] )
-
 	NUKE_ROOT = nukeReg["location"]
 	NUKE_LICENSE_FILE = nukeReg["wrapperEnvVars"]["foundry_LICENSE"]
 	INSTALL_NUKELIB_NAME = os.path.join( appPrefix, "lib", "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )

--- a/python/IECoreNuke/FnAxis.py
+++ b/python/IECoreNuke/FnAxis.py
@@ -36,7 +36,7 @@ import math
 import nuke
 import imath
 import IECore
-from KnobAccessors import getKnobValue
+from .KnobAccessors import getKnobValue
 
 ## This function set can be used to manipulate any nodes which have
 # an axis knob. This includes the Axis, TransformGeo and Camera nodes.

--- a/python/IECoreNuke/FnOpHolder.py
+++ b/python/IECoreNuke/FnOpHolder.py
@@ -35,7 +35,7 @@
 import nuke
 
 import IECoreNuke
-import _IECoreNuke
+from . import _IECoreNuke
 
 class FnOpHolder( IECoreNuke.FnParameterisedHolder ) :
 

--- a/python/IECoreNuke/FnParameterisedHolder.py
+++ b/python/IECoreNuke/FnParameterisedHolder.py
@@ -35,14 +35,15 @@
 import nuke
 
 import IECore
-from _IECoreNuke import _parameterisedHolderGetParameterisedResult
-from _IECoreNuke import _parameterisedHolderSetModifiedParametersInput
+from ._IECoreNuke import _parameterisedHolderGetParameterisedResult
+from ._IECoreNuke import _parameterisedHolderSetModifiedParametersInput
+import six
 
 class FnParameterisedHolder :
 
 	def __init__( self, node ) :
 
-		if isinstance( node, basestring ) :
+		if isinstance( node, six.string_types ) :
 			self.__node = nuke.toNode( node )
 		else :
 			self.__node = node

--- a/python/IECoreNuke/KnobConverters.py
+++ b/python/IECoreNuke/KnobConverters.py
@@ -35,7 +35,7 @@
 from __future__ import with_statement
 import nuke
 import IECore
-from StringUtil import nukeFileSequence, ieCoreFileSequence
+from .StringUtil import nukeFileSequence, ieCoreFileSequence
 
 __parameterKnobConverters = []
 
@@ -236,7 +236,7 @@ def __createNumericVectorParameterKnob( knobHolder, parameter, knobName, knobLab
 def __numericVectorParameterToKnob( knobHolder, parameter, knobName ):
 
 	knob = knobHolder.knobs()[knobName]
-	knob.setValue( " ".join( map( lambda v: str(v), parameter.getValue() ) ) )
+	knob.setValue( " ".join( [str(v) for v in parameter.getValue()] ) )
 
 def __numericVectorParameterFromKnob( knobHolder, parameter, knobName ) :
 
@@ -244,7 +244,7 @@ def __numericVectorParameterFromKnob( knobHolder, parameter, knobName ) :
 	dataType = IECore.DataTraits.valueTypeFromSequenceType( dataVectorType )
 	values = knobHolder.knobs()[knobName].getText().strip()
 	if len(values) :
-		dataValues = map( lambda v: dataType(v), values.split() )
+		dataValues = [dataType(v) for v in values.split()]
 		parameter.setValue( dataVectorType( dataValues ) )
 	else :
 		parameter.setValue( dataVectorType() )

--- a/python/IECoreNuke/StringUtil.py
+++ b/python/IECoreNuke/StringUtil.py
@@ -33,6 +33,7 @@
 ##########################################################################
 
 import re
+from six.moves import range
 
 def __toFormatString( match ):
 	txt = match.group(0)
@@ -49,7 +50,7 @@ def __toNumberSign( match ):
 	if len(txt) :
 		cc = int(txt)
 		if txt[0] != '0' and cc > 1 :
-			raise RuntimeError, "Frame numbers padded with space is not supported!"
+			raise RuntimeError("Frame numbers padded with space is not supported!")
 	result = ""
 	for c in range( cc ) :
 		result = result + "#"

--- a/python/IECoreNuke/StringUtil.py
+++ b/python/IECoreNuke/StringUtil.py
@@ -59,9 +59,9 @@ def __toNumberSign( match ):
 ## Converts IECore standard file sequence path to Nuke's syntax
 def nukeFileSequence( ieCorefs ) :
 
-	return re.sub( "#+", __toFormatString, ieCorefs )
+	return re.sub( r"#+", __toFormatString, ieCorefs )
 
 ## Converts Nuke standard file sequence path to IECore's syntax
 def ieCoreFileSequence( nukefs ) :
 
-	return re.sub( "%([0-9]*)d", __toNumberSign, nukefs )
+	return re.sub( r"%([0-9]*)d", __toNumberSign, nukefs )

--- a/python/IECoreNuke/__init__.py
+++ b/python/IECoreNuke/__init__.py
@@ -34,15 +34,15 @@
 
 __import__( "IECore" )
 
-from _IECoreNuke import *
+from ._IECoreNuke import *
 
-from KnobAccessors import setKnobValue, getKnobValue
-from FnAxis import FnAxis
-from StringUtil import nukeFileSequence, ieCoreFileSequence
-from KnobConverters import registerParameterKnobConverters, createKnobsFromParameter, setKnobsFromParameter, setParameterFromKnobs
-from FnParameterisedHolder import FnParameterisedHolder
-from UndoManagers import UndoState, UndoDisabled, UndoEnabled, UndoBlock
-from TestCase import TestCase
-from FnOpHolder import FnOpHolder
+from .KnobAccessors import setKnobValue, getKnobValue
+from .FnAxis import FnAxis
+from .StringUtil import nukeFileSequence, ieCoreFileSequence
+from .KnobConverters import registerParameterKnobConverters, createKnobsFromParameter, setKnobsFromParameter, setParameterFromKnobs
+from .FnParameterisedHolder import FnParameterisedHolder
+from .UndoManagers import UndoState, UndoDisabled, UndoEnabled, UndoBlock
+from .TestCase import TestCase
+from .FnOpHolder import FnOpHolder
 
 __import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", subdirectory = "IECoreNuke" )

--- a/src/IECoreNuke/ClassParameterHandler.cpp
+++ b/src/IECoreNuke/ClassParameterHandler.cpp
@@ -92,7 +92,7 @@ void ClassParameterHandler::setState( IECore::Parameter *parameter, const IECore
 		boost::python::object pythonParameter( ParameterPtr( const_cast<Parameter *>( parameter ) ) );
 		pythonParameter.attr( "setClass" )( className, classVersion, classSearchPathEnvVar );
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}
@@ -126,7 +126,7 @@ IECore::ObjectPtr ClassParameterHandler::getState( const IECore::Parameter *para
 		result->members()["__classVersion"] = new IECore::IntData( classVersion );
 		result->members()["__searchPathEnvVar"] = new IECore::StringData( searchPathEnvVar );
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}
@@ -234,7 +234,7 @@ void ClassParameterHandler::classChooserKnob( const IECore::Parameter *parameter
 		}
 
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}

--- a/src/IECoreNuke/ClassVectorParameterHandler.cpp
+++ b/src/IECoreNuke/ClassVectorParameterHandler.cpp
@@ -100,7 +100,7 @@ void ClassVectorParameterHandler::setState( IECore::Parameter *parameter, const 
 		boost::python::object pythonParameter( ParameterPtr( const_cast<Parameter *>( parameter ) ) );
 		pythonParameter.attr( "setClasses" )( classes );
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}
@@ -141,7 +141,7 @@ IECore::ObjectPtr ClassVectorParameterHandler::getState( const IECore::Parameter
 		result->members()["__classNames"] = classNames;
 		result->members()["__classVersions"] = classVersions;
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}
@@ -178,7 +178,7 @@ void ClassVectorParameterHandler::addEditKnobs( const IECore::Parameter *paramet
 		buildAddMenu( addKnob, parameter, parameterPath );
 		buildRemoveMenu( removeKnob, parameter, parameterPath );
 	}
-	catch( boost::python::error_already_set )
+	catch( boost::python::error_already_set &e )
 	{
 		PyErr_Print();
 	}

--- a/src/IECoreNuke/DisplayIop.cpp
+++ b/src/IECoreNuke/DisplayIop.cpp
@@ -47,7 +47,7 @@
 
 #include "boost/bind.hpp"
 #include "boost/lexical_cast.hpp"
-#include "boost/signal.hpp"
+#include "boost/signals2.hpp"
 
 using namespace IECore;
 using namespace IECoreImage;
@@ -123,11 +123,11 @@ class NukeDisplayDriver : public IECoreImage::ImageDisplayDriver
 		/// This signal is emitted when a new NukeDisplayDriver has been created.
 		/// This allows nuke nodes to pick up the new DisplayDrivers even when they're
 		/// created in some other code, such as a DisplayDriverServer.
-		typedef boost::signal<void( NukeDisplayDriver * )> InstanceCreatedSignal;
+		typedef boost::signals2::signal<void( NukeDisplayDriver * )> InstanceCreatedSignal;
 		static InstanceCreatedSignal instanceCreatedSignal;
 
 		/// This signal is emitted when this NukeDisplayDriver instance receives new data.
-		typedef boost::signal<void( NukeDisplayDriver *, const Imath::Box2i &box )> DataReceivedSignal;
+		typedef boost::signals2::signal<void( NukeDisplayDriver *, const Imath::Box2i &box )> DataReceivedSignal;
 		DataReceivedSignal dataReceivedSignal;
 
 	private :

--- a/src/IECoreNuke/DrawableHolder.cpp
+++ b/src/IECoreNuke/DrawableHolder.cpp
@@ -176,7 +176,7 @@ IECoreGL::ConstScenePtr DrawableHolder::scene()
 			m_scene->setCamera( 0 );
 
 		}
-		catch( boost::python::error_already_set )
+		catch( boost::python::error_already_set &e )
 		{
 			IECorePython::ScopedGILLock gilLock;
 			PyErr_Print();

--- a/test/IECoreNuke/SceneCacheReaderTest.py
+++ b/test/IECoreNuke/SceneCacheReaderTest.py
@@ -41,6 +41,7 @@ import nuke
 import IECore
 import IECoreImage
 import IECoreNuke
+from six.moves import range
 
 class SceneCacheReaderTest( IECoreNuke.TestCase ) :
 
@@ -60,7 +61,7 @@ class SceneCacheReaderTest( IECoreNuke.TestCase ) :
 		nuke.scriptOpen("test/IECoreNuke/scripts/sceneCacheTest.nk" )
 		w = nuke.toNode("Write1")
 		frames = [ 1, 10, 20, 30, 40, 50, 60, 70, 80 ]
-		nuke.executeMultiple( [ w ], map( lambda f: (f,f,1), frames ) )
+		nuke.executeMultiple( [ w ], [(f,f,1) for f in frames] )
 		for f in frames :
 			imageA = IECore.Reader.create( "test/IECoreNuke/scripts/data/sceneCacheExpectedResults.%04d.exr" % f )()
 			imageB = IECore.Reader.create( "test/IECoreNuke/scripts/data/sceneCacheTestResults.%04d.exr" % f )()
@@ -83,7 +84,7 @@ class SceneCacheReaderTest( IECoreNuke.TestCase ) :
 		nuke.scriptOpen("test/IECoreNuke/scripts/sceneCacheTestUV.nk" )
 		w = nuke.toNode("Write1")
 		frames = [ 1, 10, 20, 30, 40, 50 ]
-		nuke.executeMultiple( [ w ], map( lambda f: (f,f,1), frames ) )
+		nuke.executeMultiple( [ w ], [(f,f,1) for f in frames] )
 		for f in frames :
 			imageA = IECore.Reader.create( "test/IECoreNuke/scripts/data/sceneCacheExpectedUVResults.%04d.exr" % f )()
 			imageB = IECore.Reader.create( "test/IECoreNuke/scripts/data/sceneCacheTestResultsUV.%04d.exr" % f )()


### PR DESCRIPTION
A couple things of note:

- I have built Cortex with gcc 9 c++17 despite Nuke 13 expecting gcc 6 c++14
- I have not really tested 9a62b70a615a05ea0fd3901e3addb65f47b9b114 beyond getting it to compile... I don't think the test suite exercises the `DisplayIop` and I don't yet have a functional IE toolset to try it interactively (requires a Gaffer OCIOv2 update).
- I dropped this Nuke USD override 833587e8718aee0f49b0299f9073d42253c53e4c which it seems should never have been added... I don't know why the 1 mysterious Nuke distro had proper USD headers...