### PR TITLE
IECoreScene::Font : Replace invalid chars with X instead of crashing

### DIFF
--- a/src/IECoreScene/Font.cpp
+++ b/src/IECoreScene/Font.cpp
@@ -522,6 +522,11 @@ class Font::Implementation : public IECore::RefCounted
 
 		const Mesh *cachedMesh( char c ) const
 		{
+			if( c < 0 )
+			{
+				// Map all invalid characters to capital X
+				c = 'X';
+			}
 			FreeTypeMutex::scoped_lock lock( g_freeTypeMutex );
 
 			// see if we have it cached

--- a/test/IECoreScene/FontTest.py
+++ b/test/IECoreScene/FontTest.py
@@ -107,5 +107,12 @@ class FontTest( unittest.TestCase ) :
 
 		self.assertGreater( font.bound( "T\nT" ).size().y, font.bound( "TT" ).size().y )
 
+	def testInvalidChar( self ) :
+
+		font = IECoreScene.Font( os.path.join( "test", "IECore", "data", "fonts", "Vera.ttf" ) )
+
+		self.assertEqual( font.bound( "X" ), font.bound( b"\xff" ) )
+		self.assertEqual( font.mesh( "X" ), font.mesh( b"\xff" ) )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Currently we use the char `c` to index into m_meshes, which is only 128 in size.  One could argue about whether this should just return a zero-sized character, but throwing an exception is unambiguously better than segfaulting.