### PR TITLE
SConstruct : Silence OpenGL deprecations on MacOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2211,7 +2211,8 @@ if env["WITH_GL"] and doConfigure :
 			glEnv.Append(
 				FRAMEWORKS = [
 					"OpenGL",
-				]
+				],
+				CPPDEFINES = [ "GL_SILENCE_DEPRECATION" ],
 			)
 		elif env["PLATFORM"] == "win32" :
 			glEnv.Append(


### PR DESCRIPTION
One such example being :

```
src/IECoreGL/Debug.cpp:59:30: error: 'gluErrorString' is deprecated: first deprecated in macOS 10.9 - OpenGL API deprecated. (Define GL_SILENCE_DEPRECATION to silence these warnings) [-Werror,-Wdeprecated-declarations]
```

We really need to modernise our use of OpenGL, but that's a much bigger endeavour.
