### PR TITLE
Visibility override fixes

### DIFF
--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1418,16 +1418,6 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 		return;
 	}
 
-	// respect visibility attribute
-	if( sceneInterface->hasAttribute( SceneInterface::visibilityName ) )
-	{
-		ConstBoolDataPtr vis = runTimeCast<const BoolData>( sceneInterface->readAttribute( SceneInterface::visibilityName, m_time ) );
-		if( vis && !vis->readable() )
-		{
-			return;
-		}
-	}
-
 	MMatrix accumulatedMatrix;
 	if( !isRoot )
 	{

--- a/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
+++ b/src/IECoreMaya/SceneShapeSubSceneOverride.cpp
@@ -1463,6 +1463,10 @@ void SceneShapeSubSceneOverride::visitSceneLocations( const SceneInterface *scen
 		int count = 0;
 		for( const auto &instance : m_instances )
 		{
+			if ( !instance.visible )
+			{
+				continue;
+			}
 			std::string instanceName = rootItemName + "_" + std::to_string( count++ );
 			MString itemName( instanceName.c_str() );
 			MRenderItem *renderItem = acquireRenderItem( container, IECore::NullObject::defaultNullObject(), instance, relativeLocation, bound, itemName, RenderStyle::BoundingBox );


### PR DESCRIPTION
PR #1290 addressed various issues when drawing scene caches in maya's ViewPort2. This PR attempts to fix a regression introduced by this PR. The actual visibility determination is done correctly by `LiveScene` but then stomped over by any value present in the cache itself, disregarding overrides made in the scene. This change was introduces to fix an issue where lower level locations would be drawn even with an override higher up. But with the `LiveScene` implementation this seems not needed anymore.

We also address an issue for scene shapes that represent a root location, e.g. when we have set it to `objectOnly` where the various instances never checked visibility when set to "draw root bounds". That means we would always draw the bounds in the viewport even when overriding the visibility.