### PR TITLE
CurvesAlgo : Support V2f fully in `resamplePrimitiveVariable()`

### DIFF
--- a/src/IECoreScene/CurvesAlgo.cpp
+++ b/src/IECoreScene/CurvesAlgo.cpp
@@ -52,14 +52,16 @@ namespace
 
 
 // PrimitiveEvaluator only supports certain types
-template< typename T > struct IsPrimitiveEvaluatableTypedData : boost::mpl::and_<
+template< typename T >
+struct IsPrimitiveEvaluatableTypedData : boost::mpl::and_<
 	TypeTraits::IsNumericBasedVectorTypedData<T>,
 	boost::mpl::or_<
-		TypeTraits::IsVec3<typename TypeTraits::VectorValueType<T>::type >,
-	boost::is_same< typename TypeTraits::VectorValueType<T>::type, float >,
-	boost::is_same< typename TypeTraits::VectorValueType<T>::type, int >,
-	TypeTraits::IsColor3<typename TypeTraits::VectorValueType<T>::type >
->
+		TypeTraits::IsVec2<typename TypeTraits::VectorValueType<T>::type>,
+		TypeTraits::IsVec3<typename TypeTraits::VectorValueType<T>::type>,
+		boost::is_same<typename TypeTraits::VectorValueType<T>::type, float>,
+		boost::is_same<typename TypeTraits::VectorValueType<T>::type, int>,
+		TypeTraits::IsColor3<typename TypeTraits::VectorValueType<T>::type>
+	>
 > {};
 
 
@@ -69,6 +71,11 @@ static T evalPrimVar( PrimitiveEvaluator::Result *result, const PrimitiveVariabl
 	throw Exception( "PrimvarResamplerCache : This should never be called because of IsPrimitiveEvaluatableTypedData" );
 }
 
+template<>
+Imath::V2f evalPrimVar<Imath::V2f>( PrimitiveEvaluator::Result *result, const PrimitiveVariable &primVar )
+{
+	return result->vec2PrimVar( primVar );
+}
 
 template<>
 Imath::V3f evalPrimVar<Imath::V3f>( PrimitiveEvaluator::Result *result, const PrimitiveVariable &primVar )

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -1195,6 +1195,24 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 	# endregion
 
+	def testV2fVaryingToVertex( self ) :
+
+		curves = IECoreScene.CurvesPrimitive(
+			IECore.IntVectorData( [ 4 ] ), IECore.CubicBasisf.catmullRom(), False,
+			IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 4 ) ] )
+		)
+
+		uv = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Varying,
+			IECore.V2fVectorData( [ imath.V2f( 0 ), imath.V2f( 1 ) ] )
+		)
+		curves["uv"] = uv
+
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable( curves, uv, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertTrue( curves.arePrimitiveVariablesValid() )
+		self.assertEqual( uv.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( len( uv.data ), 4 )
+
 class CurvesAlgoDeleteCurvesTest ( unittest.TestCase ):
 
 	def createLinearCurves(self):


### PR DESCRIPTION
It was previously unsupported for vertex->varying and varying->vertex conversions.
