### PR TITLE
Allow building RV with older version of OIIO

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -260,6 +260,10 @@ o.Add(
 	"",
 )
 
+o.Add(
+	BoolVariable( "WITH_OIIO_UTIL", "Build with OpenImageIO_Util", True ),
+)
+
 # Blosc options
 
 o.Add(
@@ -1858,13 +1862,14 @@ imageEnvPrepends = {
 	],
 	"LIBS" : [
 		"OpenImageIO$OIIO_LIB_SUFFIX",
-		"OpenImageIO_Util$OIIO_LIB_SUFFIX",
 	],
 	"CXXFLAGS" : [
 		"-DIECoreImage_EXPORTS",
 		systemIncludeArgument, "$OIIO_INCLUDE_PATH"
 	]
 }
+if imageEnv.get( "WITH_OIIO_UTIL", True ):
+	imageEnvPrepends["LIBS"].append( "OpenImageIO_Util$OIIO_LIB_SUFFIX" )
 
 imageEnv.Prepend( **imageEnvPrepends )
 # Windows uses PATH for to find libraries, we must append to it to make sure we don't overwrite existing PATH entries.
@@ -2216,11 +2221,12 @@ if env["WITH_GL"] and doConfigure :
 				os.path.basename( imageEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				os.path.basename( sceneEnv.subst( "$INSTALL_LIB_NAME" ) ),
 				"OpenImageIO$OIIO_LIB_SUFFIX",
-				"OpenImageIO_Util$OIIO_LIB_SUFFIX",
 				"GLEW$GLEW_LIB_SUFFIX",
 				"boost_wave$BOOST_LIB_SUFFIX",
 			]
 		)
+		if glEnv.get( "WITH_OIIO_UTIL", True ):
+			glEnv.Append( LIBS = [ "OpenImageIO_Util$OIIO_LIB_SUFFIX", ] )
 
 		if env["PLATFORM"]=="darwin" :
 			glEnv.Append(

--- a/config/ie/options
+++ b/config/ie/options
@@ -196,6 +196,7 @@ oiioRoot = os.path.join( "/software", "apps", "OpenImageIO", oiioVersion, platfo
 OIIO_INCLUDE_PATH = os.path.join( oiioRoot, "include" )
 OIIO_LIB_PATH = os.path.join( oiioRoot, "lib64" )
 OIIO_LIB_SUFFIX = IEEnv.BuildUtil.libSuffix( "OpenImageIO", oiioLibSuffix )
+WITH_OIIO_UTIL = "true"
 
 FREETYPE_LIB_PATH = os.path.join( "/software", "tools", "lib", platform, compiler, compilerVersion )
 FREETYPE_INCLUDE_PATH = "/usr/include/freetype2"
@@ -436,6 +437,9 @@ if targetApp=="rv" :
 			# the default `OIIO_INCLUDE_PATH` value.
 			OIIO_LIB_PATH = rvLibs
 			OIIO_LIB_SUFFIX = rvReg.get( "OpenImageIOLibSuffix", OIIO_LIB_SUFFIX )
+			# current version of OIIO used by RV doesn't include the Util library
+			# this variable will tell the build process to not require it
+			WITH_OIIO_UTIL = rvReg.get( "WithOpenImageIOUtil", WITH_OIIO_UTIL )
 
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )


### PR DESCRIPTION
Features
---
- Added build support for older OpenImageIO version that doesn't have OpenImageIO_Util library. This can be driven by setting WITH_OIIO_UTIL option. Setting it to false will disable the requirement of Util library.

### Generally describe what this PR will do, and why it is needed. ###
Newer version of RV (>=2022.3.0) is crashing randomly on startup. After few trial and error the combination that seems to work is to build cortex for RV by using OIIO libraries packaged with RV. That library is old enough so to not contain OpenImageIO_Util library which is assumed to exist in SConstruct configuration. These changes will allow to use that older version.

There still occasional "double memory free" crushes on application close. But I could not yet figure out how to address that. Theoretically that crash is because of incompatible version of boost. However, using proper version of boost doesn't seem enough.

### Related Issues ###

- OpenImageIO not found when building cortex with an older version of the library

### Dependencies ###

None

### Breaking Changes ###

None

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
