### PR TITLE
IE Config : Account for no suitable appleseed

### DIFF
--- a/config/ie/buildAll
+++ b/config/ie/buildAll
@@ -117,6 +117,9 @@ if platform in ( "cent7.x86_64", ) :
 		appleseedCompilerMap[compilerVersion].append( appleseedVersion )
 		for pythonVersion in IEEnv.activeVersions( IEEnv.registry["apps"]["python"] ) :
 			build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "APPLESEED_VERSION="+appleseedVersion, "DL_VERSION=UNDEFINED" ] )
+	for appleseedCompiler, versions in appleseedCompilerMap.items() :
+		if len(versions) == 0 :
+			appleseedCompilerMap[appleseedCompiler].append( "UNDEFINED" )
 
 	for mayaVersion in IEEnv.activeAppVersions( "maya" ) :
 		compilerVersion = IEEnv.registry["apps"]["maya"][mayaVersion][platform]["compilerVersion"]


### PR DESCRIPTION
This is a backport of b42c34e000141c473d8bebd1d2e84e76c99443e8, which I'd forgotten is also needed to deploy RB-10.3 at IE