### PR TITLE
USDScene : Fix `attributesHash()` to consider UsdLuxLights

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -1423,6 +1423,15 @@ void USDScene::attributesHash( double time, IECore::MurmurHash &h ) const
 		// Kind can not be animated so no need to update `mightBeTimeVarying`.
 	}
 
+#if PXR_VERSION >= 2111
+	if( m_location->prim.HasAPI<pxr::UsdLuxLightAPI>() )
+	{
+		/// \todo Consider time-varying lights - see comment below
+		/// for materials.
+		haveAttributes = true;
+	}
+#endif
+
 	auto doubleSidedAttr = pxr::UsdGeomGprim( m_location->prim ).GetDoubleSidedAttr();
 	if( doubleSidedAttr && doubleSidedAttr.HasAuthoredValue() )
 	{

--- a/contrib/IECoreUSD/test/IECoreUSD/data/twoLights.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/twoLights.usda
@@ -1,0 +1,17 @@
+#usda 1.0
+
+def Xform "NoLight" ()
+{
+}
+
+def SphereLight "Light1" (
+)
+{
+	float inputs:exposure = 1
+}
+
+def SphereLight "Light2" (
+)
+{
+	float inputs:exposure = 2
+}


### PR DESCRIPTION
This fixes problems where the light shaders weren't loading in Gaffer at all, because the hash matched other locations where there was no light.
