### PR TITLE
IECoreGL Buffer/Primitive accessors

### DIFF
--- a/include/IECoreGL/Buffer.h
+++ b/include/IECoreGL/Buffer.h
@@ -62,6 +62,12 @@ class IECOREGL_API Buffer : public IECore::RunTimeTyped
 		/// Deletes the buffer with glDeleteBuffers().
 		~Buffer() override;
 
+		/// Returns the GL handle for the buffer. Note that this is
+		/// owned by the Buffer class and will be destroyed in the
+		/// destructor - you must therefore not call glDeleteBuffers()
+		/// yourself.
+		GLuint buffer() const;
+
 		/// Returns the size of the buffer in bytes.
 		size_t size() const;
 

--- a/include/IECoreGL/Primitive.h
+++ b/include/IECoreGL/Primitive.h
@@ -37,6 +37,7 @@
 
 #include "IECoreGL/Export.h"
 #include "IECoreGL/GL.h"
+#include "IECoreGL/Buffer.h"
 #include "IECoreGL/Renderable.h"
 #include "IECoreGL/Shader.h"
 #include "IECoreGL/TypedStateComponent.h"
@@ -164,6 +165,12 @@ class IECOREGL_API Primitive : public Renderable
 		typedef TypedStateComponent<bool, PrimitiveTransparencySortStateComponentTypeId> TransparencySort;
 		IE_CORE_DECLAREPTR( TransparencySort );
 		//@}
+
+		/// Call to retrieve the buffer for a previously registered vertex attribute.
+		ConstBufferPtr getVertexBuffer( const std::string &name ) const;
+
+		/// Call to determine the number of vertices in each registered vertex attribute.
+		size_t getVertexCount() const;
 
 	protected :
 

--- a/src/IECoreGL/Buffer.cpp
+++ b/src/IECoreGL/Buffer.cpp
@@ -94,6 +94,11 @@ Buffer::~Buffer()
 	glDeleteBuffers( 1, &m_buffer );
 }
 
+GLuint Buffer::buffer() const
+{
+	return m_buffer;
+}
+
 size_t Buffer::size() const
 {
 	ScopedBinding binding( *this, GL_ARRAY_BUFFER );


### PR DESCRIPTION
Provide public access to the OpenGL buffer name managed by IECoreGL::Buffer so that external code can use OpenGL functions and functionality not available through IECoreGL.
Provide public access to the processed and cached vertex attribute data stored by IECoreGL::Primitive. This allows external code to pass the vertex attribute data pointer to IECoreGL's toGLConverter and make use of the cached OpenGL buffers used by IECoreGL's renderer without having to duplicate processing or data.

### Related Issues ###

None

### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
