### PR TITLE
SConstruct : Fix linking against OpenImageIO 2.3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1835,6 +1835,7 @@ imageEnvPrepends = {
 	],
 	"LIBS" : [
 		"OpenImageIO$OIIO_LIB_SUFFIX",
+		"OpenImageIO_Util$OIIO_LIB_SUFFIX",
 	],
 	"CXXFLAGS" : [
 		"-DIECoreImage_EXPORTS",
@@ -2191,6 +2192,7 @@ if env["WITH_GL"] and doConfigure :
 				os.path.basename( imageEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				os.path.basename( sceneEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				"OpenImageIO$OIIO_LIB_SUFFIX",
+				"OpenImageIO_Util$OIIO_LIB_SUFFIX",
 				"GLEW$GLEW_LIB_SUFFIX",
 				"boost_wave$BOOST_LIB_SUFFIX",
 			]


### PR DESCRIPTION
In this version, libOpenImageIO no longer has its own copies of the symbols from libOpenImageIOUtil. Note that, as documented in https://github.com/OpenImageIO/oiio/pull/2906, linking against both libraries in OpenImageIO 2.2 can cause problems. We intend Cortex 10.4 to be used exclusively with OIIO 2.3 and later.
