### PR TITLE
IECoreGL::Buffer : Export `ScopedBinding` symbol

### DIFF
--- a/include/IECoreGL/Buffer.h
+++ b/include/IECoreGL/Buffer.h
@@ -74,7 +74,7 @@ class IECOREGL_API Buffer : public IECore::RunTimeTyped
 		/// The ScopedBinding class allows the buffer to be bound to a target
 		/// for a specific duration, without worrying about remembering to
 		/// unbind it.
-		class ScopedBinding
+		class IECOREGL_API ScopedBinding
 		{
 
 			public :


### PR DESCRIPTION
This symbol is needed in particular by https://github.com/GafferHQ/gaffer/pull/4767.

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
