### PR TITLE
SConstruct : Fix slash error on Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+10.3.7.x (relative to 10.3.7.2)
+========
+
+Fixes
+-----
+
+- IECoreUSD : Fixed error in `pluginfo.json` preventing USD on Windows from loading `IECoreUSD.dll`.
+
 10.3.7.2 (relative to 10.3.7.1)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -3112,7 +3112,7 @@ if doConfigure :
 				"!IECOREUSD_RELATIVE_LIB_FOLDER!" : os.path.relpath(
 					usdLibraryInstall[0].get_path(),
 					os.path.dirname( usdEnv.subst( "$INSTALL_USD_RESOURCE_DIR/IECoreUSD/plugInfo.json" ) )
-				).format( "\\", "\\\\" ),
+				).replace( "\\", "\\\\" ),
 			}
 		)
 		usdEnv.AddPostAction( "$INSTALL_USD_RESOURCE_DIR/IECoreUSD", lambda target, source, env : makeSymLinks( usdEnv, usdEnv["INSTALL_USD_RESOURCE_DIR"] ) )


### PR DESCRIPTION
This fixes an error on Windows related to the escaping of backslashes that prevented USD from loading `IECoreUSD.dll`. It was testing correctly in the past because the tests use a different `pluginfo.json` than what is installed, which was formatted correctly.

### Breaking Changes ###

None

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
