### PR TITLE
IECoreGL::Shader : Support 1D samplers

### DIFF
--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -181,7 +181,7 @@ class Shader::Implementation : public IECore::RefCounted
 						}
 					}
 
-					if( p.type == GL_SAMPLER_2D || p.type == GL_SAMPLER_3D )
+					if( p.type == GL_SAMPLER_1D || p.type == GL_SAMPLER_2D || p.type == GL_SAMPLER_3D )
 					{
 						// we assign a specific texture unit to each individual
 						// sampler parameter - this makes it much easier to save


### PR DESCRIPTION
Pretty simple omission - it prevented shaders generated by OCIO2 from working.