### PR TITLE
Release prep for 10.4.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,47 +30,37 @@ jobs:
         # and then use `include` to define their settings.
 
         name: [
-          linux-python2,
-          linux-python2-debug,
           linux-python3,
+          linux-python3-debug,
           windows-python3,
           windows-python3-debug
         ]
 
         include:
 
-          - name: linux-python2
-            os: ubuntu-20.04
-            buildType: RELEASE
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python2-linux.tar.gz
-            tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
-            publish: true
-
-          - name: linux-python2-debug
-            os: ubuntu-20.04
-            buildType: DEBUG
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
-            options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python2-linux.tar.gz
-            tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
-            publish: false
-
           - name: linux-python3
             os: ubuntu-20.04
             buildType: RELEASE
             containerImage: ghcr.io/gafferhq/build/build:2.0.0
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/5.1.0/gafferDependencies-5.1.0-Python3-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-linux.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
             publish: true
+
+          - name: linux-python3-debug
+            os: ubuntu-20.04
+            buildType: DEBUG
+            containerImage: ghcr.io/gafferhq/build/build:2.0.0
+            options: .github/workflows/main/options.posix
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-linux.tar.gz
+            tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB testAppleseed
+            publish: false
 
           - name: windows-python3
             os: windows-2019
             buildType: RELEASE
             options: .github/workflows/main/options.windows
-            dependenciesURL: https://github.com/hypothetical-inc/gafferDependencies/releases/download/6.2.1/gafferDependencies-6.2.1-Python3-windows.zip
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: true
 
@@ -78,7 +68,7 @@ jobs:
             os: windows-2019
             buildType: RELWITHDEBINFO
             options: .github/workflows/main/options.windows
-            dependenciesURL: https://github.com/hypothetical-inc/gafferDependencies/releases/download/6.2.1/gafferDependencies-6.2.1-Python3-windows.zip
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/6.0.0/gafferDependencies-6.0.0-windows.zip
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: false
 

--- a/Changes
+++ b/Changes
@@ -12,6 +12,11 @@ Fixes
 - ImageReader : Fixed compilation with versions of OIIO < 2.4.
 - USDScene : Invalid primitive variables are now skipped during loading, with a warning being emitted instead.
 
+Build
+-----
+
+- Updated CI builds to use GafferHQ/dependencies version `6.0.0`, making them suitable for use in Gaffer `1.2.x.x`.
+
 10.4.5.0 (relative to 10.4.4.0)
 ========
 

--- a/Changes
+++ b/Changes
@@ -1,16 +1,24 @@
-10.4.x.x (relative to 10.4.5.0)
+10.4.6.0 (relative to 10.4.5.0)
 ========
+
+Features
+--------
+
+- MeshAlgo : Added new MeshSplitter class, for efficient splitting meshes based on uniform primitive variables.
+- ImathHash : Added new header that defines `std::hash` for Imath types.
 
 Improvements
 ------------
 
 - PointsPrimitive, Primitive : Accelerated bounds computation using `tbb::parallel_reduce`.
+- MeshAlgo : Improved performance of `segment()`.
 
 Fixes
 -----
 
 - ImageReader : Fixed compilation with versions of OIIO < 2.4.
 - USDScene : Invalid primitive variables are now skipped during loading, with a warning being emitted instead.
+- MeshAlgo : Fixed crease handling in `deleteFaces()`.
 
 Build
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -56,7 +56,7 @@ SConsignFile()
 
 ieCoreMilestoneVersion = 10 # for announcing major milestones - may contain all of the below
 ieCoreMajorVersion = 4 # backwards-incompatible changes
-ieCoreMinorVersion = 5 # new backwards-compatible features
+ieCoreMinorVersion = 6 # new backwards-compatible features
 ieCorePatchVersion = 0 # bug fixes
 ieCoreVersionSuffix = "" # used for alpha/beta releases. Example: "a1", "b2", etc.
 


### PR DESCRIPTION
In which John realises he has made a horrible mistake :

1. After I merged https://github.com/ImageEngine/cortex/pull/1333, I realised it had been targeting `main` and not `RB-10.4` as it should have been.
2. So I merged the PR branch to `RB-10.4` manually on the command line too.
3. But I didn't notice that the PR branch was branched from `main` too, and therefore contained all the commits from `main` as well as the MeshSplitter code we wanted.
4. So now `RB-10.4` contains everything from `main`.
5. Sorry. If there was an emoji for a muppet, I would put it here a thousand times.

I've "fixed" this in this PR with a [commit](https://github.com/ImageEngine/cortex/pull/1340/commits/166b31f41954b639ae3ad5109d01342d8d783140) that reverts everything from that merge. Then I've cherry-picked the MeshSplitter commits we _do_ want, and done the usual commits to bump version and update Changes for a new release. Presumably, I will have to also revert the revert when next merging `RB-10.4` to `main`.

In practice, very little had been done on `main` since we branched `RB-10.4`. The main things I see are removal of a 3Delight display driver (which doesn't work with recent 3Delight any more) and some code changes for Imath 3 (which _shouldn't_ break ABI anyway). So, do verify this for yourself, but it seems possible that we could actually _not_ revert the bad merge, if we were feeling in a positive sort of mood. But I want to provide all options I can, hence the revert commit - let me know if you think it best to keep it or remove it.

Daniel, I've tested the cherry-picked MeshSplit stuff in a Gaffer build and all seems well, but please do give it a good check yourself to be sure I've got all the right things.

That leaves the final 3 commits, which are the only bits that would be necessary if I wasn't a colossal plonker.