### PR TITLE
AlembicScene : Support various flavours of integer GeomParams

### DIFF
--- a/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveReader.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveReader.cpp
@@ -72,6 +72,26 @@ void PrimitiveReader::readArbGeomParams( const Alembic::Abc::ICompoundProperty &
 			IV3dGeomParam p( params, header.getName() );
 			readGeomParam( p, sampleSelector, primitive );
 		}
+		else if( IUcharGeomParam::matches( header ) )
+		{
+			IUcharGeomParam p( params, header.getName() );
+			readGeomParam( p, sampleSelector, primitive );
+		}
+		else if( IUInt16GeomParam::matches( header ) )
+		{
+			IUInt16GeomParam p( params, header.getName() );
+			readGeomParam( p, sampleSelector, primitive );
+		}
+		else if( IInt16GeomParam::matches( header ) )
+		{
+			IInt16GeomParam p( params, header.getName() );
+			readGeomParam( p, sampleSelector, primitive );
+		}
+		else if( IUInt32GeomParam::matches( header ) )
+		{
+			IUInt32GeomParam p( params, header.getName() );
+			readGeomParam( p, sampleSelector, primitive );
+		}
 		else if( IInt32GeomParam::matches( header ) )
 		{
 			IInt32GeomParam p( params, header.getName() );

--- a/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveWriter.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/PrimitiveWriter.cpp
@@ -101,6 +101,18 @@ void PrimitiveWriter::writeArbGeomParams( const IECoreScene::Primitive *primitiv
 			case BoolVectorDataTypeId :
 				writeArbGeomParam<BoolVectorData, OBoolGeomParam>( p.first, p.second, params );
 				break;
+			case UCharVectorDataTypeId :
+				writeArbGeomParam<UCharVectorData, OUcharGeomParam>( p.first, p.second, params );
+				break;
+			case UShortVectorDataTypeId :
+				writeArbGeomParam<UShortVectorData, OUInt16GeomParam>( p.first, p.second, params );
+				break;
+			case ShortVectorDataTypeId :
+				writeArbGeomParam<ShortVectorData, OInt16GeomParam>( p.first, p.second, params );
+				break;
+			case UIntVectorDataTypeId :
+				writeArbGeomParam<UIntVectorData, OUInt32GeomParam>( p.first, p.second, params );
+				break;
 			case IntVectorDataTypeId :
 				writeArbGeomParam<IntVectorData, OInt32GeomParam>( p.first, p.second, params );
 				break;

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -2005,5 +2005,40 @@ class AlembicSceneTest( unittest.TestCase ) :
 		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 ), animatedFrame1Hash )
 		self.assertNotEqual( child.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 1 ), withoutHash )
 
+	def testArbGeomParamTypes( self ) :
+
+		points = IECoreScene.PointsPrimitive( IECore.V3fVectorData( [ imath.V3f( i ) for i in range( 0, 2 ) ] ) )
+
+		points["uint8"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.UCharVectorData( range( 0, 2 ) )
+		)
+		points["uint16"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.UShortVectorData( range( 0, 2 ) )
+		)
+		points["int16"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.ShortVectorData( range( 0, 2 ) )
+		)
+		points["uint32"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.UIntVectorData( range( 0, 2 ) )
+		)
+		points["int32"] = IECoreScene.PrimitiveVariable(
+			IECoreScene.PrimitiveVariable.Interpolation.Vertex,
+			IECore.IntVectorData( range( 0, 2 ) )
+		)
+
+		fileName = os.path.join( self.temporaryDirectory(), "visibilityAttribute.abc" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		root.createChild( "object" ).writeObject( points, 0 )
+		del root
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		points2 = root.child( "object" ).readObject( 0 )
+		for name in points.keys() :
+			self.assertEqual( points2[name], points[name] )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I've omitted CharVectorData/ICharGeomParam as we are unable to support them using the generic code we currently use. CharVectorData is templated on `char` and ICharGeomParam is templated on `unsigned char` and these are distinct types. Really we should define our TypedData types using `[u]int_[8|16|32]` rather than `char|short|int`, but that is a job for another day.
