### PR TITLE
Primitive : Use tbb parallel_reduce to accelerate bounds compute

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.4.x.x (relative to 10.4.5.0)
 ========
 
+Improvements
+------------
+
+- PointsPrimitive, Primitive : Accelerated bounds computation using `tbb::parallel_reduce`.
+
 Fixes
 -----
 


### PR DESCRIPTION
Multithread default bounds computation using `tbb::parallel_reduce`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
