### PR TITLE
Fix the IECoreUSD build for maya with the USD libraries shipped by Autodesk 

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -336,14 +336,15 @@ if targetApp=="maya" :
 		if usdReg :
 			USD_INCLUDE_PATH = os.path.join( usdReg["location"], targetApp, compatibilityVersion, "include" )
 
+			mayaMajorVersion = mayaVersion.split(".")[0]
 			mayaLooseVersion = distutils.version.LooseVersion(mayaVersion)
 			if mayaLooseVersion >= "2022" and mayaLooseVersion < "2023":
 				# Maya 2022 installs the USD libs and the maya plugin itself for python 2 and 3. This is not the case for the 2020 version
 				# We make the assumption, that the python version suffix is for Maya 2022 only, because Maya 2023 will be python 3 exclusively.
 				mayaPythonMajorVersion = mayaReg["pythonVersion"].split(".")[0]
-				USD_LIB_PATH = os.path.join( mayaUsdReg["location"], "mayausd/USD{}/lib".format( mayaPythonMajorVersion ) )
+				USD_LIB_PATH = os.path.join( mayaUsdReg["location"], mayaMajorVersion, "mayausd/USD{}/lib".format( mayaPythonMajorVersion ) )
 			else:
-				USD_LIB_PATH = os.path.join( mayaUsdReg["location"], "mayausd/USD/lib" )
+				USD_LIB_PATH = os.path.join( mayaUsdReg["location"], mayaMajorVersion, "mayausd/USD/lib" )
 
 			# Pixar introduced a library prefix `usd_` in USD v21.11, which Autodesk does not use yet, so we have to reset the prefix.
 			# See https://github.com/Autodesk/maya-usd/issues/2108 for reference

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -93,6 +93,10 @@ using namespace IECoreUSD;
 #define HasAuthoredValue HasAuthoredValueOpinion
 #endif
 
+#if USD_VERSION < 2011
+#define GetPrimInPrototype GetPrimInMaster
+#endif
+
 namespace
 {
 
@@ -105,7 +109,7 @@ void appendPrimOrMasterPath( const pxr::UsdPrim &prim, IECore::MurmurHash &h )
 {
 	if( prim.IsInstanceProxy() )
 	{
-		append( prim.GetPrimInMaster().GetPrimPath(), h );
+		append( prim.GetPrimInPrototype().GetPrimPath(), h );
 	}
 	else
 	{


### PR DESCRIPTION
We stripped the Maya major version part from the `maya-usd` registry location entry, so we have to add it to the `USD_LIB_PATH` when building `IECoreUSD` for maya against the USD libraries shipped by Autodesk.

I further backported a compatibility fix for USD 21.08 from the main branch, which is necessary because `maya-usd` version 0.16.0 is using USD 21.11 and we want to build cortex 10.3 against the `maya-usd` libraries. 
