### PR TITLE
VectorOps : Add missing `#include <cmath>`

### DIFF
--- a/include/IECore/VectorOps.inl
+++ b/include/IECore/VectorOps.inl
@@ -36,6 +36,7 @@
 #define IE_CORE_VECTOROPS_INL
 
 #include <cassert>
+#include <cmath>
 
 namespace IECore
 {


### PR DESCRIPTION
This fixes the build on MacOS.

