### PR TITLE
USD PrimitiveAlgo : Don't load invalid primitive variables

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,8 +3,9 @@
 
 Fixes
 -----
-- ImageReader : Fixed compilation with versions of OIIO < 2.4
 
+- ImageReader : Fixed compilation with versions of OIIO < 2.4.
+- USDScene : Invalid primitive variables are now skipped during loading, with a warning being emitted instead.
 
 10.4.5.0 (relative to 10.4.4.0)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/PointsAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointsAlgo.cpp
@@ -57,14 +57,8 @@ namespace
 
 IECore::ObjectPtr readPoints( pxr::UsdGeomPoints &points, pxr::UsdTimeCode time, const Canceller *canceller )
 {
-	IECoreScene::PointsPrimitivePtr newPoints = new IECoreScene::PointsPrimitive();
+	IECoreScene::PointsPrimitivePtr newPoints = new IECoreScene::PointsPrimitive( points.GetPointCount( time ) );
 	PrimitiveAlgo::readPrimitiveVariables( points, time, newPoints.get(), canceller );
-
-	Canceller::check( canceller );
-	if( auto *p = newPoints->variableData<V3fVectorData>( "P" ) )
-	{
-		newPoints->setNumPoints( p->readable().size() );
-	}
 
 	Canceller::check( canceller );
 	if( auto i = boost::static_pointer_cast<Int64VectorData>( DataAlgo::fromUSD( points.GetIdsAttr(), time ) ) )

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -242,7 +242,14 @@ void readPrimitiveVariable( const pxr::UsdGeomPrimvar &primVar, pxr::UsdTimeCode
 		indices = DataAlgo::fromUSD( srcIndices );
 	}
 
-	primitive->variables[name] = IECoreScene::PrimitiveVariable( interpolation, data, indices );
+	const IECoreScene::PrimitiveVariable primitiveVariable( interpolation, data, indices );
+	if( !primitive->isPrimitiveVariableValid( primitiveVariable ) )
+	{
+		IECore::msg( IECore::MessageHandler::Level::Warning, "IECoreUSD::PrimitiveAlgo", boost::format( "Skipping invalid UsdGeomPrimvar \"%1%\"" ) % primVar.GetAttr().GetPath().GetAsString() );
+		return;
+	}
+
+	primitive->variables[name] = primitiveVariable;
 }
 
 pxr::UsdSkelCache *skelCache()

--- a/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/customAttribute.usda
@@ -38,10 +38,10 @@ def Xform "a"
 		)
 		string primvars:user:baz = "white"
 		string primvars:notUserPrefixAttribute = "orange"
-		float[] primvars:withIndices = [ 1, 2, 3 ] (
+		float[] primvars:withIndices = [ 1, 2 ] (
 			interpolation = "vertex"
 		)
-		int[] primvars:withIndices:indices = [1]
+		int[] primvars:withIndices:indices = [0, 1, 0, 1]
 
 		def Sphere "c"
 		{

--- a/contrib/IECoreUSD/test/IECoreUSD/data/invalidCube.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/invalidCube.usda
@@ -1,0 +1,30 @@
+#usda 1.0
+(
+    defaultPrim = "pCube1"
+    endTimeCode = 1
+    startTimeCode = 1
+    upAxis = "Y"
+)
+
+def Mesh "pCube1" (
+    kind = "component"
+)
+{
+    uniform bool doubleSided = 1
+    float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+    int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+    int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+    point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+    color3f[] primvars:displayColor = [(0.21763764, 0.21763764, 0.21763764)] (
+        customData = {
+            dictionary Maya = {
+                bool generated = 1
+            }
+        }
+    )
+    float2[] primvars:st = [] (
+        interpolation = "faceVarying"
+    )
+    int[] primvars:st:indices = [0, 1, 2, 3, 3, 2, 4, 5, 5, 4, 6, 7, 7, 6, 8, 9, 1, 10, 11, 2, 12, 0, 3, 13]
+}
+


### PR DESCRIPTION
This required some fixes to the existing tests, since they were accidentally using invalid variables. Also required a change to the PointsPrimitive reader to construct the primitive with the right point count, so that the primitive variable checks are using the right sizes.
