### PR TITLE
ImageReader : Fix compilation with OIIO 2.4

### DIFF
--- a/Changes
+++ b/Changes
@@ -12,6 +12,7 @@ Build
 -----
 
 - Update Windows release build dependencies to 6.2.1.
+- Added compatibility with OpenImageIO 2.4.
 
 10.4.4.0 (relative to 10.4.3.1)
 ========

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -166,6 +166,8 @@ class ImageReader::Implementation
 					if( !tiled )
 					{
 						return input->read_native_deep_scanlines(
+							0, // subimage
+							0, // miplevel
 							spec->height + spec->y - 1,
 							spec->height + spec->y,
 							0, // first deep sample
@@ -186,6 +188,8 @@ class ImageReader::Implementation
 						// are doing things correctly, and this is an OIIO bug.  For the moment, just read in
 						// the whole image starting from the origin, because this doesn't crash.
 						return input->read_native_deep_tiles(
+							0, // subimage
+							0, // miplevel
 							spec->x, spec->width + spec->x,
 							spec->y, spec->height + spec->y,
 							0, 1, // first deep sample


### PR DESCRIPTION
We were using the old form of the function, which is now deprecated.

Would be great to get a quick review on this one @ericmehl, so I can make a new release and keep the Gaffer 1.2 dependencies update rolling...