### PR TITLE
USDScene : Register `.usdz` file format

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -1440,5 +1440,6 @@ namespace
 SceneInterface::FileFormatDescription<USDScene> g_descriptionUSD( ".usd", IndexedIO::Read | IndexedIO::Write );
 SceneInterface::FileFormatDescription<USDScene> g_descriptionUSDA( ".usda", IndexedIO::Read | IndexedIO::Write );
 SceneInterface::FileFormatDescription<USDScene> g_descriptionUSDC( ".usdc", IndexedIO::Read | IndexedIO::Write );
+SceneInterface::FileFormatDescription<USDScene> g_descriptionUSDZ( ".usdz", IndexedIO::Read | IndexedIO::Write );
 
 } // namespace


### PR DESCRIPTION
There is a USD API for querying all supported file formats, but it has changed between the USD versions we have active. So rather than do some #ifdefing and filtering to exclude file formats supported directly by our own SceneInterfaces, I've gone the easy route and just added `.usdz` manually for now.