### PR TITLE
Resample algorithms (mesh, curves, points) from constant support all data types

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,13 @@
+10.4.x.x (relative to 10.4.4.0)
+========
+
+Fixes
+---
+
+- CurvesAlgo.resamplePrimitiveVariable : From Constant now supports all data types.
+- MeshAlgo.resamplePrimitiveVariable : From Constant now supports all data types.
+- PointsAlgo.resamplePrimitiveVariable : From Constant now supports all data types.
+
 10.4.4.0 (relative to 10.4.3.1)
 ========
 

--- a/src/IECoreScene/CurvesAlgo.cpp
+++ b/src/IECoreScene/CurvesAlgo.cpp
@@ -514,11 +514,8 @@ void resamplePrimitiveVariable( const CurvesPrimitive *curves, PrimitiveVariable
 	}
 	else if ( primitiveVariable.interpolation == PrimitiveVariable::Constant )
 	{
-		DataPtr arrayData = Detail::createArrayData(primitiveVariable, curves, interpolation);
-		if (arrayData)
-		{
-			dstData = arrayData;
-		}
+		Detail::FillVectorFromValue fn( curves->variableSize( interpolation ) );
+		dstData = dispatch( srcData.get(), fn );
 	}
 	else if ( interpolation == PrimitiveVariable::Uniform )
 	{

--- a/src/IECoreScene/MeshAlgoResample.cpp
+++ b/src/IECoreScene/MeshAlgoResample.cpp
@@ -329,7 +329,8 @@ void IECoreScene::MeshAlgo::resamplePrimitiveVariable( const MeshPrimitive *mesh
 
 	if ( primitiveVariable.interpolation == PrimitiveVariable::Constant )
 	{
-		DataPtr arrayData = Detail::createArrayData(primitiveVariable, mesh, interpolation);
+		Detail::FillVectorFromValue fn( mesh->variableSize( interpolation ) );
+		DataPtr arrayData = dispatch( srcData.get(), fn );
 		if (arrayData)
 		{
 			primitiveVariable = PrimitiveVariable(interpolation, arrayData);

--- a/src/IECoreScene/PointsAlgo.cpp
+++ b/src/IECoreScene/PointsAlgo.cpp
@@ -257,15 +257,16 @@ void resamplePrimitiveVariable( const PointsPrimitive *points, PrimitiveVariable
 
 	if ( primitiveVariable.interpolation == PrimitiveVariable::Constant )
 	{
-
-		DataPtr arrayData = Detail::createArrayData(primitiveVariable, points, interpolation);
+		Detail::FillVectorFromValue fn( points->variableSize( interpolation ) );
+		DataPtr arrayData = dispatch( srcData.get(), fn );
 		if (arrayData)
 		{
 			primitiveVariable = PrimitiveVariable(interpolation, arrayData);
 		}
 		return;
 	}
-	else if( interpolation == PrimitiveVariable::Uniform )
+
+	if( interpolation == PrimitiveVariable::Uniform )
 	{
 		if( primitiveVariable.interpolation == PrimitiveVariable::Vertex || primitiveVariable.interpolation == PrimitiveVariable::Varying || primitiveVariable.interpolation == PrimitiveVariable::FaceVarying )
 		{

--- a/test/IECoreScene/CurvesAlgoTest.py
+++ b/test/IECoreScene/CurvesAlgoTest.py
@@ -97,6 +97,8 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		testObject["varying_Color_V3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.V3fVectorData( [imath.V3f(i, i, i) for i in range(0, 12)], IECore.GeometricData.Interpretation.Color ) )
 		testObject["facevarying_Normal_V3f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.V3fVectorData( [imath.V3f(i, i, i) for i in range(0, 12)], IECore.GeometricData.Interpretation.Normal) )
 
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
+
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
 		return testObject
@@ -110,14 +112,26 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 16 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 16 ) )
+
 	def testBSplineCurvesConstantToUniform( self ) :
 
 		curves = self.curvesBSpline()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 2 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 2 ) )
 
 	def testBSplineCurvesConstantToVarying( self ) :
 
@@ -128,6 +142,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 12 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 12 ) )
+
 	def testBSplineCurvesConstantToFaceVarying( self ) :
 
 		curves = self.curvesBSpline()
@@ -136,6 +156,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 12 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 12 ) )
 
 	def testBSplineCurvesVertexToConstant( self ) :
 
@@ -484,6 +510,7 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		testObject["c"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.FloatVectorData( range( 0, 2 ) ) )
 		testObject["d"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( range( 0, 12 ) ) )
 		testObject["e"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( range( 0, 12 ) ) )
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
 		return testObject
@@ -497,14 +524,26 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 16 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 16 ) )
+
 	def testCatmullRomCurvesConstantToUniform( self ) :
 
 		curves = self.curvesCatmullRom()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 2 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 2 ) )
 
 	def testCatmullRomCurvesConstantToVarying( self ) :
 
@@ -515,6 +554,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 12 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 12 ) )
+
 	def testCatmullRomCurvesConstantToFaceVarying( self ) :
 
 		curves = self.curvesCatmullRom()
@@ -523,6 +568,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 12 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 12 ) )
 
 	def testCatmullRomCurvesVertexToConstant( self ) :
 
@@ -683,6 +734,7 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		testObject["c"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.FloatVectorData( range( 0, 2 ) ) )
 		testObject["d"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( range( 0, 4 ) ) )
 		testObject["e"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( range( 0, 4 ) ) )
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
@@ -696,23 +748,41 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 4 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 4 ) )
+
 	def testLinearCurvesConstantToUniform( self ) :
 
 		curves = self.curvesLinear()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 2 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 2 ) )
 
 	def testLinearCurvesConstantToVarying( self ) :
 
 		curves = self.curvesLinear()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 4 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 4 ) )
 
 	def testLinearCurvesConstantToFaceVarying( self ) :
 
@@ -722,6 +792,12 @@ class CurvesAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 4 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 4 ) )
 
 	def testLinearCurvesVertexToConstant( self ) :
 
@@ -1026,6 +1102,7 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		testObject["d"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Varying, IECore.FloatVectorData( range( 0, 6 ) ) )
 		testObject["e"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, IECore.FloatVectorData( range( 0, 6 ) ) )
 		testObject["f"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "test" ) )
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
 		return testObject
@@ -1038,35 +1115,59 @@ class CurvesAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 14 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 14 ) )
+
 	def testBezierCurvesConstantToUniform( self ) :
 		curves = self.curvesBezier()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 2 ) )
 
 		p = curves["f"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.StringVectorData( [ "test" ] * 2 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 2 ) )
+
 	def testBezierCurvesConstantToVarying( self ) :
 		curves = self.curvesBezier()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 6 ) )
 
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 6 ) )
+
 	def testBezierCurvesConstantToFaceVarying( self ) :
 		curves = self.curvesBezier()
 		p = curves["a"]
-		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying)
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 6 ) )
+
+		p = curves["k"]
+		IECoreScene.CurvesAlgo.resamplePrimitiveVariable(curves, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 6 ) )
 
 	def testBezierCurvesVertexToConstant( self ) :
 		curves = self.curvesBezier()
@@ -1693,7 +1794,7 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
 		self.assertTrue( actualBSplineCurves.arePrimitiveVariablesValid() )
 
-		actualBSplineCurves2Step = IECoreScene.CurvesAlgo.updateEndpointMultiplicity( 
+		actualBSplineCurves2Step = IECoreScene.CurvesAlgo.updateEndpointMultiplicity(
 			IECoreScene.CurvesAlgo.updateEndpointMultiplicity( linearCurves, IECore.CubicBasisf.catmullRom() ),
 			IECore.CubicBasisf.bSpline()
 		)
@@ -1777,7 +1878,7 @@ class CurvesAlgoUpdateEndpointMultiplicityTest( unittest.TestCase ):
 
 		self.assertTrue( actualCatCurves.arePrimitiveVariablesValid() )
 
-		actualCatCurves2Step = IECoreScene.CurvesAlgo.updateEndpointMultiplicity( 
+		actualCatCurves2Step = IECoreScene.CurvesAlgo.updateEndpointMultiplicity(
 			IECoreScene.CurvesAlgo.updateEndpointMultiplicity( linearCurves, IECore.CubicBasisf.bSpline() ),
 			IECore.CubicBasisf.catmullRom()
 		)

--- a/test/IECoreScene/MeshAlgoResampleTest.py
+++ b/test/IECoreScene/MeshAlgoResampleTest.py
@@ -68,6 +68,7 @@ class MeshAlgoResampleTest( unittest.TestCase ) :
 			IECore.V2fVectorData( [imath.V2f( i, i ) for i in range( 0, 16 )], IECore.GeometricData.Interpretation.Color ) )
 
 		testObject["j"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "test" ) )
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 
 		return testObject
 
@@ -78,9 +79,14 @@ class MeshAlgoResampleTest( unittest.TestCase ) :
 	def testMeshConstantToVertex( self ) :
 
 		p = self.mesh["a"]
-		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex );
+		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 9 ) )
+
+		p = self.mesh["k"]
+		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 9 ) )
 
 	def testMeshConstantToUniform( self ) :
 
@@ -94,6 +100,11 @@ class MeshAlgoResampleTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.StringVectorData( [ "test" ] * 4 ) )
 
+		p = self.mesh["k"]
+		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 4 ) )
+
 	def testMeshConstantToVarying( self ) :
 
 		p = self.mesh["a"]
@@ -101,13 +112,22 @@ class MeshAlgoResampleTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 9 ) )
 
+		p = self.mesh["k"]
+		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 9 ) )
+
 	def testMeshConstantToFaceVarying( self ) :
 
 		p = self.mesh["a"]
 		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
-
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 16 ) )
+
+		p = self.mesh["k"]
+		IECoreScene.MeshAlgo.resamplePrimitiveVariable( self.mesh, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 16 ) )
 
 	def testMeshVertexToConstant( self ) :
 		p = self.mesh["b"]

--- a/test/IECoreScene/PointsAlgoTest.py
+++ b/test/IECoreScene/PointsAlgoTest.py
@@ -63,6 +63,7 @@ class PointsAlgoTest( unittest.TestCase ) :
 		 	IECore.V3fVectorData( [imath.V3f( i, i, i ) for i in range( 0, 10 )], IECore.GeometricData.Interpretation.Normal ) )
 
 		testObject["j"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "test" ) )
+		testObject["k"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.BoolData( True ) )
 
 		self.assertTrue( testObject.arePrimitiveVariablesValid() )
 
@@ -75,6 +76,12 @@ class PointsAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 10 ) )
+
+		p = points["k"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 10 ) )
 
 	def testPointsConstantToUniform( self ) :
 		points = self.points()
@@ -90,6 +97,12 @@ class PointsAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
 		self.assertEqual( p.data, IECore.StringVectorData( [ "test" ] ) )
 
+		p = points["k"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Uniform )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] ) )
+
 	def testPointsConstantToVarying( self ) :
 		points = self.points()
 		p = points["a"]
@@ -98,6 +111,12 @@ class PointsAlgoTest( unittest.TestCase ) :
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 10 ) )
 
+		p = points["k"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.Varying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 10 ) )
+
 	def testPointsConstantToFaceVarying( self ) :
 		points = self.points()
 		p = points["a"]
@@ -105,6 +124,12 @@ class PointsAlgoTest( unittest.TestCase ) :
 
 		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
 		self.assertEqual( p.data, IECore.FloatVectorData( [ 0.5 ] * 10 ) )
+
+		p = points["k"]
+		IECoreScene.PointsAlgo.resamplePrimitiveVariable(points, p, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+
+		self.assertEqual( p.interpolation, IECoreScene.PrimitiveVariable.Interpolation.FaceVarying )
+		self.assertEqual( p.data, IECore.BoolVectorData( [ True ] * 10 ) )
 
 	def testPointsVertexToConstant( self ) :
 		points = self.points()
@@ -368,7 +393,7 @@ class DeletePointsTest( unittest.TestCase ) :
 		points["delete"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.BoolVectorData( [True] * 10 ) )
 
 		self.assertTrue( points.arePrimitiveVariablesValid() )
-		
+
 		invertedPoints = IECoreScene.PointsAlgo.deletePoints(points, points["delete"], invert=True)
 
 		self.assertTrue( invertedPoints.arePrimitiveVariablesValid() )


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

The resample algorithms for mesh, curves and points primitives only supported a limited set of data types when resampling from a Constant interpolation primitive variable. The implementation now uses DataAlgo::dispatch and supports all types for which a corresponding vector data type is defined. 

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
