### PR TITLE
GL primitives : Add utilities to query OpenGL draw mode

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,12 @@ Fixes
   - Fixed reading of primitives containing `primvars:normals`. These are now correctly loaded as a primitive variable called `N`, taking precedence over the UsdGeomPointBased `normals` attribute.
   - Fixed writing of indexed normals so that the indexing is retained on load. Note that this means that normals are now _always_ written as `primvars:normals` and never via the UsdGeomPointBased `normals` attribute.
 
+API
+---
+
+- IECoreGL::PointsPrimitive : Added `renderUsesGLPoints()` method.
+- IECoreGL::CurvesPrimitive : Added `renderUsesGLLines()` method.
+
 10.4.6.0 (relative to 10.4.5.0)
 ========
 

--- a/include/IECoreGL/CurvesPrimitive.h
+++ b/include/IECoreGL/CurvesPrimitive.h
@@ -59,6 +59,9 @@ class IECOREGL_API CurvesPrimitive : public Primitive
 		void addPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primVar ) override;
 		const Shader::Setup *shaderSetup( const Shader *shader, State *state ) const override;
 		void render( const State *currentState, IECore::TypeId style ) const override;
+		/// Returns `true` if `render( state )` will render the curves as `GL_LINES`,
+		/// and `false` if the curves will be rendered as ribbons.
+		bool renderUsesGLLines( const State *state ) const;
 		/// Just renders each segment as linear with GL_LINES.
 		void renderInstances( size_t numInstances = 1 ) const override;
 

--- a/include/IECoreGL/PointsPrimitive.h
+++ b/include/IECoreGL/PointsPrimitive.h
@@ -67,6 +67,10 @@ class IECOREGL_API PointsPrimitive : public Primitive
 		void addPrimitiveVariable( const std::string &name, const IECoreScene::PrimitiveVariable &primVar ) override;
 		const Shader::Setup *shaderSetup( const Shader *shader, State *state ) const override;
 		void render( const State *currentState, IECore::TypeId style ) const override;
+		/// Returns `true` if `render( state )` will render the points as `GL_POINTS`,
+		/// and `false` if the curves will be rendered as geometry such as disks or
+		/// spheres.
+		bool renderUsesGLPoints( const State *state ) const;
 		void renderInstances( size_t numInstances = 1 ) const override;
 
 		//! @name StateComponents

--- a/src/IECoreGL/CurvesPrimitive.cpp
+++ b/src/IECoreGL/CurvesPrimitive.cpp
@@ -288,6 +288,18 @@ void CurvesPrimitive::renderMode( const State *state, bool &linear, bool &ribbon
 	ribbons = !state->get<UseGLLines>()->value();
 }
 
+bool CurvesPrimitive::renderUsesGLLines( const State *state ) const
+{
+	if( const auto s = state->get<UseGLLines>() )
+	{
+		if( s->value() )
+		{
+			return true;
+		}
+	}
+	return glslVersion() < 150;
+}
+
 const std::string &CurvesPrimitive::cubicLinesGeometrySource()
 {
 	static std::string s =

--- a/src/IECoreGL/PointsPrimitive.cpp
+++ b/src/IECoreGL/PointsPrimitive.cpp
@@ -305,6 +305,11 @@ void PointsPrimitive::render( const State *currentState, IECore::TypeId style ) 
 	}
 }
 
+bool PointsPrimitive::renderUsesGLPoints( const State *state ) const
+{
+	return effectiveType( state ) == Point;
+}
+
 void PointsPrimitive::renderInstances( size_t numInstances ) const
 {
 	glDrawArraysInstancedARB( GL_POINTS, 0, m_memberData->points->readable().size(), numInstances );


### PR DESCRIPTION
These are needed by Gaffer, to allow selection wireframes to be drawn successfully without z-fighting with the underlying geometry. See https://github.com/GafferHQ/gaffer/pull/5220.
