### PR TITLE
Allow Manually Created Textures in IECoreGL::Shader::Setup

### DIFF
--- a/include/IECoreGL/Shader.h
+++ b/include/IECoreGL/Shader.h
@@ -158,6 +158,12 @@ class IECOREGL_API Shader : public IECore::RunTimeTyped
 
 				const Shader *shader() const;
 
+				/// \todo : This function currently has a special hidden feature to compensate for not being
+				/// able to change ABI at the moment.  While Texture itself currently only supports 2D textures,
+				/// if you pass a Texture into this function, it will just be treated as a container for a GL
+				/// texture ID, and the target type for the texture will be deduced from the type of the
+				/// corresponding sampler uniform.  Once we can add targetType to Texture, we can clean all
+				/// this up.
 				void addUniformParameter( const std::string &name, ConstTexturePtr value );
 				void addUniformParameter( const std::string &name, IECore::ConstDataPtr value );
 				/// Binds the specified value to the named vertex attribute. The divisor will be passed to

--- a/include/IECoreGL/Texture.h
+++ b/include/IECoreGL/Texture.h
@@ -96,6 +96,10 @@ class IECOREGL_API Texture : public Bindable
 		/// Derived classes must set this in their constructor.
 		GLuint m_texture;
 
+		// \todo : Needed by hack in Shader::Setup::MemberData::TextureValue until we are able
+		// to break ABI and add targetType support to Texture
+		friend class Shader;
+
 };
 
 IE_CORE_DECLAREPTR( Texture );


### PR DESCRIPTION
I've left the V1 commit in the history, even though we agreed that we won't be using that approach.

Thinking about trying to actually use Texture to store the textures, adding API to Shader::Setup that takes a separate target felt very wrong, since the target is so clearly part of the Texture - in particular, there wouldn't be any nice path forward for code written using this weird API.

What I've ended up with here is a subclass RawTexture that adds the target type.
Pros:  No modification needed to Shader::Setup API.  Decent path forward in the long run - once we can change the API, RawTexture becomes a synonym/shim for Texture.
Cons:  Some weird friend declarations needed to mess around with private stuff in the meantime.  Shader::ScopedBinding doesn't work with RawTexture ( because ~ScopedBinding can't have any way to access the Texture or its type without breaking ABI ).  I was feeling pretty proud of this plan until I realized that spanner in the works, but at least I can error clearly on that case, so maybe it's still OK?

Or maybe this was all a waste of time and I should have just gone with implementing the weird API on Shader::Setup::addUniformParameterWithOverriddenTextureTarget?