### PR TITLE
IECoreScene : MeshPrimitiveEvaluator assert operator typo fix

### DIFF
--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -724,7 +724,7 @@ bool MeshPrimitiveEvaluator::signedDistance( const Imath::V3f &p, float &distanc
 			else
 			{
 				assert( region == 6 );
-				assert( closestVertex = 1 );
+				assert( closestVertex == 1 );
 			}
 
 			assert( triangleVertexIds[ closestVertex ] < (int)(m_vertexAngleWeightedNormals->readable().size()) );


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

- When compiling in debug mode, an assert had the wrong operator (should be `==` not `=`).

### Related Issues ###

- NA

### Dependencies ###

- NA

### Breaking Changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
