### PR TITLE
USD ShaderAlgo : Support Arnold-USD's convention for array connections

### DIFF
--- a/contrib/IECoreUSD/test/IECoreUSD/data/arnoldArrayInputs.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/arnoldArrayInputs.usda
@@ -1,0 +1,47 @@
+#usda 1.0
+
+def Sphere "sphere"
+{
+    rel material:binding = </rampSurface>
+}
+
+def Material "rampSurface"
+{
+    token outputs:arnold:surface.connect = </rampSurface/standardSurface.outputs:surface>
+
+    def Shader "standardSurface"
+    {
+        uniform token info:id = "arnold:standard_surface"
+        color3f inputs:base_color = (0.8, 0.8, 0.8)
+        prepend color3f inputs:base_color.connect = </rampSurface/rampRGB.outputs:out>
+        float inputs:indirect_specular = 0
+        token outputs:surface
+    }
+
+    def Shader "rampRGB"
+    {
+        uniform token info:id = "arnold:ramp_rgb"
+        color3f[] inputs:color = [(0, 0, 0), (0.5, 0.5, 0.5)]
+        prepend color3f inputs:color:i0.connect = </rampSurface/noise.outputs:out>
+        prepend color3f inputs:color:i1.connect = </rampSurface/flat.outputs:out>
+        int[] inputs:interpolation = [1, 1]
+        float[] inputs:position = [0, 1]
+        token inputs:type = "v"
+        color3f outputs:out
+    }
+
+    def Shader "noise"
+    {
+        uniform token info:id = "arnold:noise"
+        color3f inputs:color1 = (1, 0, 0)
+        color3f inputs:color2 = (0, 1, 0)
+        color3f outputs:out
+    }
+
+    def Shader "flat"
+    {
+        uniform token info:id = "arnold:flat"
+        color3f inputs:color = (0, 0, 1)
+        color3f outputs:out
+    }
+}


### PR DESCRIPTION
USDShade doesn't support connections in to indices within arrays (or for that matter, to the components of vectors or colors). It _does_ support multiple connections to the _same_ parameter, but as far as I can tell that seems to be peculiar to RenderMan/Pixar, and I have no idea what the expected semantics for multiple source connections are.

So, the [arnold-usd](https://github.com/Autodesk/arnold-usd) project adopted a [convention](https://github.com/Autodesk/arnold-usd/pull/381) for storing indexed connections in USD, and that's what folks end up using if they export an Arnold shading network from Maya. This PR adds support for loading such connections, converting to our standard internal convention, and for converting them back on write.

See https://groups.google.com/g/gaffer-dev/c/9pcdwKzK4lE for the original bug report.

