### PR TITLE
ie options: Fix Python 3 `exec` issue with list comprehensions

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -207,7 +207,9 @@ LIBPATH = ":".join( [
 	os.path.join( "/software", "apps", compiler, compilerVersion, platform, "lib64" ),
 ] )
 if targetApp :
-	libPaths = [ os.path.join( targetAppReg["location"], x ) for x in targetAppReg.get( "libPaths", [] ) ]
+	libPaths = []
+	for libPath in targetAppReg.get( "libPaths", [] ):
+		libPaths.append( os.path.join( targetAppReg["location"], libPath ) )
 	libPaths.append( LIBPATH )
 	LIBPATH = ":".join( libPaths )
 


### PR DESCRIPTION
In Python 3 list comprehensions were changed to create their own local scope. If we pass in different objects for the `globals` and `locals` to the `exec` function this leads to `NameErrors` in the list comprehension. SCons passes in two different dictionaries when calling `exec` on the the options files. To circumvent this issue, we rewrite the list comprehension to a loop.

For reference:
https://stackoverflow.com/questions/45132645/list-comprehension-in-exec-with-empty-locals-nameerror