### PR TITLE
Fix More Compile Issues With -Wextra

### DIFF
--- a/src/IECoreMaya/ImageFile.cpp
+++ b/src/IECoreMaya/ImageFile.cpp
@@ -290,8 +290,10 @@ MStatus ImageFile::glLoad( const MImageFileInfo& info, unsigned int idx )
 	{
 		case 3:
 			glTexImage2D( GL_TEXTURE_2D, 0, GL_RGB, m_width, m_height, 0, GL_RGB, GL_FLOAT, &pixels[0] );
+			break;
 		case 4:
 			glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA, m_width, m_height, 0, GL_RGBA, GL_FLOAT, &pixels[0] );
+			break;
 		default:
 			assert(false);
 	}

--- a/src/IECoreNuke/DisplayIop.cpp
+++ b/src/IECoreNuke/DisplayIop.cpp
@@ -65,7 +65,7 @@ using namespace Imath;
 typedef LRUCache<int, DisplayDriverServerPtr> ServerCache;
 
 // key is the port number for the server.
-static DisplayDriverServerPtr serverCacheGetter( int key, size_t cost )
+static DisplayDriverServerPtr serverCacheGetter( int key, size_t &cost )
 {
 	cost = 1;
 	return new DisplayDriverServer( key );

--- a/src/IECoreNuke/FromNukeCameraConverter.cpp
+++ b/src/IECoreNuke/FromNukeCameraConverter.cpp
@@ -79,6 +79,7 @@ IECore::ObjectPtr FromNukeCameraConverter::doConversion( IECore::ConstCompoundOb
 		case DD::Image::CameraOp::LENS_RENDER_CAMERA :
 			msg( Msg::Warning, "FromNukeCameraConverter::doConversion", "Unsupported projection type - reverting to orthographic" );
 			// fall through to orthographic code
+			[[fallthrough]];
 		case DD::Image::CameraOp::LENS_ORTHOGRAPHIC :
 		{
 			result->setProjection( "orthographic" );


### PR DESCRIPTION
This is a follow up to my previous PR where I started compiling with -Wextra.  I hadn't caught some issues in parts of Cortex that aren't built by CI.

This now builds with config/ie/buildAll, so hopefully it's all good.

Note that 2 of the 3 fixes appear to be actual bugs ( failing to set the cost of the cache getter might be an actual issue, the IECoreMaya::ImageFile GL problem definitely looks like it would scramble the data and/or crash ).  Ideally, these fixes would have tests, but since it's currently broken and no one cares, I haven't bothered.