### PR TITLE
USDScene : Cache the reading of ShaderNetworks

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.h
@@ -42,6 +42,10 @@
 
 #include "IECore/PathMatcherData.h"
 
+// Included here to avoid it being included indirectly via `stage.h`, inside the
+// scope of IECORE_PUSH_DEFAULT_VISIBILITY.
+#include "boost/function/function_base.hpp"
+
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usd/stage.h"
 IECORE_POP_DEFAULT_VISIBILITY


### PR DESCRIPTION
Typically many prims will all reference the same UsdShadeMaterial, and we want to avoid loading the same material over and over again. This change gives a 10x speedup when loading the Moana island scene in Gaffer.