### PR TITLE
CI : Update to GafferHQ/dependencies 5.0.0a3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
             buildType: RELEASE
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/4.0.0/gafferDependencies-4.0.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
             publish: true
 
@@ -54,7 +54,7 @@ jobs:
             buildType: DEBUG
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/4.0.0/gafferDependencies-4.0.0-Python2-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
             publish: false
 
@@ -63,7 +63,7 @@ jobs:
             buildType: RELEASE
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/4.0.0/gafferDependencies-4.0.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-linux.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
             publish: true
 
@@ -72,7 +72,7 @@ jobs:
             buildType: RELEASE
             containerImage:
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/4.0.0/gafferDependencies-4.0.0-Python2-osx.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.0.0a3/gafferDependencies-5.0.0a3-Python2-osx.tar.gz
             # `testAppleseed` currently omitted due to clashes with system image IO frameworks.
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: true

--- a/.github/workflows/main/options.posix
+++ b/.github/workflows/main/options.posix
@@ -45,7 +45,7 @@ BOOST_LIB_SUFFIX = ""
 
 OPENEXR_INCLUDE_PATH = includes
 OIIO_INCLUDE_PATH = includes
-OIIO_LIB_PATH = libs
+OIIO_LIB_PATH = ""
 OSL_INCLUDE_PATH = includes
 BLOSC_INCLUDE_PATH = includes
 FREETYPE_INCLUDE_PATH = includes + "/freetype2"
@@ -57,7 +57,9 @@ WITH_GL = "1"
 GLEW_INCLUDE_PATH = includes + "/GL"
 
 TBB_INCLUDE_PATH = includes
+
 USD_INCLUDE_PATH = includes
+USD_LIB_PREFIX = "usd_"
 
 # Renderers
 # =========

--- a/SConstruct
+++ b/SConstruct
@@ -1483,6 +1483,9 @@ if testEnv["TEST_LIBPATH"] != "" :
 	testEnvLibPath = testEnv["TEST_LIBPATH"] + os.pathsep + testEnvLibPath
 testEnvLibPath = testEnv.subst( testEnvLibPath )
 
+if testEnv["PLATFORM"] == "darwin" :
+	testEnvLibPath = os.pathsep.join( [ "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/ImageIO.framework/Resources/", testEnvLibPath ] )
+
 testEnv["ENV"][testEnv["TEST_LIBRARY_PATH_ENV_VAR"]] = os.pathsep.join( [ testEnv["ENV"].get(testEnv["TEST_LIBRARY_PATH_ENV_VAR"], ""), testEnvLibPath ] )
 if testEnv["TEST_LIBRARY_PATH_ENV_VAR"] != libraryPathEnvVar :
 	testEnv["ENV"][libraryPathEnvVar] = os.pathsep.join( [ testEnv["ENV"].get(libraryPathEnvVar, ""), testEnvLibPath ] )


### PR DESCRIPTION
This is what we are using for the Gaffer 0.62 test builds.
