### PR TITLE
IECoreMaya : Fixed various SceneShape drawing bugs.

### DIFF
--- a/include/IECoreMaya/LiveScene.h
+++ b/include/IECoreMaya/LiveScene.h
@@ -78,9 +78,6 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		/// Name of maya attribute overriding `IECoreScene::SceneInterface::visibilityName`
 		static IECoreScene::SceneInterface::Name visibilityOverrideName;
 
-		/// Returns the MDagPath object to the scene node
-		MDagPath dagPath() const;
-
 		/*
 		 * Bounding box
 		 */
@@ -187,6 +184,13 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 
 		/// Currently raises an exception
 		void hash( HashType hashType, double time, IECore::MurmurHash &h ) const override;
+
+		/*
+		* Utility functions
+		*/
+
+		/// Returns the MDagPath object to the scene node
+		MDagPath dagPath() const;
 
 		/// Translates cortex attribute name to maya attribute name
 		/// Returns an empty string if there are no valid mappings

--- a/include/IECoreMaya/LiveScene.h
+++ b/include/IECoreMaya/LiveScene.h
@@ -192,6 +192,12 @@ class IECOREMAYA_API LiveScene : public IECoreScene::SceneInterface
 		/// Returns the MDagPath object to the scene node
 		MDagPath dagPath() const;
 
+		/// Returns the scene path corresponding to the maya dag path
+		static void dagPathToPath( MDagPath dagPath, IECoreScene::SceneInterface::Path &path );
+
+		/// Returns the maya dag path corresponding to the scene path
+		static void pathToDagPath( const IECoreScene::SceneInterface::Path &path, MDagPath &dagPath );
+
 		/// Translates cortex attribute name to maya attribute name
 		/// Returns an empty string if there are no valid mappings
 		static Name toMayaAttributeName( const Name &name );

--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -138,6 +138,8 @@ class IECOREMAYA_API SceneShapeInterface: public MPxComponentShape
 		const std::vector< IECore::InternedString > & componentNames() const;
 		/// Return the value of the time plug for the SceneShape.
 		double time() const;
+		/// Determines scene visibility while accounting for ancestral visibility overrides
+		static bool isVisible( const MDagPath &dagPath );
 
 	protected :
 

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -206,20 +206,7 @@ void LiveScene::path( Path &p ) const
 		throw Exception( "IECoreMaya::LiveScene::path: Dag path no longer exists!" );
 	}
 
-	std::string pathStr( m_dagPath.fullPathName().asChar() );
-	boost::tokenizer<boost::char_separator<char> > t( pathStr, boost::char_separator<char>( "|" ) );
-
-	p.clear();
-
-	for (
-		boost::tokenizer<boost::char_separator<char> >::iterator it = t.begin();
-		it != t.end();
-		++it
-	)
-	{
-		p.push_back( Name( *it ) );
-	}
-
+	dagPathToPath( m_dagPath, p );
 }
 
 Imath::Box3d LiveScene::readBound( double time ) const

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1923,16 +1923,15 @@ void SceneShapeSubSceneOverride::collectInstances( Instances &instances ) const
 	MDagPathArray dagPaths;
 	dagNode.getAllPaths(dagPaths);
 	size_t numInstances = dagPaths.length();
-
 	instances.reserve( numInstances );
+
 	for( size_t pathIndex = 0; pathIndex < numInstances; ++pathIndex )
 	{
 		MDagPath& path = dagPaths[pathIndex];
 		MMatrix matrix = path.inclusiveMatrix();
 		bool pathSelected = isPathSelected( selectionList, path );
 		bool componentMode = componentsSelectable( path );
-		MFnDagNode nodeFn( path );
-		bool visible = path.isVisible();
+		bool visible = IECoreMaya::SceneShapeInterface::isVisible( path );
 
 		instances.emplace_back( matrix, pathSelected, componentMode, path, visible );
 	}

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1404,6 +1404,16 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 		return;
 	}
 
+	// respect visibility attribute
+	if( sceneInterface->hasAttribute( SceneInterface::visibilityName ) )
+	{
+		ConstBoolDataPtr vis = runTimeCast<const BoolData>( sceneInterface->readAttribute( SceneInterface::visibilityName, m_time ) );
+		if( vis && !vis->readable() )
+		{
+			return;
+		}
+	}
+
 	MMatrix accumulatedMatrix;
 	if( !isRoot )
 	{
@@ -1430,7 +1440,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	}
 
 	// Now handle current location.
-
 	if( isRoot )
 	{
 		// override relative location for root as it would otherwise be empty
@@ -1467,16 +1476,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 	if( !m_drawTagsFilter.empty() && !sceneInterface->hasTag( m_drawTagsFilter ) )
 	{
 		return;
-	}
-
-	// respect visibility attribute
-	if( sceneInterface->hasAttribute( "scene:visible" ) )
-	{
-		ConstBoolDataPtr vis = runTimeCast<const BoolData>( sceneInterface->readAttribute( "scene:visible", m_time ) );
-		if( vis && !vis->readable() )
-		{
-			return;
-		}
 	}
 
 	IECore::ConstObjectPtr object = sceneInterface->readObject( m_time );

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1121,17 +1121,22 @@ bool SceneShapeSubSceneOverride::requiresUpdate(const MSubSceneContainer& contai
 	{
 		allInvisibleByFilter = true;
 
-		MObject component;
-		MSelectionList viewSelectedSet;
-		view.filteredObjectList( viewSelectedSet );
+		// Create a selection list of the dagPaths which are visible after the view is filtered
+		MSelectionList visibleList;
+		view.filteredObjectList( visibleList );
 
-		for( size_t i = 0; i < dagPaths.length(); ++i )
+		// Create a selection list with all of our dag paths
+		MSelectionList dagPathList;
+		for( const auto &dagPath : dagPaths )
 		{
-			if( viewSelectedSet.hasItemPartly( dagPaths[i], component ) )
-			{
-				allInvisibleByFilter = false;
-				break;
-			}
+			dagPathList.add( dagPath );
+		}
+
+		// Intersect the two lists to determine if any of our dag paths remain unfiltered
+		visibleList.intersect( dagPathList, true );
+		if( !visibleList.isEmpty() )
+		{
+			allInvisibleByFilter = false;
 		}
 	}
 
@@ -1360,22 +1365,31 @@ void SceneShapeSubSceneOverride::update( MSubSceneContainer& container, const MF
 	M3dView view;
 	MString panelName;
 	MSelectionList viewSelectedSet;
-	MObject component;
 	frameContext.renderingDestination( panelName );
 	M3dView::getM3dViewFromModelPanel( panelName, view );
 	view.filteredObjectList( viewSelectedSet );
 
 	bool allInvisibleByFilter = false;
-	if ( view.viewIsFiltered() )
+	if( view.viewIsFiltered() )
 	{
 		allInvisibleByFilter = true;
-		for( auto &instance : m_instances )
+
+		// Create a selection list of the dagPaths which are visible after the view is filtered
+		MSelectionList visibleList;
+		view.filteredObjectList( visibleList );
+
+		// Create a selection list with all of our dag paths
+		MSelectionList dagPathList;
+		for( const auto &instance : m_instances )
 		{
-			if ( viewSelectedSet.hasItemPartly( instance.path, component ) )
-			{
-				allInvisibleByFilter = false;
-				break;
-			}
+			dagPathList.add( instance.path );
+		}
+
+		// Intersect the two lists to determine if any of our dag paths remain unfiltered
+		visibleList.intersect( dagPathList, true );
+		if( !visibleList.isEmpty() )
+		{
+			allInvisibleByFilter = false;
 		}
 	}
 

--- a/src/IECoreMaya/SceneShapeUI.cpp
+++ b/src/IECoreMaya/SceneShapeUI.cpp
@@ -102,6 +102,13 @@ void SceneShapeUI::getDrawRequests( const MDrawInfo &info, bool objectAndActiveO
 	{
 		return;
 	}
+
+	// make sure we don't have an ancestral visibility override which makes us invisible
+	if( !SceneShapeInterface::isVisible( info.multiPath() ) )
+	{
+		return;
+	}
+
 	// the node we're meant to be drawing
 	SceneShape *sceneShape = (SceneShape *)surfaceShape();
 

--- a/src/IECoreMaya/bindings/LiveSceneBinding.cpp
+++ b/src/IECoreMaya/bindings/LiveSceneBinding.cpp
@@ -204,6 +204,39 @@ inline std::string dagPath( object liveSceneObject )
 	return liveScene.dagPath().fullPathName().asChar();
 }
 
+inline list dagPathToPath( object dagObj )
+{
+	list pathList;
+	extract<MDagPath> dagPath( dagObj );
+
+	// Return the root path (an empty list) if we are given an empty string
+	// Maya doesn't really have a "root" dag path, so this is as close as we can get while simultaneously
+	// ensuring dagPathToPath( pathToDagPath( [] ) ) == []
+	if( dagPath.check() && len( dagObj ) == 0 )
+	{
+		return pathList;
+	}
+
+	// Get the path, or throw if the dag path object is invalid
+	IECoreScene::SceneInterface::Path path;
+	LiveScene::dagPathToPath( dagPath(), path );
+	for(const auto &name : path )
+	{
+		pathList.append( name.string() );
+	}
+	return pathList;
+}
+
+inline std::string pathToDagPath( list pathList )
+{
+	IECoreScene::SceneInterface::Path path;
+	container_utils::extend_container( path, pathList );
+
+	MDagPath dagPath;
+	LiveScene::pathToDagPath( path, dagPath );
+	return dagPath.fullPathName().asChar();
+}
+
 } // namespace
 
 void IECoreMaya::bindLiveScene()
@@ -213,6 +246,8 @@ void IECoreMaya::bindLiveScene()
 		.def( "registerCustomTags", registerCustomTags, ( arg_( "hasFn" ), arg_( "readFn" ) ) ).staticmethod( "registerCustomTags" )
 		.def( "registerCustomAttributes", registerCustomAttributes, (  arg_( "namesFn" ), arg_( "readFn" ), arg_( "mightHaveFn" ) = object() ) ).staticmethod( "registerCustomAttributes" )
 		.def( "dagPath", ::dagPath )
+		.def( "dagPathToPath", ::dagPathToPath ).staticmethod( "dagPathToPath" )
+		.def( "pathToDagPath", ::pathToDagPath ).staticmethod( "pathToDagPath" )
 		.def( "toMayaAttributeName", LiveScene::toMayaAttributeName ).staticmethod( "toMayaAttributeName" )
 		.def( "fromMayaAttributeName", LiveScene::fromMayaAttributeName ).staticmethod( "fromMayaAttributeName" )
 		.def_readonly("visibilityOverrideName", LiveScene::visibilityOverrideName )

--- a/src/IECoreMaya/bindings/LiveSceneBinding.cpp
+++ b/src/IECoreMaya/bindings/LiveSceneBinding.cpp
@@ -198,6 +198,12 @@ void registerCustomAttributes( object namesFn, object readFn, object mightHaveFn
 	}
 }
 
+inline std::string dagPath( object liveSceneObject )
+{
+	const LiveScene &liveScene = extract<const LiveScene&>( liveSceneObject );
+	return liveScene.dagPath().fullPathName().asChar();
+}
+
 } // namespace
 
 void IECoreMaya::bindLiveScene()
@@ -206,6 +212,7 @@ void IECoreMaya::bindLiveScene()
 		.def( init<>() )
 		.def( "registerCustomTags", registerCustomTags, ( arg_( "hasFn" ), arg_( "readFn" ) ) ).staticmethod( "registerCustomTags" )
 		.def( "registerCustomAttributes", registerCustomAttributes, (  arg_( "namesFn" ), arg_( "readFn" ), arg_( "mightHaveFn" ) = object() ) ).staticmethod( "registerCustomAttributes" )
+		.def( "dagPath", ::dagPath )
 		.def( "toMayaAttributeName", LiveScene::toMayaAttributeName ).staticmethod( "toMayaAttributeName" )
 		.def( "fromMayaAttributeName", LiveScene::fromMayaAttributeName ).staticmethod( "fromMayaAttributeName" )
 		.def_readonly("visibilityOverrideName", LiveScene::visibilityOverrideName )

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -1458,6 +1458,46 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		cubeScene = liveScene.scene( [group, cube] )
 		self.assertEqual( cubeScene.dagPath(), '|{}|{}'.format( group, cube ) )
 
+	def testDagPathToPath( self ):
+		group = str( maya.cmds.group( empty=True ) )
+		cubeTransform = maya.cmds.polyCube( constructionHistory=False )[0]
+		maya.cmds.parent( cubeTransform, group )
+		cubeTransform = str( maya.cmds.ls( cubeTransform, long=True )[0] )
+		cubeShape = str( maya.cmds.listRelatives( cubeTransform, fullPath=True )[0] )
+
+		dagTransform = OpenMaya.MDagPath()
+		dagShape = OpenMaya.MDagPath()
+		sel = OpenMaya.MSelectionList()
+		sel.add( cubeTransform )
+		sel.add( cubeShape )
+		sel.getDagPath( 0, dagTransform )
+		sel.getDagPath( 0, dagShape )
+
+		pathTransform = IECoreMaya.LiveScene.dagPathToPath( dagTransform.fullPathName() )
+		self.assertEqual( pathTransform, cubeTransform[1:].split('|') )
+
+		pathShape = IECoreMaya.LiveScene.dagPathToPath( dagShape.fullPathName() )
+		self.assertEqual( pathShape, cubeTransform[1:].split('|') )
+
+		pathRoot = IECoreMaya.LiveScene.dagPathToPath( '' )
+		self.assertEqual( pathRoot, [] )
+
+		self.assertRaises( Exception, IECoreMaya.LiveScene.dagPathToPath, '|invalid' )
+
+	def testPathToDagPath( self ):
+		group = str( maya.cmds.group( empty=True ) )
+		cube = str( maya.cmds.polyCube( constructionHistory=False )[0] )
+		maya.cmds.parent( cube, group )
+
+		path = [group, cube]
+		dagTransform = IECoreMaya.LiveScene.pathToDagPath( path )
+		self.assertEqual( dagTransform, '|{}|{}'.format( group, cube ) )
+
+		dagRoot = IECoreMaya.LiveScene.pathToDagPath( [] )
+		self.assertEqual( dagRoot, '' )
+
+		self.assertRaises( Exception, IECoreMaya.LiveScene.pathToDagPath, ['invalid'] )
+
 
 if __name__ == "__main__":
 	IECoreMaya.TestProgram( plugins = [ "ieCore" ] )

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -1449,6 +1449,16 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 	def testVisibilityOverrideName( self ) :
 		self.assertEqual( IECoreMaya.LiveScene.visibilityOverrideName, 'ieVisibility' )
 
+	def testDagPath( self ):
+		group = str( maya.cmds.group( empty=True ) )
+		cube = str( maya.cmds.polyCube( constructionHistory=False )[0] )
+		maya.cmds.parent( cube, group )
+
+		liveScene = IECoreMaya.LiveScene()
+		cubeScene = liveScene.scene( [group, cube] )
+		self.assertEqual( cubeScene.dagPath(), '|{}|{}'.format( group, cube ) )
+
+
 if __name__ == "__main__":
 	IECoreMaya.TestProgram( plugins = [ "ieCore" ] )
 


### PR DESCRIPTION
This PR fixes a couple of drawing bugs related to SceneShapes in VP2:
- IECoreMaya : Fixed erroneous display of hidden locations in VP2.
- IECoreMaya : Updated SceneShape drawing to respect ancestral visibility overrides.
- IECoreMaya : Fixed SceneShape isolate selection in maya.

### Related Issues ###

- N/A

### Dependencies ###

- N/A

### Breaking Changes ###

- N/A

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
