### PR TITLE
SceneCacheData.cpp: expansionRule token removed from header in USD 22.03

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -113,6 +113,7 @@ static InternedString g_ioIndices( "indices" );
 static const SceneInterface::Path g_mayaFpsHeaderPath = { "header", "data", "CompoundObject", "data", "members", "maya", "data", "CompoundDataBase", "data", "members", "frameRate", "data"};
 static const SceneInterface::Path g_houdiniFpsHeaderPath = { "header", "data", "CompoundObject", "data", "members", "houdini", "data", "CompoundDataBase", "data", "members", "frameRate", "data"};
 static const VtValue g_empty = VtValue();
+static const InternedString g_expansionRule( "expansionRule" );
 } // namespace
 
 
@@ -1112,7 +1113,7 @@ void SceneCacheData::addCollections( SpecData& spec, TfTokenVector& properties, 
 		collectionList.push_back( TfToken( boost::str( boost::format( "CollectionAPI:%s" ) % safeCollectionName ) ) );
 
 		// expansion rule
-		TfToken expansionRuleName( boost::str( boost::format( "collection:%s:%s" ) % safeCollectionName % UsdTokens->expansionRule.GetString() ) );
+		TfToken expansionRuleName( boost::str( boost::format( "collection:%s:%s" ) % safeCollectionName % g_expansionRule ) );
 		addProperty(
 			properties,
 			primPath,


### PR DESCRIPTION
- SceneCacheData: Fix compatibility with USD 22.03
  - USD 22.03 removed `expansionRule` token from its header. Hardcoding the property name to continue creating Collection with that property for each `set` from `SceneCache`.


### Related Issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

- List any other unmerged PRs that this PR depends on

### Breaking Changes ###

- List any breaking API/ABI changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
