### PR TITLE
IECoreUSD : Maintain support for USD 20

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+10.3.4.1 (relative to 10.3.4.0)
+========
+
+Build
+-----
+
+- IECoreUSD : Support for USD 20.??
+
 10.3.4.0 (relative to 10.3.3.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -57,7 +57,7 @@ SConsignFile()
 ieCoreMilestoneVersion = 10 # for announcing major milestones - may contain all of the below
 ieCoreMajorVersion = 3 # backwards-incompatible changes
 ieCoreMinorVersion = 4 # new backwards-compatible features
-ieCorePatchVersion = 0 # bug fixes
+ieCorePatchVersion = 1 # bug fixes
 ieCoreVersionSuffix = "" # used for alpha/beta releases. Example: "a1", "b2", etc.
 
 ###########################################################################################

--- a/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
@@ -44,6 +44,10 @@
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/pointer_cast.hpp"
 
+#if PXR_VERSION < 2102
+#define IsContainer IsNodeGraph
+#endif
+
 namespace
 {
 


### PR DESCRIPTION
USD 20 is still used at IE for cortex 10.3, so we need to make sure the code still builds for it.

This was done following @johnhaddon's suggestions.

