### PR TITLE
Match default compiler warning flags to Gaffer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -195,7 +195,7 @@ jobs:
         sleep 20
         # Print SCons logs and MacOS crash logs
         shopt -s nullglob
-        for logFile in buildConfig.log ~/Library/Logs/DiagnosticReports/*.crash
+        for logFile in config.log buildConfig.log ~/Library/Logs/DiagnosticReports/*.crash
         do
          echo $logFile
          cat $logFile

--- a/SConstruct
+++ b/SConstruct
@@ -81,13 +81,14 @@ except NameError :
 o.Add(
 	"CXX",
 	"The C++ compiler.",
-	"g++" if Environment()["PLATFORM"] != "win32" else "cl",
+	{"darwin" : "clang++", "win32" : "cl"}.get(Environment()["PLATFORM"], "g++")
+
 )
 
 o.Add(
 	"CXXFLAGS",
 	"The extra flags to pass to the C++ compiler during compilation.",
-	[ "-pipe", "-Wall" ] if Environment()["PLATFORM"] != "win32" else [],
+	[ "-pipe", "-Wall", "-Wextra" ] if Environment()["PLATFORM"] != "win32" else [],
 )
 
 o.Add(
@@ -1118,8 +1119,13 @@ if env["PLATFORM"] != "win32" :
 
 	env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )
 
+	if "g++" in os.path.basename( env["CXX"] ) :
+		# Turn off the parts of `-Wextra` that we don't like.
+		env.Append( CXXFLAGS = [ "-Wno-cast-function-type", "-Wno-unused-parameter" ] )
+
 	if "clang++" in os.path.basename( env["CXX"] ) :
-		env.Append( CXXFLAGS = ["-Wno-unused-local-typedef"] )
+		# Turn off the parts of `-Wall` and `-Wextra` that we don't like.
+		env.Append( CXXFLAGS = ["-Wno-unused-local-typedef", "-Wno-unused-parameter"] )
 
 	if env["ASAN"] :
 		env.Append(

--- a/SConstruct
+++ b/SConstruct
@@ -1110,7 +1110,7 @@ if env["PLATFORM"] != "win32" :
 			env.Append( CXXFLAGS = [ "-Wno-unused-local-typedef", "-Wno-deprecated-declarations" ] )
 
 	elif env["PLATFORM"]=="posix" :
-		if "g++" in os.path.basename( env["CXX"] ) :
+		if "g++" in os.path.basename( env["CXX"] ) and not "clang++" in os.path.basename( env["CXX"] ) :
 			gccVersion = subprocess.check_output( [ env["CXX"], "-dumpversion" ], env=env["ENV"], universal_newlines=True )
 			gccVersion = gccVersion.strip()
 			gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
@@ -1119,13 +1119,13 @@ if env["PLATFORM"] != "win32" :
 
 	env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )
 
-	if "g++" in os.path.basename( env["CXX"] ) :
-		# Turn off the parts of `-Wextra` that we don't like.
-		env.Append( CXXFLAGS = [ "-Wno-cast-function-type", "-Wno-unused-parameter" ] )
-
 	if "clang++" in os.path.basename( env["CXX"] ) :
 		# Turn off the parts of `-Wall` and `-Wextra` that we don't like.
 		env.Append( CXXFLAGS = ["-Wno-unused-local-typedef", "-Wno-unused-parameter"] )
+
+	elif "g++" in os.path.basename( env["CXX"] ) :
+		# Turn off the parts of `-Wextra` that we don't like.
+		env.Append( CXXFLAGS = [ "-Wno-cast-function-type", "-Wno-unused-parameter" ] )
 
 	if env["ASAN"] :
 		env.Append(

--- a/config/ie/options
+++ b/config/ie/options
@@ -65,6 +65,7 @@ pythonVersion = getOption( "PYTHON_VERSION", None )
 sixVersion = getOption( "SIX_VERSION", "1.14.0" )
 targetApp = getOption( "APP", None )
 
+
 # get cortex config information from the registry. if we have setting specific to this platform then use them, otherwise
 # fall back to the generic settings for this compatibility version.
 
@@ -166,7 +167,7 @@ else :
 if not m :
 	raise RuntimeError( "Cannot determine compiler version (%s)" % compilerVersion )
 
-CXXFLAGS = [ "-pipe", "-Wall", "-pthread" ]
+CXXFLAGS = [ "-pipe", "-Wall", "-Wextra", "-pthread" ]
 
 LINKFLAGS = []
 

--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
@@ -547,6 +547,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 						scalarPropertyReader->getSample( sampleIndex, &value );
 						return new IECore::Color4fData( C4f( value[0] / 255.0f, value[1] / 255.0f, value[2] / 255.0f, value[3] / 255.0f ) );
 					}
+					break;
 				}
 				case kInt8POD:
 				{
@@ -597,6 +598,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 						default:
 							break;
 					}
+					break;
 				}
 				case kUint32POD:
 				{
@@ -641,6 +643,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 						default:
 							break;
 					}
+					break;
 				}
 				case kUint64POD:
 				{
@@ -680,6 +683,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 							return new IECore::Color4fData( C4f( value[0], value[1], value[2], value[3] ) );
 						}
 					}
+					break;
 				}
 				case kFloat32POD:
 				{
@@ -710,6 +714,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 							{
 								return new IECore::Color3fData( C3f( value[0], value[1], value[2] ) );
 							}
+							break;
 						}
 						case 4:
 						{
@@ -728,6 +733,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 							{
 								return new IECore::Color4fData( C4f( tmpValue[0], tmpValue[1], tmpValue[2], tmpValue[3] ) );
 							}
+							break;
 						}
 						case 6:
 						{
@@ -773,6 +779,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 						default:
 							break;
 					}
+					break;
 				}
 				case kFloat64POD:
 				{
@@ -808,6 +815,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 							{
 								return new IECore::Box2dData( Box2d( V2d( tmpValue[0], tmpValue[1] ), V2d( tmpValue[2], tmpValue[3] ) ) );
 							}
+							break;
 						}
 						case 6:
 						{
@@ -853,7 +861,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 						default:
 							break;
 					}
-
+					break;
 				}
 
 				case kStringPOD:

--- a/contrib/IECoreAlembic/src/IECoreAlembic/CurvesReader.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/CurvesReader.cpp
@@ -68,6 +68,7 @@ CubicBasisf convertBasis( const ICurvesSchema::Sample &sample )
 					return CubicBasisf::bSpline();
 				case kHermiteBasis :
 				case kPowerBasis :
+				default :
 					IECore::msg( IECore::Msg::Warning, "CurvesAlgo::convert", "Unsupported basis" );
 					return CubicBasisf::bSpline();
 			}

--- a/include/IECore/InternedString.h
+++ b/include/IECore/InternedString.h
@@ -66,9 +66,12 @@ class IECORE_API InternedString
 
 		inline InternedString();
 		inline InternedString( const std::string &value );
-		inline InternedString( const InternedString &other );
 		inline InternedString( const char *value );
 		inline InternedString( const char *value, size_t length );
+
+		InternedString( const InternedString &other ) = default;
+		InternedString &operator= ( const InternedString &rhs ) = default;
+		~InternedString() = default;
 
 #if BOOST_VERSION > 105500
 
@@ -77,8 +80,6 @@ class IECORE_API InternedString
 #endif
 
 		inline InternedString( int64_t number );
-
-		inline ~InternedString();
 
 		// The equality operators are extremely fast because they
 		// need only compare the address of the internal string,

--- a/include/IECore/InternedString.inl
+++ b/include/IECore/InternedString.inl
@@ -48,11 +48,6 @@ inline InternedString::InternedString( const std::string &value )
 {
 }
 
-inline InternedString::InternedString( const InternedString &other )
-	:	m_value( other.m_value )
-{
-}
-
 inline InternedString::InternedString( const char *value )
 	:	m_value( internedString( value ) )
 {
@@ -74,10 +69,6 @@ inline InternedString::InternedString( const boost::string_view &value )
 
 inline InternedString::InternedString( int64_t number )
 	: m_value( numberString( number ).m_value )
-{
-}
-
-inline InternedString::~InternedString()
 {
 }
 

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -125,23 +125,37 @@ inline void MurmurHash::appendRaw( const void *data, size_t bytes, int elementSi
 	switch( bytes & 15)
 	{
 	case 15: k2 ^= uint64_t(tail[14]) << 48;
+		[[fallthrough]];
 	case 14: k2 ^= uint64_t(tail[13]) << 40;
+		[[fallthrough]];
 	case 13: k2 ^= uint64_t(tail[12]) << 32;
+		[[fallthrough]];
 	case 12: k2 ^= uint64_t(tail[11]) << 24;
+		[[fallthrough]];
 	case 11: k2 ^= uint64_t(tail[10]) << 16;
+		[[fallthrough]];
 	case 10: k2 ^= uint64_t(tail[ 9]) << 8;
+		[[fallthrough]];
 	case  9: k2 ^= uint64_t(tail[ 8]) << 0;
-		   k2 *= c2; k2  = rotl64(k2,33); k2 *= c1; h2 ^= k2;
+		k2 *= c2; k2  = rotl64(k2,33); k2 *= c1; h2 ^= k2;
+		[[fallthrough]];
 
 	case  8: k1 ^= uint64_t(tail[ 7]) << 56;
+		[[fallthrough]];
 	case  7: k1 ^= uint64_t(tail[ 6]) << 48;
+		[[fallthrough]];
 	case  6: k1 ^= uint64_t(tail[ 5]) << 40;
+		[[fallthrough]];
 	case  5: k1 ^= uint64_t(tail[ 4]) << 32;
+		[[fallthrough]];
 	case  4: k1 ^= uint64_t(tail[ 3]) << 24;
+		[[fallthrough]];
 	case  3: k1 ^= uint64_t(tail[ 2]) << 16;
+		[[fallthrough]];
 	case  2: k1 ^= uint64_t(tail[ 1]) << 8;
+		[[fallthrough]];
 	case  1: k1 ^= uint64_t(tail[ 0]) << 0;
-		   k1 *= c1; k1  = rotl64(k1,31); k1 *= c2; h1 ^= k1;
+		k1 *= c1; k1  = rotl64(k1,31); k1 *= c2; h1 ^= k1;
 	};
 
 	// finalisation

--- a/include/IECore/PathMatcher.h
+++ b/include/IECore/PathMatcher.h
@@ -68,9 +68,11 @@ class IECORE_API PathMatcher
 		};
 
 		PathMatcher();
-		/// Copy constructor. Uses lazy-copy-on-write so
-		/// that copies are cheap until edited.
-		PathMatcher( const PathMatcher &other );
+		/// We use lazy-copy-on-write so that copies are cheap until edited.
+		/// This means we can use default copy and assignment
+		PathMatcher( const PathMatcher &other ) = default;
+		PathMatcher& operator= ( const PathMatcher &other ) = default;
+		~PathMatcher() = default;
 
 		template<typename PathIterator>
 		PathMatcher( PathIterator pathsBegin, PathIterator pathsEnd );

--- a/include/IECore/StringAlgo.inl
+++ b/include/IECore/StringAlgo.inl
@@ -76,12 +76,11 @@ inline bool matchCharacterClass( char c, const char *&pattern )
 					}
 					continue;
 				}
-				else
-				{
-					// The '-' was at the start or end of the
-					// pattern, fall through to treat it
-					// as a regular character below.
-				}
+
+				// The '-' was at the start or end of the
+				// pattern, fall through to treat it
+				// as a regular character below.
+				[[fallthrough]];
 			default :
 				if( d == c )
 				{
@@ -160,7 +159,7 @@ inline bool matchInternal( const char *s, const char *&pattern, bool spaceTermin
 					return *s == '\0';
 				}
 				// Fall through to default
-
+				[[fallthrough]];
 			default :
 
 				if( c != *s++ )

--- a/include/IECore/TransformationMatrix.h
+++ b/include/IECore/TransformationMatrix.h
@@ -75,8 +75,10 @@ class IECORE_EXPORT TransformationMatrix
 		/// Basic constructor for setting common parameters: scale, rotate and translate.
 		TransformationMatrix( const Imath::Vec3< T > &s, const Imath::Euler< T > &r, const Imath::Vec3< T > &t );
 
-		/// Copy constructor
-		TransformationMatrix( const TransformationMatrix &cp );
+		/// Copying and assignment just sets all members, so we can use the defaults
+		TransformationMatrix( const TransformationMatrix &cp ) = default;
+		TransformationMatrix & operator= ( const TransformationMatrix &rhs ) = default;
+		~TransformationMatrix() = default;
 
 		/// Returns the transform this object represents.
 		Imath::Matrix44<T> transform( ) const;

--- a/include/IECore/TransformationMatrix.inl
+++ b/include/IECore/TransformationMatrix.inl
@@ -52,14 +52,6 @@ TransformationMatrix<T>::TransformationMatrix( const Imath::Vec3< T > &s, const 
 }
 
 template <class T>
-TransformationMatrix<T>::TransformationMatrix( const TransformationMatrix &cp ) :
-		scalePivot( cp.scalePivot ), scale( cp.scale ), shear( cp.shear ), scalePivotTranslation( cp.scalePivotTranslation ),
-						rotatePivot( cp.rotatePivot ), rotationOrientation( cp.rotationOrientation ), rotate( cp.rotate ),
-						rotatePivotTranslation( cp.rotatePivotTranslation ), translate( cp.translate )
-{
-}
-
-template <class T>
 Imath::Matrix44<T> TransformationMatrix<T>::transform( ) const
 {
 	return Imath::Matrix44<T>().setTranslation( -scalePivot ) * Imath::Matrix44<T>().setScale( scale ) * Imath::Matrix44<T>().setShear( shear ) * Imath::Matrix44<T>().setTranslation( scalePivot + scalePivotTranslation - rotatePivot ) * rotationOrientation.normalized().toMatrix44() * rotate.toMatrix44() * Imath::Matrix44<T>().setTranslation( rotatePivot + rotatePivotTranslation + translate );

--- a/include/IECoreScene/PolygonIterator.h
+++ b/include/IECoreScene/PolygonIterator.h
@@ -65,7 +65,9 @@ class IECORESCENE_API PolygonIterator
 		inline bool operator==( const PolygonIterator &rhs ) const;
 		inline bool operator!=( const PolygonIterator &rhs ) const;
 
-		inline PolygonIterator &operator=( const PolygonIterator &rhs );
+		PolygonIterator &operator=( const PolygonIterator &rhs ) = default;
+		PolygonIterator( const PolygonIterator &p ) = default;
+		~PolygonIterator() = default;
 
 		/// Returns an iterator to the beginning of the range of vertex interpolated values
 		/// for this polygon. Typically you should pass PrimitiveVariable::data::readable()::begin()

--- a/include/IECoreScene/PolygonIterator.inl
+++ b/include/IECoreScene/PolygonIterator.inl
@@ -71,14 +71,6 @@ inline bool PolygonIterator::operator!=( const PolygonIterator &rhs ) const
 	return ! operator==( rhs );
 }
 
-inline PolygonIterator &PolygonIterator::operator=( const PolygonIterator &rhs )
-{
-	m_vertexIndexIterator = rhs.m_vertexIndexIterator;
-	m_numVerticesIterator = rhs.m_numVerticesIterator;
-	m_faceVaryingOffset = rhs.m_faceVaryingOffset;
-	return *this;
-}
-
 template<typename ValueIterator>
 PolygonVertexIterator<ValueIterator> PolygonIterator::vertexBegin( ValueIterator valuesBegin ) const
 {

--- a/include/IECoreScene/PolygonVertexIterator.h
+++ b/include/IECoreScene/PolygonVertexIterator.h
@@ -71,7 +71,9 @@ class PolygonVertexIterator
 		bool operator==( const PolygonVertexIterator &rhs ) const;
 		bool operator!=( const PolygonVertexIterator &rhs ) const;
 
-		PolygonVertexIterator &operator=( const PolygonVertexIterator &rhs );
+		PolygonVertexIterator &operator=( const PolygonVertexIterator &rhs ) = default;
+		PolygonVertexIterator( const PolygonVertexIterator &p ) = default;
+		~PolygonVertexIterator() = default;
 
 	private :
 

--- a/include/IECoreScene/PolygonVertexIterator.inl
+++ b/include/IECoreScene/PolygonVertexIterator.inl
@@ -88,14 +88,6 @@ bool PolygonVertexIterator<VertexValueIterator, VertexIndexIterator>::operator!=
 	return ! operator==( rhs );
 }
 
-template<typename VertexValueIterator, typename VertexIndexIterator>
-PolygonVertexIterator<VertexValueIterator, VertexIndexIterator> &PolygonVertexIterator<VertexValueIterator, VertexIndexIterator>::operator=( const PolygonVertexIterator &rhs )
-{
-	m_vertexValuesBegin = rhs.m_vertexValuesBegin;
-	m_vertexIndexIterator = rhs.m_vertexIndexIterator;
-	return *this;
-}
-
 } // namespace IECoreScene
 
 #endif // IECORESCENE_POLYGONVERTEXITERATOR_INL

--- a/include/IECoreScene/PrimitiveVariable.h
+++ b/include/IECoreScene/PrimitiveVariable.h
@@ -72,8 +72,11 @@ struct IECORESCENE_API PrimitiveVariable
 	PrimitiveVariable( Interpolation i, IECore::DataPtr d );
 	/// Constructor - Data is not copied but referenced directly.
 	PrimitiveVariable( Interpolation i, IECore::DataPtr d, IECore::IntVectorDataPtr indices );
-	/// Shallow copy constructor - data is not copied just rereferenced
-	PrimitiveVariable( const PrimitiveVariable &other );
+	/// It's OK to make shallow copies where the data is not copied just rereferenced,
+	/// so we can use default copy and assignment
+	PrimitiveVariable( const PrimitiveVariable &other ) = default;
+	PrimitiveVariable & operator= ( const PrimitiveVariable &rhs ) = default;
+	~PrimitiveVariable() = default;
 
 	/// Copy constructor which optionally allows a deep copy of data
 	/// to be taken.

--- a/src/IECore/DataCastOp.cpp
+++ b/src/IECore/DataCastOp.cpp
@@ -526,6 +526,7 @@ ObjectPtr DataCastOp::doOperation( const CompoundObject * operands )
 				CASTVECTORDATA( DoubleVector, Box3dVector )
 				default:	break;
 			}
+			break;
 		case HalfVectorDataTypeId:
 			switch ( targetType )
 			{

--- a/src/IECore/PathMatcher.cpp
+++ b/src/IECore/PathMatcher.cpp
@@ -172,11 +172,6 @@ PathMatcher::PathMatcher()
 {
 }
 
-PathMatcher::PathMatcher( const PathMatcher &other )
-	:	m_root( other.m_root )
-{
-}
-
 PathMatcher::PathMatcher( const NodePtr &root )
 	:	m_root( root )
 {

--- a/src/IECoreScene/PDCParticleWriter.cpp
+++ b/src/IECoreScene/PDCParticleWriter.cpp
@@ -188,6 +188,7 @@ void PDCParticleWriter::doWrite( const CompoundObject *operands )
 					castOp.targetTypeParameter()->setNumericValue( DoubleVectorDataTypeId );
 					attr = boost::static_pointer_cast<DoubleVectorData>( castOp.operate() );
 				} // intentionally falling through
+				[[fallthrough]];
 			case DoubleVectorDataTypeId :
 				{
 					int type = 3; type = asBigEndian( type );
@@ -204,6 +205,7 @@ void PDCParticleWriter::doWrite( const CompoundObject *operands )
 					castOp.targetTypeParameter()->setNumericValue( V3dVectorDataTypeId );
 					attr = boost::static_pointer_cast<V3dVectorData>( castOp.operate() );
 				} // intentionally falling through
+				[[fallthrough]];
 			case V3dVectorDataTypeId :
 				{
 					int type = 5; type = asBigEndian( type );
@@ -227,6 +229,7 @@ void PDCParticleWriter::doWrite( const CompoundObject *operands )
 					castOp.targetTypeParameter()->setNumericValue( DoubleDataTypeId );
 					attr = boost::static_pointer_cast<DoubleData>( castOp.operate() );
 				} // intentionally falling through
+				[[fallthrough]];
 			case DoubleDataTypeId :
 				{
 					int type = 2; type = asBigEndian( type );
@@ -243,6 +246,7 @@ void PDCParticleWriter::doWrite( const CompoundObject *operands )
 					castOp.targetTypeParameter()->setNumericValue( V3dDataTypeId );
 					attr = boost::static_pointer_cast<V3dData>( castOp.operate() );
 				} // intentionally falling through
+				[[fallthrough]];
 			case V3dDataTypeId :
 				{
 					int type = 4; type = asBigEndian( type );

--- a/src/IECoreScene/PrimitiveVariable.cpp
+++ b/src/IECoreScene/PrimitiveVariable.cpp
@@ -55,13 +55,6 @@ PrimitiveVariable::PrimitiveVariable( Interpolation i, DataPtr d, IntVectorDataP
 {
 }
 
-PrimitiveVariable::PrimitiveVariable( const PrimitiveVariable &other )
-{
-	interpolation = other.interpolation;
-	data = other.data;
-	indices = other.indices;
-}
-
 PrimitiveVariable::PrimitiveVariable( const PrimitiveVariable &other, bool deepCopy )
 {
 	interpolation = other.interpolation;

--- a/src/IECoreScene/SpherePrimitiveEvaluator.cpp
+++ b/src/IECoreScene/SpherePrimitiveEvaluator.cpp
@@ -431,7 +431,6 @@ int SpherePrimitiveEvaluator::intersectionPoints( const Imath::V3f &origin, cons
 		}
 	}
 
-	assert( results.size() >= 0 );
 	assert( results.size() <= 2 );
 
 	return results.size();


### PR DESCRIPTION
I've tried to also match the fixes to how things were fixed in Gaffer.

The most possibly contentious is probably switching to defaulted copy/assignment - maybe some of these cases are philosophical special enough that they deserve user implementation, despite that user implementation being identical to the default?  My reason for using default is that in all these cases we were relying on default behaviour for either copying or assignment.

I also explicitly defaulted the destructors ... not quite sure why, but it matches what you did in Gaffer.