### PR TITLE
AlembicScene : Account for visibility in attributes hash

### DIFF
--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
@@ -850,12 +850,26 @@ class AlembicScene::AlembicReader : public AlembicIO
 			const IXformSchema &schema = m_xform.getSchema();
 			ICompoundProperty compoundProperty = schema.getUserProperties();
 
+			bool haveAttributes = false;
+			bool haveAnimation = false;
+
 			if( compoundProperty.valid() )
+			{
+				haveAttributes = true;
+				haveAnimation = haveAnimation || isAnimated( compoundProperty );
+			}
+
+			if( auto visibilityReader = scalarPropertyReader( visibilityName ) )
+			{
+				haveAttributes = true;
+				haveAnimation = haveAnimation || !visibilityReader->isConstant();
+			}
+
+			if( haveAttributes )
 			{
 				h.append( fileName() );
 				h.append( m_xform ? m_xform.getFullName() : "/" );
-
-				if( isAnimated( compoundProperty ) )
+				if( haveAnimation )
 				{
 					h.append( time );
 				}

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -1964,24 +1964,46 @@ class AlembicSceneTest( unittest.TestCase ) :
 
 		fileName = os.path.join( self.temporaryDirectory(), "visibilityAttribute.abc" )
 		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
 		root.createChild( "withoutAttribute" )
-		child = root.createChild( "withAttribute" )
+
+		child = root.createChild( "withAnimatedAttribute" )
 		child.writeAttribute( "scene:visible", IECore.BoolData( True ), 0 )
 		child.writeAttribute( "scene:visible", IECore.BoolData( False ), 1 )
+
+		child = root.createChild( "withStaticAttribute" )
+		child.writeAttribute( "scene:visible", IECore.BoolData( True ), 0 )
 
 		del child, root
 
 		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
 
-		child = root.child( "withAttribute" )
+		child = root.child( "withoutAttribute" )
+		self.assertNotIn( "scene:visible", child.attributeNames() )
+		self.assertFalse( child.hasAttribute( "scene:visible" ) )
+		withoutHash = child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0 )
+
+		child = root.child( "withAnimatedAttribute" )
 		self.assertIn( "scene:visible", child.attributeNames() )
 		self.assertTrue( child.hasAttribute( "scene:visible" ) )
 		self.assertEqual( child.readAttribute( "scene:visible", 0 ), IECore.BoolData( True ) )
 		self.assertEqual( child.readAttribute( "scene:visible", 1 ), IECore.BoolData( False ) )
+		animatedFrame1Hash = child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 )
+		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0 ), animatedFrame1Hash )
+		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0 ), withoutHash )
+		self.assertNotEqual( animatedFrame1Hash, withoutHash )
 
-		child = root.child( "withoutAttribute" )
-		self.assertNotIn( "scene:visible", child.attributeNames() )
-		self.assertFalse( child.hasAttribute( "scene:visible" ) )
+		child = root.child( "withStaticAttribute" )
+		self.assertIn( "scene:visible", child.attributeNames() )
+		self.assertTrue( child.hasAttribute( "scene:visible" ) )
+		self.assertEqual( child.readAttribute( "scene:visible", 0 ), IECore.BoolData( True ) )
+		self.assertEqual( child.readAttribute( "scene:visible", 1 ), IECore.BoolData( True ) )
+		self.assertEqual(
+			child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0 ),
+			child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 ),
+		)
+		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 ), animatedFrame1Hash )
+		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 ), withoutHash )
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fixes the failure to load animated visibility demonstrated in #944.
