### PR TITLE
USD DataAlgo : Support conversion of `float4` to `Color4f`

### DIFF
--- a/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/DataAlgo.cpp
@@ -215,6 +215,8 @@ static const std::map<pxr::TfType, IECore::DataPtr (*)( const pxr::VtValue &, Ge
 	{ TfType::Find<VtArray<GfVec2f>>(), &dataFromArray<GfVec2f> },
 	{ TfType::Find<GfVec3f>(), &dataFromValue<GfVec3f> },
 	{ TfType::Find<VtArray<GfVec3f>>(), &dataFromArray<GfVec3f> },
+	{ TfType::Find<GfVec4f>(), &dataFromValue<GfVec4f> },
+	{ TfType::Find<VtArray<GfVec4f>>(), &dataFromArray<GfVec4f> },
 	{ TfType::Find<GfVec2d>(), &dataFromValue<GfVec2d> },
 	{ TfType::Find<VtArray<GfVec2d>>(), &dataFromArray<GfVec2d> },
 	{ TfType::Find<GfVec3d>(), &dataFromValue<GfVec3d> },

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -283,6 +283,8 @@ class USDSceneTest( unittest.TestCase ) :
 			'test_Float2_Scalar_constant' : IECore.V2fData( imath.V2f( 0.1, 0.2 ) ),
 			'test_Float3_Array_constant' : IECore.V3fVectorData( [imath.V3f( 1.1, 1.2, 1.3 ), imath.V3f( 2.1, 2.2, 2.3 ), imath.V3f( 3.1, 3.2, 3.3 )] ),
 			'test_Float3_Scalar_constant' : IECore.V3fData( imath.V3f( 0.1, 0.2, 0.3 ) ),
+			'test_Float4_Array_constant' : IECore.Color4fVectorData( [imath.Color4f( 1.1, 1.2, 1.3, 1.4 ), imath.Color4f( 2.1, 2.2, 2.3, 2.4 ), imath.Color4f( 3.1, 3.2, 3.3, 3.4 )] ),
+			'test_Float4_Scalar_constant' : IECore.Color4fData( imath.Color4f( 0.1, 0.2, 0.3, 0.4 ) ),
 			'test_Float_Array_constant' : IECore.FloatVectorData( [0.7, 0.8, 0.9] ),
 			'test_Float_Scalar_constant' : IECore.FloatData( 0.6 ),
 			'test_Half_Array_constant' : IECore.HalfVectorData( [0.0999756, 0.199951, 0.300049] ),


### PR DESCRIPTION
This allows us to load the colour shader parameters from the USD files exported from Blender and reported here : https://groups.google.com/g/gaffer-dev/c/yGE-N2SPjx4/m/ukGAEaahCQAJ. To be clear, the Blender export is wrong - it should be creating `color` parameters, because that is the type of the corresponding socket in Cycles. But we also want to be able to load all the data we can from USD, so plugging this hole is a good thing generally.