### PR TITLE
SConstruct : VFX Platform 2023 uses new ABI with GCC 11.2.1

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1119,10 +1119,13 @@ if env["PLATFORM"] != "win32" :
 
 	elif env["PLATFORM"]=="posix" :
 		if "g++" in os.path.basename( env["CXX"] ) and not "clang++" in os.path.basename( env["CXX"] ) :
-			gccVersion = subprocess.check_output( [ env["CXX"], "-dumpversion" ], env=env["ENV"], universal_newlines=True )
-			gccVersion = gccVersion.strip()
+			gccVersion = subprocess.check_output( [ env["CXX"], "-dumpversion" ], env=env["ENV"], universal_newlines=True ).strip()
+			if "." not in gccVersion :
+				# GCC 7 onwards requires `-dumpfullversion` to get minor/patch, but this
+				# flag does not exist on earlier GCCs, where minor/patch was provided by `-dumpversion`.
+				gccVersion = subprocess.check_output( [ env["CXX"], "-dumpfullversion" ], env=env["ENV"], universal_newlines=True ).strip()
 			gccVersion = [ int( v ) for v in gccVersion.split( "." ) ]
-			if gccVersion >= [ 5, 1 ] :
+			if gccVersion >= [ 5, 1 ] and gccVersion < [ 11, 2 ] :
 				env.Append( CXXFLAGS = [ "-D_GLIBCXX_USE_CXX11_ABI=0" ] )
 
 	env.Append( CXXFLAGS = [ "-std=$CXXSTD", "-fvisibility=hidden" ] )


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

- VFX Platform has decided to use the new ABI (removal of `_GLIBCXX_USE_CXX11_ABI=0`) https://vfxplatform.com/
- To build on eg. Rocky Linux 9 with GCC 11.2.1

### Related Issues ###

- NA

### Dependencies ###

- NA

### Breaking Changes ###

- Gaffer and its dependencies compiling on GCC 11.2.x will have to omit `_GLIBCXX_USE_CXX11_ABI=0` if set

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
