### PR TITLE
Remove Use of Imath Functionality that is Going To Be Deprecated

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.cpp
@@ -294,7 +294,7 @@ void SceneCacheData::loadSceneIntoCache( ConstSceneInterfacePtr scene )
 		spec.fields.push_back( FieldValuePair( SdfFieldKeys->TimeCodesPerSecond, m_fps ) );
 
 		// figure out start and end frame based on timeSamples in header
-		float minTime = Imath::limits<float>::max();
+		float minTime = std::numeric_limits<float>::max();
 		float maxTime = 0;
 		bool validTimeSampleRange = false;
 		if ( auto sampleTimesDir = m_sceneio->subdirectory( g_sampleTimes, IndexedIO::MissingBehaviour::NullIfMissing ) )

--- a/include/IECore/BoundedKDTree.inl
+++ b/include/IECore/BoundedKDTree.inl
@@ -135,8 +135,8 @@ template<class BoundIterator>
 unsigned char BoundedKDTree<BoundIterator>::majorAxis( PermutationConstIterator permFirst, PermutationConstIterator permLast )
 {
 	BaseType min, max;
-	vecSetAll( min, Imath::limits<typename BaseType::BaseType>::max() );
-	vecSetAll( max, Imath::limits<typename BaseType::BaseType>::min() );
+	vecSetAll( min, std::numeric_limits<typename BaseType::BaseType>::max() );
+	vecSetAll( max, std::numeric_limits<typename BaseType::BaseType>::lowest() );
 
 	for( PermutationConstIterator it=permFirst; it!=permLast; it++ )
 	{

--- a/include/IECore/ByteOrder.h
+++ b/include/IECore/ByteOrder.h
@@ -35,8 +35,6 @@
 #ifndef IE_CORE_BYTEORDER_H
 #define IE_CORE_BYTEORDER_H
 
-#include "OpenEXR/ImfInt64.h"
-
 #include "boost/static_assert.hpp"
 
 #include <stdint.h>
@@ -138,7 +136,7 @@ inline float reverseBytes<float>( const float &x )
 }
 
 template<>
-inline Imf::Int64 reverseBytes<Imf::Int64>( const Imf::Int64 &x )
+inline uint64_t reverseBytes<uint64_t>( const uint64_t &x )
 {
 	return ((x & 255) << 56) |
 			(((x >> 8) & 255) << 48) |
@@ -153,13 +151,13 @@ inline Imf::Int64 reverseBytes<Imf::Int64>( const Imf::Int64 &x )
 template<>
 inline double reverseBytes<double>( const double &x )
 {
-	BOOST_STATIC_ASSERT( sizeof(Imf::Int64) == sizeof(double) );
+	BOOST_STATIC_ASSERT( sizeof(uint64_t) == sizeof(double) );
 	union {
-		Imf::Int64 i;
+		uint64_t i;
 		double d;
 	} xx;
 	xx.d = x;
-	xx.i = 	reverseBytes<Imf::Int64>(xx.i);
+	xx.i = 	reverseBytes<uint64_t>(xx.i);
 	return xx.d;
 }
 

--- a/include/IECore/EuclideanToSphericalTransform.inl
+++ b/include/IECore/EuclideanToSphericalTransform.inl
@@ -38,8 +38,6 @@
 #include "IECore/Math.h"
 #include "IECore/VectorTraits.h"
 
-#include "OpenEXR/ImathMath.h"
-
 #include <cassert>
 
 namespace IECore
@@ -57,14 +55,14 @@ T EuclideanToSphericalTransform<F, T>::transform( const F &f )
 	U len = f.length();
 	F v( f );
 	v.normalize();
-	U phi = Imath::Math< U >::atan2( v.y, v.x );
+	U phi = std::atan2( v.y, v.x );
 	if ( phi < 0 )
 	{
 		phi += static_cast< U >( 2*M_PI );
 	}
 	T res;
 	res[0] = phi;
-	res[1] = Imath::Math< U >::acos( v.z );
+	res[1] = std::acos( v.z );
 	if ( TypeTraits::IsVec3<T>::value )
 	{
 		res[2] = len;

--- a/include/IECore/HenyeyGreenstein.inl
+++ b/include/IECore/HenyeyGreenstein.inl
@@ -37,8 +37,6 @@
 
 #include "IECore/Math.h"
 
-#include "OpenEXR/ImathMath.h"
-
 namespace IECore
 {
 
@@ -51,7 +49,7 @@ inline typename Vec::BaseType henyeyGreenstein( typename Vec::BaseType g, const 
 template<typename T>
 inline T henyeyGreenstein( T g, T theta )
 {
-	return henyeyGreensteinCT( g, Imath::Math<T>::cos( theta ) );
+	return henyeyGreensteinCT( g, std::cos( theta ) );
 }
 
 template<typename T>
@@ -60,7 +58,7 @@ inline T henyeyGreensteinCT( T g, T cosTheta )
 	T g2 = g * g;
 	T top = T( 1 ) - g2;
 	T bottom = T( 1 ) + g2 - ( T( 2 ) * g * cosTheta );
-	bottom = T( 4 * M_PI ) * Imath::Math<T>::pow( bottom, T( 1.5 ) );
+	bottom = T( 4 * M_PI ) * std::pow( bottom, T( 1.5 ) );
 	return top / bottom;
 }
 

--- a/include/IECore/IndexedIO.inl
+++ b/include/IECore/IndexedIO.inl
@@ -32,7 +32,6 @@
 //
 //////////////////////////////////////////////////////////////////////////
 
-#include "OpenEXR/ImfInt64.h"
 #include "OpenEXR/ImfXdr.h"
 
 #include "boost/static_assert.hpp"

--- a/include/IECore/InverseDistanceWeightedInterpolation.inl
+++ b/include/IECore/InverseDistanceWeightedInterpolation.inl
@@ -34,8 +34,6 @@
 
 #include "IECore/VectorOps.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 #include <algorithm>
 
 namespace IECore
@@ -83,7 +81,7 @@ typename InverseDistanceWeightedInterpolation<PointIterator, ValueIterator>::Val
 	if( neighbourCount )
 	{
 
-		PointBaseType distanceToFurthest = std::max<PointBaseType>( Imath::Math<PointBaseType>::sqrt( neighbours.rbegin()->distSquared ), 1.e-6 );
+		PointBaseType distanceToFurthest = std::max<PointBaseType>( std::sqrt( neighbours.rbegin()->distSquared ), 1.e-6 );
 
 		PointBaseType totalNeighbourWeight = 0.0;
 
@@ -93,12 +91,12 @@ typename InverseDistanceWeightedInterpolation<PointIterator, ValueIterator>::Val
 
 			const Value &neighbourValue = *(m_firstValue + (neighbourPointIt - m_firstPoint));
 
-			PointBaseType distanceToNeighbour = std::max<PointBaseType>( Imath::Math<PointBaseType>::sqrt( it->distSquared ), 1.e-6 );
+			PointBaseType distanceToNeighbour = std::max<PointBaseType>( std::sqrt( it->distSquared ), 1.e-6 );
 			assert( distanceToNeighbour <= distanceToFurthest );
 
 			// Franke & Nielson's (1980) improvement on Shephard's original weight function
 			PointBaseType neighbourWeight = ( distanceToFurthest - distanceToNeighbour ) / ( distanceToFurthest * distanceToNeighbour );
-			assert( neighbourWeight >= -Imath::limits<PointBaseType>::epsilon() );
+			assert( neighbourWeight >= -std::numeric_limits<PointBaseType>::epsilon() );
 
 			neighbourWeight = std::max<PointBaseType>(neighbourWeight * neighbourWeight, 1.e-6 );
 

--- a/include/IECore/KDTree.inl
+++ b/include/IECore/KDTree.inl
@@ -35,8 +35,6 @@
 #include "IECore/BoxOps.h"
 #include "IECore/VectorOps.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 #include <algorithm>
 
 namespace IECore
@@ -144,8 +142,8 @@ unsigned char KDTree<PointIterator>::majorAxis( PermutationConstIterator permFir
 {
 	Point min, max;
 	for( unsigned char i=0; i<VectorTraits<Point>::dimensions(); i++ ) {
-		min[i] = Imath::limits<BaseType>::max();
-		max[i] = Imath::limits<BaseType>::min();
+		min[i] = std::numeric_limits<BaseType>::max();
+		max[i] = std::numeric_limits<BaseType>::lowest();
 	}
 	for( PermutationConstIterator it=permFirst; it!=permLast; it++ )
 	{
@@ -206,7 +204,7 @@ void KDTree<PointIterator>::build( NodeIndex nodeIndex, PermutationIterator perm
 template<class PointIterator>
 PointIterator KDTree<PointIterator>::nearestNeighbour( const Point &p ) const
 {
-	BaseType maxDistSquared = Imath::limits<BaseType>::max();
+	BaseType maxDistSquared = std::numeric_limits<BaseType>::max();
 	PointIterator closestPoint = m_lastPoint;
 	nearestNeighbourWalk( rootIndex(), p, closestPoint, maxDistSquared );
 	return closestPoint;
@@ -244,7 +242,7 @@ unsigned int KDTree<PointIterator>::nearestNNeighbours( const Point &p, unsigned
 
 	if( numNeighbours )
 	{
-		BaseType maxDistSquared = Imath::limits<BaseType>::max();
+		BaseType maxDistSquared = std::numeric_limits<BaseType>::max();
 		nearestNNeighboursWalk( rootIndex(), p, numNeighbours, nearNeighbours, maxDistSquared );
 		std::sort_heap( nearNeighbours.begin(), nearNeighbours.end() );
 	}

--- a/include/IECore/NumericParameter.h
+++ b/include/IECore/NumericParameter.h
@@ -38,7 +38,7 @@
 #include "IECore/Parameter.h"
 #include "IECore/TypedData.h"
 
-#include "OpenEXR/ImathLimits.h"
+#include "OpenEXR/half.h"
 
 namespace IECore
 {
@@ -58,7 +58,7 @@ class IECORE_EXPORT NumericParameter : public Parameter
 		typedef std::vector<Preset> PresetsContainer;
 
 		NumericParameter( const std::string &name, const std::string &description, T defaultValue = T(),
-			T minValue = Imath::limits<T>::min(), T maxValue = Imath::limits<T>::max(),
+			T minValue = std::numeric_limits<T>::lowest(), T maxValue = std::numeric_limits<T>::max(),
 			const PresetsContainer &presets = PresetsContainer(), bool presetsOnly = false, ConstCompoundObjectPtr userData = nullptr );
 
 		NumericParameter( const std::string &name, const std::string &description, T defaultValue,

--- a/include/IECore/PolygonAlgo.inl
+++ b/include/IECore/PolygonAlgo.inl
@@ -37,7 +37,6 @@
 
 #include "IECore/CircularIterator.h"
 
-#include "OpenEXR/ImathMath.h"
 #include "OpenEXR/ImathVecAlgo.h"
 
 namespace IECore

--- a/include/IECore/QuatAlgo.h
+++ b/include/IECore/QuatAlgo.h
@@ -43,95 +43,41 @@
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathQuat.h"
+#include "OpenEXR/ImathMath.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore
 {
 
-/// This is copied from the Imath corresponding to OpenEXR 1.6.1. It (and the other
-/// copied functions below) can be removed when we're no longer building against 1.4.0.
+/// We copied these imath functions into our code before they were released.  Now that we're
+/// using OpenEXR 2, we no longer need them.  I've left these as aliases until we make sure
+/// we remove any use of them in our namespace
 template <class T>
 inline T
 sinx_over_x (T x)
 {
-    if (x * x < Imath::limits<T>::epsilon())
-	return T (1);
-    else
-	return Imath::Math<T>::sin (x) / x;
+	return Imath::sinx_over_x( x );
 }
 
-/// This is copied from the Imath corresponding to OpenEXR 1.6.1. It (and the other
-/// copied functions below) can be removed when we're no longer building against 1.4.0.
 template<class T>
 T
 angle4D (const Imath::Quat<T> &q1, const Imath::Quat<T> &q2)
 {
-    //
-    // Compute the angle between two quaternions,
-    // interpreting the quaternions as 4D vectors.
-    //
-
-    Imath::Quat<T> d = q1 - q2;
-    T lengthD = Imath::Math<T>::sqrt (d ^ d);
-
-    Imath::Quat<T> s = q1 + q2;
-    T lengthS = Imath::Math<T>::sqrt (s ^ s);
-
-    return 2 * Imath::Math<T>::atan2 (lengthD, lengthS);
+	return Imath::angle4D( q1, q2 );
 }
 
-/// This is copied from the Imath corresponding to OpenEXR 1.6.1. It
-/// is much more stable than the one in OpenEXR 1.4.0 so we take a copy of
-/// the preferred one while we're still building with the old OpenEXR.
 template<class T>
 Imath::Quat<T>
 slerp(const Imath::Quat<T> &q1,const Imath::Quat<T> &q2, T t)
 {
-
- 	//
-    // Spherical linear interpolation.
-    // Assumes q1 and q2 are normalized and that q1 != -q2.
-    //
-    // This method does *not* interpolate along the shortest
-    // arc between q1 and q2.  If you desire interpolation
-    // along the shortest arc, and q1^q2 is negative, then
-    // consider flipping the second quaternion explicitly.
-    //
-    // The implementation of squad() depends on a slerp()
-    // that interpolates as is, without the automatic
-    // flipping.
-    //
-    // Don Hatch explains the method we use here on his
-    // web page, The Right Way to Calculate Stuff, at
-    // http://www.plunk.org/~hatch/rightway.php
-    //
-
-    T a = IECore::angle4D (q1, q2);
-    T s = 1 - t;
-
-    Imath::Quat<T> q = IECore::sinx_over_x (s * a) / IECore::sinx_over_x (a) * s * q1 +
-	        IECore::sinx_over_x (t * a) / IECore::sinx_over_x (a) * t * q2;
-
-    return q.normalized();
+    return Imath::slerp( q1, q2, t );
 }
 
-/// This is copied from revision 1.7 of IlmBase/Imath/ImathQuat.h in the
-/// OpenEXR cvs repository. It's useful and it's not available in any of
-/// the official OpenEXR releases yet.
 template<class T>
 Imath::Quat<T>
 slerpShortestArc (const Imath::Quat<T> &q1, const Imath::Quat<T> &q2, T t)
 {
-    //
-    // Spherical linear interpolation along the shortest
-    // arc from q1 to either q2 or -q2, whichever is closer.
-    // Assumes q1 and q2 are unit quaternions.
-    //
-
-    if ((q1 ^ q2) >= 0)
-        return IECore::slerp (q1, q2, t);
-    else
-        return IECore::slerp (q1, -q2, t);
+    return Imath::slerpShortestArc( q1, q2, t );
 }
 
 } // namespace IECore

--- a/include/IECore/RandomAlgo.inl
+++ b/include/IECore/RandomAlgo.inl
@@ -41,8 +41,6 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathVec.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
-#include "OpenEXR/ImathMath.h"
-
 namespace IECore
 {
 
@@ -80,7 +78,7 @@ Vec cosineHemisphereRand( Rand &rand )
 	Vec result;
 	result[0] = d[0];
 	result[1] = d[1];
-	result[2] = Imath::Math<BaseType>::sqrt( std::max( BaseType( 0 ), BaseType( 1 ) - d.x*d.x - d.y*d.y ) );
+	result[2] = std::sqrt( std::max( BaseType( 0 ), BaseType( 1 ) - d.x*d.x - d.y*d.y ) );
 	return result;
 }
 

--- a/include/IECore/SphericalToEuclideanTransform.inl
+++ b/include/IECore/SphericalToEuclideanTransform.inl
@@ -43,8 +43,6 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "OpenEXR/ImathVec.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
-#include "OpenEXR/ImathLimits.h"
-
 #include <cassert>
 
 namespace IECore
@@ -59,11 +57,8 @@ template<typename F, typename T>
 T SphericalToEuclideanTransform<F, T>::transform( const F &f )
 {
 	typedef typename VectorTraits< T >::BaseType V;
-	V sinTheta = sin( f.y );
-	T res( sinTheta*Imath::Math<V>::cos( f.x ),
-						sinTheta*Imath::Math<V>::sin( f.x ),
-						Imath::Math<V>::cos( f.y )
-	);
+	V sinTheta = std::sin( f.y );
+	T res( sinTheta * std::cos( f.x ), sinTheta * std::sin( f.x ), std::cos( f.y ) );
 	if ( TypeTraits::IsVec3<F>::value )
 	{
 		res *= f[2];

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -37,8 +37,7 @@
 
 #include "IECore/Exception.h"
 
-#include "OpenEXR/ImathLimits.h"
-#include "OpenEXR/ImathMath.h"
+#include "OpenEXR/half.h"
 
 #include "boost/format.hpp"
 
@@ -219,7 +218,7 @@ inline X Spline<X,Y>::solve( X x, typename PointContainer::const_iterator &segme
 	}
 
 	X tMid, xMid;
-	X epsilon = Imath::limits<X>::epsilon(); // might be nice to present this as a parameter
+	X epsilon = std::numeric_limits<X>::epsilon(); // might be nice to present this as a parameter
 	do
 	{
 		tMid = ( tMin + tMax ) / X( 2 );
@@ -232,7 +231,7 @@ inline X Spline<X,Y>::solve( X x, typename PointContainer::const_iterator &segme
 		{
 			tMin = tMid;
 		}
-	} while( Imath::Math<X>::fabs( tMin - tMax ) > epsilon );
+	} while( std::fabs( tMin - tMax ) > epsilon );
 
 	return tMid;
 }

--- a/include/IECore/StreamIndexedIO.h
+++ b/include/IECore/StreamIndexedIO.h
@@ -181,8 +181,8 @@ class IECORE_API StreamIndexedIO : public IndexedIO
 				void seekp( size_t pos, std::ios_base::seekdir dir );
 				void read( char *buffer, size_t size );
 				void write( const char *buffer, size_t size );
-				Imf::Int64 tellg();
-				Imf::Int64 tellp();
+				uint64_t tellg();
+				uint64_t tellp();
 
 				IndexedIO::OpenMode openMode() const;
 

--- a/include/IECore/TetrahedronAlgo.inl
+++ b/include/IECore/TetrahedronAlgo.inl
@@ -38,8 +38,6 @@
 #include "IECore/TriangleAlgo.h"
 #include "IECore/VectorOps.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 #include <cassert>
 
 namespace IECore
@@ -120,7 +118,7 @@ typename VectorTraits<Vec>::BaseType tetrahedronClosestBarycentric(
 	Vec centroid = vecAdd( v0, vecAdd( v1, vecAdd( v2, v3 ) ) ) / 4.0;
 
 	Vec closestPoint = p;
-	typename VectorTraits<Vec>::BaseType closestDistSqrd = Imath::limits< typename VectorTraits<Vec>::BaseType >::max();
+	typename VectorTraits<Vec>::BaseType closestDistSqrd = std::numeric_limits< typename VectorTraits<Vec>::BaseType >::max();
 
 	Vec v[4] = { v0, v1, v2, v3 };
 

--- a/include/IECore/TriangleAlgo.inl
+++ b/include/IECore/TriangleAlgo.inl
@@ -37,7 +37,6 @@
 
 #include "IECore/VectorOps.h"
 
-#include "OpenEXR/ImathLimits.h"
 #include "OpenEXR/ImathLineAlgo.h"
 
 #include <cassert>
@@ -184,7 +183,7 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 			{
 				s = Real(0.0);
 				t = Real(0.0);
-				distSqrd = Imath::limits<Real>::max();
+				distSqrd = std::numeric_limits<Real>::max();
 			}
 			else
 			{

--- a/include/IECore/VectorOps.inl
+++ b/include/IECore/VectorOps.inl
@@ -183,7 +183,7 @@ inline typename VectorTraits<T>::BaseType vecLength2( const T &v )
 template<typename T>
 inline typename VectorTraits<T>::BaseType vecLength( const T &v )
 {
-	return Imath::Math<typename VectorTraits<T>::BaseType>::sqrt( vecLength2( v ) );
+	return std::sqrt( vecLength2( v ) );
 }
 
 template<typename T>
@@ -210,7 +210,7 @@ inline typename VectorTraits<T>::BaseType vecDistance2( const T &v1, const T &v2
 template<typename T>
 inline typename VectorTraits<T>::BaseType vecDistance( const T &v1, const T &v2 )
 {
-	return Imath::Math<typename VectorTraits<T>::BaseType>::sqrt( vecDistance2( v1, v2 ) );
+	return std::sqrt( vecDistance2( v1, v2 ) );
 }
 
 template<typename T, typename S>

--- a/include/IECoreMaya/BoxTraits.h
+++ b/include/IECoreMaya/BoxTraits.h
@@ -35,8 +35,6 @@
 #ifndef IE_COREMAYA_BOXTRAITS_H
 #define IE_COREMAYA_BOXTRAITS_H
 
-#include "OpenEXR/ImathLimits.h"
-
 #include "IECore/BoxTraits.h"
 #include "IECoreMaya/VectorTraits.h"
 
@@ -83,7 +81,7 @@ struct BoxTraits<MBoundingBox>
 	/// Return true if the box is considered to be empty
 	static bool isEmpty( const MBoundingBox& box )
 	{
-		return box.width() * box.height() * box.depth() <= Imath::limits<double>::epsilon() ;
+		return box.width() * box.height() * box.depth() <= std::numeric_limits<double>::epsilon() ;
 	}
 
 	/// Modify the box such that it is considered to be empty

--- a/include/IECoreScene/CurvesPrimitiveEvaluator.h
+++ b/include/IECoreScene/CurvesPrimitiveEvaluator.h
@@ -134,10 +134,10 @@ class IECORESCENE_API CurvesPrimitiveEvaluator : public PrimitiveEvaluator
 		bool pointAtUV( const Imath::V2f &uv, PrimitiveEvaluator::Result *result ) const override;
 		/// Not yet implemented.
 		bool intersectionPoint( const Imath::V3f &origin, const Imath::V3f &direction,
-			PrimitiveEvaluator::Result *result, float maxDistance = Imath::limits<float>::max() ) const override;
+			PrimitiveEvaluator::Result *result, float maxDistance = std::numeric_limits<float>::max() ) const override;
 		/// Not yet implemented.
 		int intersectionPoints( const Imath::V3f &origin, const Imath::V3f &direction,
-			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = Imath::limits<float>::max() ) const override;
+			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = std::numeric_limits<float>::max() ) const override;
 		//@}
 
 		//! @name Curve specific query functions

--- a/include/IECoreScene/MeshPrimitiveEvaluator.h
+++ b/include/IECoreScene/MeshPrimitiveEvaluator.h
@@ -121,10 +121,10 @@ class IECORESCENE_API MeshPrimitiveEvaluator : public PrimitiveEvaluator
 		bool pointAtUV( const Imath::V2f &uv, PrimitiveEvaluator::Result *result ) const override;
 
 		bool intersectionPoint( const Imath::V3f &origin, const Imath::V3f &direction,
-			PrimitiveEvaluator::Result *result, float maxDistance = Imath::limits<float>::max() ) const override;
+			PrimitiveEvaluator::Result *result, float maxDistance = std::numeric_limits<float>::max() ) const override;
 
 		int intersectionPoints( const Imath::V3f &origin, const Imath::V3f &direction,
-			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = Imath::limits<float>::max() ) const override;
+			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = std::numeric_limits<float>::max() ) const override;
 
 		/// A query specific to the MeshPrimitiveEvaluator, this just chooses a barycentric position on a specific triangle.
 		bool barycentricPosition( unsigned int triangleIndex, const Imath::V3f &barycentricCoordinates, PrimitiveEvaluator::Result *result ) const;

--- a/include/IECoreScene/PointsPrimitiveEvaluator.h
+++ b/include/IECoreScene/PointsPrimitiveEvaluator.h
@@ -122,10 +122,10 @@ class IECORESCENE_API PointsPrimitiveEvaluator : public PrimitiveEvaluator
 		bool pointAtUV( const Imath::V2f &uv, PrimitiveEvaluator::Result *result ) const override;
 		/// Not yet implemented.
 		bool intersectionPoint( const Imath::V3f &origin, const Imath::V3f &direction,
-			PrimitiveEvaluator::Result *result, float maxDistance = Imath::limits<float>::max() ) const override;
+			PrimitiveEvaluator::Result *result, float maxDistance = std::numeric_limits<float>::max() ) const override;
 		/// Not yet implemented.
 		int intersectionPoints( const Imath::V3f &origin, const Imath::V3f &direction,
-			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = Imath::limits<float>::max() ) const override;
+			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = std::numeric_limits<float>::max() ) const override;
 		//@}
 
 	protected :

--- a/include/IECoreScene/PrimitiveEvaluator.h
+++ b/include/IECoreScene/PrimitiveEvaluator.h
@@ -155,12 +155,12 @@ class IECORESCENE_API PrimitiveEvaluator : public IECore::RunTimeTyped
 		/// Finds the closest intersection point for the given ray. Optionally specify a maximum distance of interest.
 		/// Returns true if an intersection was found.
 		virtual bool intersectionPoint( const Imath::V3f &origin, const Imath::V3f &direction,
-			Result *result, float maxDistance = Imath::limits<float>::max() ) const =0;
+			Result *result, float maxDistance = std::numeric_limits<float>::max() ) const =0;
 
 		/// Finds all intersection points for the given ray. Optionally specify a maximum distance of interest.
 		/// Returns the number of interections found.
 		virtual int intersectionPoints( const Imath::V3f &origin, const Imath::V3f &direction,
-			std::vector<ResultPtr> &results, float maxDistance = Imath::limits<float>::max() ) const =0;
+			std::vector<ResultPtr> &results, float maxDistance = std::numeric_limits<float>::max() ) const =0;
 
 		//@}
 

--- a/include/IECoreScene/SpherePrimitiveEvaluator.h
+++ b/include/IECoreScene/SpherePrimitiveEvaluator.h
@@ -107,10 +107,10 @@ class IECORESCENE_API SpherePrimitiveEvaluator : public PrimitiveEvaluator
 		bool pointAtUV( const Imath::V2f &uv, PrimitiveEvaluator::Result *result ) const override;
 
 		bool intersectionPoint( const Imath::V3f &origin, const Imath::V3f &direction,
-			PrimitiveEvaluator::Result *result, float maxDistance = Imath::limits<float>::max() ) const override;
+			PrimitiveEvaluator::Result *result, float maxDistance = std::numeric_limits<float>::max() ) const override;
 
 		int intersectionPoints( const Imath::V3f &origin, const Imath::V3f &direction,
-			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = Imath::limits<float>::max() ) const override;
+			std::vector<PrimitiveEvaluator::ResultPtr> &results, float maxDistance = std::numeric_limits<float>::max() ) const override;
 
 		float volume() const override;
 

--- a/include/IECoreScene/Triangulator.inl
+++ b/include/IECoreScene/Triangulator.inl
@@ -98,7 +98,7 @@ void Triangulator<PointIterator, MeshBuilder>::triangulate( LoopIterator first, 
 	HoleMap holes;
 	for( LoopIterator lIt=++first; lIt!=last; lIt++ )
 	{
-		BaseType m = Imath::limits<BaseType>::min();
+		BaseType m = std::numeric_limits<BaseType>::lowest();
 		PointIterator mIt;
 		for( PointIterator it=lIt->first; it!=lIt->second; it++ )
 		{

--- a/src/IECore/DataCastOp.cpp
+++ b/src/IECore/DataCastOp.cpp
@@ -76,7 +76,7 @@ DataCastOp::DataCastOp()
 		"The target Data typeId.",
 		InvalidTypeId,
 		0,
-		Imath::limits<int>::max()
+		std::numeric_limits<int>::max()
 	);
 	parameters()->addParameter( m_objectParameter );
 	parameters()->addParameter( m_targetTypeParameter );

--- a/src/IECore/DataConvertOp.cpp
+++ b/src/IECore/DataConvertOp.cpp
@@ -77,7 +77,7 @@ DataConvertOp::DataConvertOp()
 			"The data type to convert to.",
 			InvalidTypeId,
 			0,
-			Imath::limits<int>::max()
+			std::numeric_limits<int>::max()
 		)
 
 	);

--- a/src/IECore/DataInterleaveOp.cpp
+++ b/src/IECore/DataInterleaveOp.cpp
@@ -78,7 +78,7 @@ DataInterleaveOp::DataInterleaveOp()
 			"The type of data created.",
 			InvalidTypeId,
 			0,
-			Imath::limits<int>::max()
+			std::numeric_limits<int>::max()
 		)
 
 	);

--- a/src/IECore/DataPromoteOp.cpp
+++ b/src/IECore/DataPromoteOp.cpp
@@ -76,7 +76,7 @@ DataPromoteOp::DataPromoteOp()
 	        "The target Data typeId.",
 	        InvalidTypeId,
 	        0,
-	        Imath::limits<int>::max()
+	        std::numeric_limits<int>::max()
 	);
 	parameters()->addParameter( m_objectParameter );
 	parameters()->addParameter( m_targetTypeParameter );

--- a/src/IECore/FileIndexedIO.cpp
+++ b/src/IECore/FileIndexedIO.cpp
@@ -159,7 +159,7 @@ FileIndexedIO::StreamFile::~StreamFile()
 		std::fstream *f = static_cast< std::fstream * >( m_stream );
 
 		f->seekg( 0, std::ios::end );
-		Imf::Int64 fileEnd = f->tellg();
+		uint64_t fileEnd = f->tellg();
 
 		// .. and the length of that file extends beyond the end of the index
 		if ( fileEnd > m_endPosition )

--- a/src/IECore/NumericParameter.cpp
+++ b/src/IECore/NumericParameter.cpp
@@ -77,7 +77,7 @@ NumericParameter<T>::NumericParameter( const std::string &name, const std::strin
 template<typename T>
 NumericParameter<T>::NumericParameter( const std::string &name, const std::string &description, T defaultValue,
 	const PresetsContainer &presets, ConstCompoundObjectPtr userData )
-	: Parameter( name, description, new ObjectType( defaultValue ), convertPresets<T>( presets ), true, userData ), m_min( Imath::limits<T>::min() ), m_max( Imath::limits<T>::max() )
+	: Parameter( name, description, new ObjectType( defaultValue ), convertPresets<T>( presets ), true, userData ), m_min( std::numeric_limits<T>::lowest() ), m_max( std::numeric_limits<T>::max() )
 {
 }
 
@@ -88,7 +88,7 @@ NumericParameter<T>::NumericParameter( const std::string &name, const std::strin
 template<typename T>
 bool NumericParameter<T>::hasMinValue() const
 {
-	return m_min != Imath::limits<T>::min();
+	return m_min != std::numeric_limits<T>::lowest();
 }
 
 template<typename T>
@@ -100,7 +100,7 @@ T NumericParameter<T>::minValue() const
 template<typename T>
 bool NumericParameter<T>::hasMaxValue() const
 {
-	return m_max != Imath::limits<T>::max();
+	return m_max != std::numeric_limits<T>::max();
 }
 
 template<typename T>

--- a/src/IECoreGL/DiskPrimitive.cpp
+++ b/src/IECoreGL/DiskPrimitive.cpp
@@ -39,8 +39,6 @@
 #include "IECore/Math.h"
 #include "IECore/MessageHandler.h"
 
-#include "OpenEXR/ImathMath.h"
-
 using namespace std;
 using namespace Imath;
 using namespace IECoreGL;
@@ -71,8 +69,8 @@ DiskPrimitive::DiskPrimitive( float radius, float z, float thetaMax )
 	for( unsigned int i=0; i<n; i++ )
 	{
 		float t = thetaMaxRadians * i/(n-1);
-		float x = Math<float>::cos( t );
-		float y = Math<float>::sin( t );
+		float x = cosf( t );
+		float y = sinf( t );
 		pVector.push_back( V3f( m_radius * x, m_radius * y, m_z ) );
 		nVector.push_back( V3f( 0.0f, 0.0f, 1.0f ) );
 		uvVector.push_back( V2f( x/2.0f + 0.5f, y/2.0f + 0.5f ) );

--- a/src/IECoreGL/HitRecord.cpp
+++ b/src/IECoreGL/HitRecord.cpp
@@ -38,15 +38,13 @@
 
 #include "IECore/Exception.h"
 
-#include "OpenEXR/ImathLimits.h"
-
 #include "boost/format.hpp"
 
 using namespace IECoreGL;
 
 HitRecord::HitRecord( const GLuint *hitRecord )
-	:	depthMin( (float)hitRecord[1]/(float)Imath::limits<GLuint>::max() ),
-		depthMax( (float)hitRecord[2]/(float)Imath::limits<GLuint>::max() ),
+	:	depthMin( (float)hitRecord[1]/(float)std::numeric_limits<GLuint>::max() ),
+		depthMax( (float)hitRecord[2]/(float)std::numeric_limits<GLuint>::max() ),
 		name( hitRecord[3] )
 
 {

--- a/src/IECoreGL/QuadPrimitive.cpp
+++ b/src/IECoreGL/QuadPrimitive.cpp
@@ -38,8 +38,6 @@
 #include "IECoreGL/CachedConverter.h"
 #include "IECoreGL/GL.h"
 
-#include "OpenEXR/ImathMath.h"
-
 using namespace IECoreGL;
 using namespace Imath;
 using namespace std;

--- a/src/IECoreGL/Selector.cpp
+++ b/src/IECoreGL/Selector.cpp
@@ -360,7 +360,7 @@ class Selector::Implementation : public IECore::RefCounted
 				std::map<unsigned int, HitRecord>::iterator it = idRecords.find( ids[i] );
 				if( it == idRecords.end() )
 				{
-					HitRecord r( Imath::limits<float>::max(), Imath::limits<float>::min(), ids[i] );
+					HitRecord r( std::numeric_limits<float>::max(), std::numeric_limits<float>::lowest(), ids[i] );
 					it = idRecords.insert( std::pair<unsigned int, HitRecord>( ids[i], r ) ).first;
 				}
 				it->second.depthMin = std::min( it->second.depthMin, z[i] );

--- a/src/IECoreGL/SpherePrimitive.cpp
+++ b/src/IECoreGL/SpherePrimitive.cpp
@@ -42,7 +42,6 @@
 #include "IECore/MessageHandler.h"
 
 #include "OpenEXR/ImathFun.h"
-#include "OpenEXR/ImathMath.h"
 
 using namespace IECoreGL;
 using namespace Imath;
@@ -56,9 +55,9 @@ SpherePrimitive::SpherePrimitive( float radius, float zMin, float zMax, float th
 	// figure out bounding box
 
 	thetaMax = m_thetaMax/180.0f * M_PI;
-	float minX = m_radius * ( thetaMax < M_PI ? Math<float>::cos( thetaMax ) : -1.0f );
-	float maxY = m_radius * ( thetaMax < M_PI/2 ? Math<float>::sin( thetaMax ) : 1.0f );
-	float minY = m_radius * ( thetaMax > 3 * M_PI/2 ? -1.0f : min( 0.0f, Math<float>::sin( thetaMax ) ) );
+	float minX = m_radius * ( thetaMax < M_PI ? cosf( thetaMax ) : -1.0f );
+	float maxY = m_radius * ( thetaMax < M_PI/2 ? sinf( thetaMax ) : 1.0f );
+	float minY = m_radius * ( thetaMax > 3 * M_PI/2 ? -1.0f : min( 0.0f, sinf( thetaMax ) ) );
 	m_bound = Imath::Box3f( V3f( minX, minY, m_zMin * m_radius ), V3f( m_radius, maxY, m_zMax * m_radius ) );
 
 	// build vertex attributes for P, N and st, and indexes for triangles.
@@ -73,8 +72,8 @@ SpherePrimitive::SpherePrimitive( float radius, float zMin, float zMax, float th
 	vector<V2f> &uvVector = uvData->writable();
 	vector<unsigned int> &vertIdsVector = m_vertIds->writable();
 
-	float oMin = Math<float>::asin( m_zMin );
-	float oMax = Math<float>::asin( m_zMax );
+	float oMin = asinf( m_zMin );
+	float oMax = asinf( m_zMax );
 	const unsigned int nO = max( 4u, (unsigned int)( 20.0f * (oMax - oMin) / M_PI ) );
 
 	thetaMax = m_thetaMax/180.0f * M_PI;
@@ -84,14 +83,14 @@ SpherePrimitive::SpherePrimitive( float radius, float zMin, float zMax, float th
 	{
 		float v = (float)i/(float)(nO-1);
 		float o = lerp( oMin, oMax, v );
-		float z = m_radius * Math<float>::sin( o );
-		float r = m_radius * Math<float>::cos( o );
+		float z = m_radius * sinf( o );
+		float r = m_radius * cosf( o );
 
 		for( unsigned int j=0; j<nT; j++ )
 		{
 			float u = (float)j/(float)(nT-1);
 			float theta = thetaMax * u;
-			V3f p( r * Math<float>::cos( theta ), r * Math<float>::sin( theta ), z );
+			V3f p( r * cosf( theta ), r * sinf( theta ), z );
 			uvVector.push_back( V2f( u, v ) );
 			pVector.push_back( p );
 			nVector.push_back( p );

--- a/src/IECoreMaya/FromMayaCameraConverter.cpp
+++ b/src/IECoreMaya/FromMayaCameraConverter.cpp
@@ -48,8 +48,6 @@
 #include "maya/MDagPath.h"
 #include "maya/MPlug.h"
 
-#include "OpenEXR/ImathMath.h"
-
 using namespace IECoreMaya;
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/IECoreMaya/FromMayaLocatorConverter.cpp
+++ b/src/IECoreMaya/FromMayaLocatorConverter.cpp
@@ -45,8 +45,6 @@
 #include "maya/MDagPath.h"
 #include "maya/MFnDagNode.h"
 
-#include "OpenEXR/ImathMath.h"
-
 using namespace IECoreMaya;
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/IECoreMaya/ImageFile.cpp
+++ b/src/IECoreMaya/ImageFile.cpp
@@ -35,8 +35,6 @@
 #include <cassert>
 #include <algorithm>
 
-#include "OpenEXR/ImathLimits.h"
-
 #include "IECoreGL/GL.h"
 
 #include "maya/MGlobal.h"

--- a/src/IECoreMaya/NumericParameterHandler.cpp
+++ b/src/IECoreMaya/NumericParameterHandler.cpp
@@ -74,7 +74,7 @@ MStatus NumericParameterHandler<T>::doUpdate( IECore::ConstParameterPtr paramete
 
 	fnNAttr.setDefault( p->numericDefaultValue() );
 
-	if( p->minValue()!=Imath::limits<T>::min() )
+	if( p->minValue()!=std::numeric_limits<T>::lowest() )
 	{
 		fnNAttr.setMin( p->minValue() );
 	}
@@ -89,7 +89,7 @@ MStatus NumericParameterHandler<T>::doUpdate( IECore::ConstParameterPtr paramete
 		}
 	}
 
-	if( p->maxValue()!=Imath::limits<T>::max() )
+	if( p->maxValue()!=std::numeric_limits<T>::max() )
 	{
 		fnNAttr.setMax( p->maxValue() );
 	}

--- a/src/IECorePython/NumericParameterBinding.cpp
+++ b/src/IECorePython/NumericParameterBinding.cpp
@@ -57,8 +57,8 @@ class NumericParameterWrapper : public ParameterWrapper<NumericParameter<T> >
 	public :
 
 		NumericParameterWrapper(
-			PyObject *wrapperSelf, const std::string &n, const std::string &d, T v = T(), T minValue = Imath::limits<T>::min(),
-			T maxValue = Imath::limits<T>::max(), const object &p = boost::python::tuple(), bool po = false, CompoundObjectPtr ud = nullptr
+			PyObject *wrapperSelf, const std::string &n, const std::string &d, T v = T(), T minValue = std::numeric_limits<T>::lowest(),
+			T maxValue = std::numeric_limits<T>::max(), const object &p = boost::python::tuple(), bool po = false, CompoundObjectPtr ud = nullptr
 		)
 			: ParameterWrapper<NumericParameter<T> >( wrapperSelf, n, d, v, minValue, maxValue, parameterPresets<typename NumericParameter<T>::PresetsContainer>( p ), po, ud )
 		{
@@ -84,8 +84,8 @@ static void bindNumericParameter()
 					arg( "name" ),
 					arg( "description" ),
 					arg( "defaultValue" ) = T(),
-					arg( "minValue" ) = Imath::limits<T>::min(),
-					arg( "maxValue" ) = Imath::limits<T>::max(),
+					arg( "minValue" ) = std::numeric_limits<T>::lowest(),
+					arg( "maxValue" ) = std::numeric_limits<T>::max(),
 					arg( "presets" ) = boost::python::tuple(),
 					arg( "presetsOnly" ) = false,
 					arg( "userData" ) = CompoundObject::Ptr( nullptr )

--- a/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
@@ -419,7 +419,7 @@ bool CurvesPrimitiveEvaluator::closestPoint( const Imath::V3f &p, PrimitiveEvalu
 
 	unsigned curveIndex = 0;
 	float v = -1;
-	float distSquared = Imath::limits<float>::max();
+	float distSquared = std::numeric_limits<float>::max();
 	closestPointWalk( m_tree.rootIndex(), p, curveIndex, v, distSquared );
 	(typedResult->*typedResult->m_init)( curveIndex, v, this );
 

--- a/src/IECoreScene/DiskPrimitive.cpp
+++ b/src/IECoreScene/DiskPrimitive.cpp
@@ -66,7 +66,7 @@ float DiskPrimitive::getRadius() const
 
 void DiskPrimitive::setRadius( float radius )
 {
-	if ( radius <= Imath::limits<float>::epsilon() )
+	if ( radius <= std::numeric_limits<float>::epsilon() )
 	{
 		throw InvalidArgumentException( "Invalid radius specified for DiskPrimitive" );
 	}

--- a/src/IECoreScene/LimitSmoothSkinningInfluencesOp.cpp
+++ b/src/IECoreScene/LimitSmoothSkinningInfluencesOp.cpp
@@ -188,7 +188,7 @@ void LimitSmoothSkinningInfluencesOp::modify( Object * object, const CompoundObj
 			for ( int j=0; j < numToLimit; j++ )
 			{
 				int indexOfMin = -1;
-				float minWeight = Imath::limits<float>::max();
+				float minWeight = std::numeric_limits<float>::max();
 
 				for ( int k=0; k < pointInfluenceCounts[i]; k++ )
 				{

--- a/src/IECoreScene/MeshPrimitive.cpp
+++ b/src/IECoreScene/MeshPrimitive.cpp
@@ -37,7 +37,6 @@
 #include "IECoreScene/PolygonIterator.h"
 #include "IECoreScene/Renderer.h"
 
-#include "IECore/Math.h"
 #include "IECore/MurmurHash.h"
 
 #include "boost/format.hpp"
@@ -708,8 +707,8 @@ MeshPrimitivePtr MeshPrimitive::createSphere( float radius, float zMin, float zM
 	/// aligned to +X with uv(0,0.5), and the moving edge should be uv(1,0.5).
 	/// Remember to update SpherePrimitive at the same time.
 
-	float oMin = Math<float>::asin( zMin );
-	float oMax = Math<float>::asin( zMax );
+	float oMin = asinf( zMin );
+	float oMax = asinf( zMax );
 	const unsigned int nO = max( 4u, (unsigned int)round( divisions.x * (oMax - oMin) / M_PI ) + 1 );
 
 	float thetaMaxRad = thetaMax / 180.0f * M_PI;
@@ -719,8 +718,8 @@ MeshPrimitivePtr MeshPrimitive::createSphere( float radius, float zMin, float zM
 	{
 		float v = (float)i/(float)(nO-1);
 		float o = lerp( oMin, oMax, v );
-		float z = radius * Math<float>::sin( o );
-		float r = radius * Math<float>::cos( o );
+		float z = radius * sinf( o );
+		float r = radius * cosf( o );
 
 		const bool atPole =
 			( i == 0 && zMin == -1 ) ||
@@ -746,7 +745,7 @@ MeshPrimitivePtr MeshPrimitive::createSphere( float radius, float zMin, float zM
 			const bool addP = atPole ? j == 0 : !(thetaMax == 360 && j == nT - 1 );
 			if( addP )
 			{
-				V3f p( r * Math<float>::cos( theta ), r * Math<float>::sin( theta ), z );
+				V3f p( r * cosf( theta ), r * sinf( theta ), z );
 				pVector.push_back( p );
 				nVector.push_back( p );
 			}

--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -559,7 +559,7 @@ void MeshPrimitiveEvaluator::calculateAverageNormals() const
 
 			double cosAngle = e0.dot( e1 );
 			double angle = acos( cosAngle );
-			assert( angle >= -Imath::limits<double>::epsilon() );
+			assert( angle >= -std::numeric_limits<double>::epsilon() );
 
 			const Imath::V3f &p0 = m_verts->readable()[ v0 ];
 			const Imath::V3f &p1 = m_verts->readable()[ v1 ];
@@ -672,7 +672,7 @@ bool MeshPrimitiveEvaluator::signedDistance( const Imath::V3f &p, float &distanc
 			const Imath::V3f &n = r->normal();
 			float planeConstant = n.dot( r->point() );
 			float sign = n.dot( p ) - planeConstant;
-			distance = (r->point() - p ).length() * (sign < Imath::limits<float>::epsilon() ? -1.0 : 1.0 );
+			distance = (r->point() - p ).length() * (sign < std::numeric_limits<float>::epsilon() ? -1.0 : 1.0 );
 			return true;
 		}
 		else  if ( region % 2 == 1 )
@@ -702,7 +702,7 @@ bool MeshPrimitiveEvaluator::signedDistance( const Imath::V3f &p, float &distanc
 			const Imath::V3f &n = it->second;
 			float planeConstant = n.dot( r->point() );
 			float sign = n.dot( p ) - planeConstant;
-			distance = (r->point() - p ).length() * (sign < Imath::limits<float>::epsilon() ? -1.0 : 1.0 );
+			distance = (r->point() - p ).length() * (sign < std::numeric_limits<float>::epsilon() ? -1.0 : 1.0 );
 			return true;
 		}
 		else
@@ -732,7 +732,7 @@ bool MeshPrimitiveEvaluator::signedDistance( const Imath::V3f &p, float &distanc
 			const V3f &n = m_vertexAngleWeightedNormals->readable()[ triangleVertexIds[ closestVertex ] ];
 			float planeConstant = n.dot( r->point() );
 			float sign = n.dot( p ) - planeConstant;
-			distance = (r->point() - p ).length() * (sign < Imath::limits<float>::epsilon() ? -1.0 : 1.0 );
+			distance = (r->point() - p ).length() * (sign < std::numeric_limits<float>::epsilon() ? -1.0 : 1.0 );
 			return true;
 		}
 	}
@@ -768,7 +768,7 @@ bool MeshPrimitiveEvaluator::closestPoint( const V3f &p, PrimitiveEvaluator::Res
 
 	Result *mr = static_cast<Result *>( result );
 
-	float maxDistSqrd = limits<float>::max();
+	float maxDistSqrd = std::numeric_limits<float>::max();
 
 	closestPointWalk( m_tree->rootIndex(), p, maxDistSqrd, mr );
 

--- a/src/IECoreScene/PrimitiveEvaluator.cpp
+++ b/src/IECoreScene/PrimitiveEvaluator.cpp
@@ -98,7 +98,7 @@ bool PrimitiveEvaluator::signedDistance( const Imath::V3f &p, float &distance, R
 	float planeConstant = result->normal().dot( result->point() );
 	float sign = result->normal().dot( p ) - planeConstant;
 
-	distance = (result->point() - p ).length() * (sign < Imath::limits<float>::epsilon() ? -1.0 : 1.0 );
+	distance = (result->point() - p ).length() * (sign < std::numeric_limits<float>::epsilon() ? -1.0 : 1.0 );
 
 	return true;
 }

--- a/src/IECoreScene/SpherePrimitive.cpp
+++ b/src/IECoreScene/SpherePrimitive.cpp
@@ -60,7 +60,7 @@ SpherePrimitive::SpherePrimitive() : m_radius( 1.0f ), m_zMin( -1.0f ), m_zMax( 
 
 SpherePrimitive::SpherePrimitive( float radius, float zMin, float zMax, float thetaMax ) : m_radius( radius), m_zMin( zMin ), m_zMax( zMax ), m_thetaMax( thetaMax )
 {
-	if ( radius <= Imath::limits<float>::epsilon() )
+	if ( radius <= std::numeric_limits<float>::epsilon() )
 	{
 		throw InvalidArgumentException( "Invalid radius specified for SpherePrimitive" );
 	}

--- a/src/IECoreScene/SpherePrimitiveEvaluator.cpp
+++ b/src/IECoreScene/SpherePrimitiveEvaluator.cpp
@@ -308,7 +308,7 @@ bool SpherePrimitiveEvaluator::intersectionPoint( const Imath::V3f &origin, cons
 		return false;
 	}
 
-	if ( discr >= Imath::limits<float>::epsilon() )
+	if ( discr >= std::numeric_limits<float>::epsilon() )
 	{
 		float root = sqrt( discr );
 		float t0 = -a1 - root;
@@ -384,7 +384,7 @@ int SpherePrimitiveEvaluator::intersectionPoints( const Imath::V3f &origin, cons
 		return 0;
 	}
 
-	if ( discr >= Imath::limits<float>::epsilon() )
+	if ( discr >= std::numeric_limits<float>::epsilon() )
 	{
 		float root = sqrt( discr );
 		float t0 = -a1 - root;


### PR DESCRIPTION
We are already able to use the alternatives that Imath recommends instead, so it's safe to do this transition now.

See the commit message on the big commit for discussion of the details.