### PR TITLE
ImageReader : Check for oiio version before calling read_native_deep_x

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,11 @@
+10.4.x.x (relative to 10.4.5.0)
+========
+
+Fixes
+-----
+- ImageReader : Fixed compilation with versions of OIIO < 2.4
+
+
 10.4.5.0 (relative to 10.4.4.0)
 ========
 

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -166,8 +166,10 @@ class ImageReader::Implementation
 					if( !tiled )
 					{
 						return input->read_native_deep_scanlines(
+#if OIIO_VERSION >= 20400
 							0, // subimage
 							0, // miplevel
+#endif
 							spec->height + spec->y - 1,
 							spec->height + spec->y,
 							0, // first deep sample
@@ -188,8 +190,10 @@ class ImageReader::Implementation
 						// are doing things correctly, and this is an OIIO bug.  For the moment, just read in
 						// the whole image starting from the origin, because this doesn't crash.
 						return input->read_native_deep_tiles(
+#if OIIO_VERSION >= 20400
 							0, // subimage
 							0, // miplevel
+#endif
 							spec->x, spec->width + spec->x,
 							spec->y, spec->height + spec->y,
 							0, 1, // first deep sample


### PR DESCRIPTION
Cortex recently added support for OIIO 2.4.x by adding extra args to read_native_deep_scanlines and read_native_deep_tiles. This breaks compatibility with older versions of OIIO which are still used to support RV so we added some checks on the OIIO version while calling the read_native_deep_x functions and provide those args accordingly.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
