### PR TITLE
IECore : MatrixInterpolator GCC 11 initialise fix

### DIFF
--- a/include/IECore/MatrixInterpolator.inl
+++ b/include/IECore/MatrixInterpolator.inl
@@ -66,10 +66,10 @@ struct LinearInterpolator< Imath::Matrix44<T> >
 			return;
 		}
 
-		Imath::Vec3<T> s0, s1, sx;
-		Imath::Vec3<T> h0, h1, hx;
-		Imath::Vec3<T> r0, r1, rx;
-		Imath::Vec3<T> t0, t1, tx;
+		Imath::Vec3<T> s0( 1 ), s1( 1 ), sx( 1 );
+		Imath::Vec3<T> h0( 0 ), h1( 0 ), hx( 0 );
+		Imath::Vec3<T> r0( 0 ), r1( 0 ), rx( 0 );
+		Imath::Vec3<T> t0( 0 ), t1( 0 ), tx( 0 );
 
 		extractSHRT(y0, s0, h0, r0, t0);
 		extractSHRT(y1, s1, h1, r1, t1);
@@ -118,10 +118,10 @@ struct CubicInterpolator< Imath::Matrix44< T > >
 			return;
 		}
 
-		Imath::Vec3<T> s0, s1, s2, s3, sx;
-		Imath::Vec3<T> h0, h1, h2, h3, hx;
-		Imath::Vec3<T> r0, r1, r2, r3, rx;
-		Imath::Vec3<T> t0, t1, t2, t3, tx;
+		Imath::Vec3<T> s0( 1 ), s1( 1 ), s2( 1 ), s3( 1 ), sx( 1 );
+		Imath::Vec3<T> h0( 0 ), h1( 0 ), h2( 0 ), h3( 0 ), hx( 0 );
+		Imath::Vec3<T> r0( 0 ), r1( 0 ), r2( 0 ), r3( 0 ), rx( 0 );
+		Imath::Vec3<T> t0( 0 ), t1( 0 ), t2( 0 ), t3( 0 ), tx( 0 );
 
 		extractSHRT(y0, s0, h0, r0, t0);
 		extractSHRT(y1, s1, h1, r1, t1);


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

- GCC 11 complains about uninitialised variables, this fixes it

### Related Issues ###

- NA

### Dependencies ###

- NA

### Breaking Changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
