### PR TITLE
USDScene : Support `doubleSided` attribute

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -56,6 +56,7 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usd/stage.h"
 #include "pxr/usd/usdGeom/bboxCache.h"
 #include "pxr/usd/usdGeom/camera.h"
+#include "pxr/usd/usdGeom/gprim.h"
 #include "pxr/usd/usdGeom/metrics.h"
 #include "pxr/usd/usdGeom/pointInstancer.h"
 #include "pxr/usd/usdGeom/primvar.h"
@@ -803,6 +804,7 @@ namespace
 
 const IECore::InternedString g_purposeAttributeName( "usd:purpose" );
 const IECore::InternedString g_kindAttributeName( "usd:kind" );
+const IECore::InternedString g_doubleSidedAttributeName( "doubleSided" );
 
 } // namespace
 
@@ -827,6 +829,10 @@ bool USDScene::hasAttribute( const SceneInterface::Name &name ) const
 		pxr::UsdModelAPI model( m_location->prim );
 		pxr::TfToken kind;
 		return model.GetKind( &kind );
+	}
+	else if( name == g_doubleSidedAttributeName )
+	{
+		return pxr::UsdGeomGprim( m_location->prim ).GetDoubleSidedAttr().HasAuthoredValue();
 	}
 	else if( auto attribute = AttributeAlgo::findUSDAttribute( m_location->prim, name.string() ) )
 	{
@@ -874,6 +880,11 @@ void USDScene::attributeNames( SceneInterface::NameList &attrs ) const
 	if( pxr::UsdModelAPI( m_location->prim ).GetKind( &kind ) )
 	{
 		attrs.push_back( g_kindAttributeName );
+	}
+
+	if( pxr::UsdGeomGprim( m_location->prim ).GetDoubleSidedAttr().HasAuthoredValue() )
+	{
+		attrs.push_back( g_doubleSidedAttributeName );
 	}
 
 	std::vector<pxr::UsdAttribute> attributes = m_location->prim.GetAuthoredAttributes();
@@ -961,6 +972,16 @@ ConstObjectPtr USDScene::readAttribute( const SceneInterface::Name &name, double
 		}
 		return new StringData( kind.GetString() );
 	}
+	else if( name == g_doubleSidedAttributeName )
+	{
+		pxr::UsdAttribute attr = pxr::UsdGeomGprim( m_location->prim ).GetDoubleSidedAttr();
+		bool doubleSided;
+		if( attr.HasAuthoredValue() && attr.Get( &doubleSided, m_root->getTime( time ) ) )
+		{
+			return new BoolData( doubleSided );
+		}
+		return nullptr;
+	}
 	else if( pxr::UsdAttribute attribute = AttributeAlgo::findUSDAttribute( m_location->prim, name.string() ) )
 	{
 		return DataAlgo::fromUSD( attribute, m_root->getTime( time ) );
@@ -1018,6 +1039,28 @@ void USDScene::writeAttribute( const SceneInterface::Name &name, const Object *a
 				IECore::msg(
 					IECore::Msg::Warning, "USDScene::writeAttribute",
 					boost::format( "Unable to write kind \"%1%\" to \"%2%\"" ) % data->readable() % m_location->prim.GetPath()
+				);
+			}
+		}
+	}
+	else if( name == g_doubleSidedAttributeName )
+	{
+		if( auto *data = reportedCast<const BoolData>( attribute, "USDScene::writeAttribute", name.c_str() ) )
+		{
+			pxr::UsdGeomGprim gprim( m_location->prim );
+			if( gprim )
+			{
+				gprim.GetDoubleSidedAttr().Set( data->readable(), m_root->getTime( time ) );
+			}
+			else
+			{
+				// We're hamstrung by the fact that USD considers `doubleSided` to be a property
+				// of a Gprim and not an inheritable attribute as it was in RenderMan and is in Cortex.
+				// We can't author a Gprim here, because it isn't a concrete type, so we must rely on
+				// `writeObject()` having been called first to get a suitable concrete type in place.
+				IECore::msg(
+					IECore::Msg::Warning, "USDScene::writeAttribute",
+					boost::format( "Unable to write attribute \"%1%\" to \"%2%\", because it is not a Gprim" ) % name % m_location->prim.GetPath()
 				);
 			}
 		}
@@ -1354,6 +1397,13 @@ void USDScene::attributesHash( double time, IECore::MurmurHash &h ) const
 	{
 		haveAttributes = true;
 		// Kind can not be animated so no need to update `mightBeTimeVarying`.
+	}
+
+	auto doubleSidedAttr = pxr::UsdGeomGprim( m_location->prim ).GetDoubleSidedAttr();
+	if( doubleSidedAttr && doubleSidedAttr.HasAuthoredValue() )
+	{
+		haveAttributes = true;
+		mightBeTimeVarying |= doubleSidedAttr.ValueMightBeTimeVarying();
 	}
 
 	std::vector<pxr::UsdAttribute> attributes = m_location->prim.GetAuthoredAttributes();

--- a/contrib/IECoreUSD/test/IECoreUSD/data/doubleSidedAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/doubleSidedAttribute.usda
@@ -1,0 +1,16 @@
+#usda 1.0
+
+def Sphere "doubleSidedSphere"
+{
+    uniform bool doubleSided = 1
+}
+
+def Sphere "singleSidedSphere"
+{
+    uniform bool doubleSided = 0
+}
+
+def Sphere "sphere"
+{
+}
+


### PR DESCRIPTION
Write support is not ideal, because USD will only author `doubleSided` onto Gprims. So it is impossible to write onto transform-only locations, and `writeObject()` must be called before `writeAttribute()` on geometric locations. It may be possible to improve on this by buffering attributes and automatically inheriting them from transforms onto primitives, but it's not clear that the complexity is justified at this point. I'll open a separate Gaffer PR to make sure that the SceneWriter adheres to the "write objects first" requirement.

