### PR TITLE
ifdefs for Imath3

### DIFF
--- a/contrib/IECoreAppleseed/include/IECoreAppleseed/TransformAlgo.h
+++ b/contrib/IECoreAppleseed/include/IECoreAppleseed/TransformAlgo.h
@@ -40,7 +40,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "renderer/api/utility.h"

--- a/contrib/IECoreAppleseed/src/IECoreAppleseed/ColorAlgo.cpp
+++ b/contrib/IECoreAppleseed/src/IECoreAppleseed/ColorAlgo.cpp
@@ -39,7 +39,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathColor.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/lexical_cast.hpp"

--- a/contrib/IECoreUSD/include/IECoreUSD/TypeTraits.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/TypeTraits.h
@@ -44,11 +44,20 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/base/vt/value.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/half.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#endif
 
 namespace IECoreUSD
 {

--- a/include/IECore/BezierAlgo.inl
+++ b/include/IECore/BezierAlgo.inl
@@ -37,7 +37,12 @@
 
 #include "IECore/LineSegment.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/BoundedKDTree.h
+++ b/include/IECore/BoundedKDTree.h
@@ -39,7 +39,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECore/BoxAlgo.h
+++ b/include/IECore/BoxAlgo.h
@@ -42,7 +42,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <iostream>

--- a/include/IECore/BoxInterpolator.inl
+++ b/include/IECore/BoxInterpolator.inl
@@ -35,7 +35,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/BoxTraits.h
+++ b/include/IECore/BoxTraits.h
@@ -39,10 +39,19 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "boost/static_assert.hpp"
 

--- a/include/IECore/CubicBasis.h
+++ b/include/IECore/CubicBasis.h
@@ -38,7 +38,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/DimensionTraits.inl
+++ b/include/IECore/DimensionTraits.inl
@@ -40,9 +40,16 @@
 #include "IECore/TypeTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathPlane.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathPlane.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/static_assert.hpp"

--- a/include/IECore/HalfTypeTraits.h
+++ b/include/IECore/HalfTypeTraits.h
@@ -38,7 +38,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/type_traits/is_arithmetic.hpp"

--- a/include/IECore/IFFFile.h
+++ b/include/IECore/IFFFile.h
@@ -39,7 +39,12 @@
 #include "IECore/RefCounted.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <fstream>

--- a/include/IECore/ImathHash.h
+++ b/include/IECore/ImathHash.h
@@ -36,12 +36,22 @@
 #define IE_CORE_IMATHHASH_H
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/half.h"
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/ImathRandAdapter.h
+++ b/include/IECore/ImathRandAdapter.h
@@ -35,7 +35,12 @@
 #ifndef IE_CORE_IMATHRANDADAPTER_H
 #define IE_CORE_IMATHRANDADAPTER_H
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/IndexedIO.h
+++ b/include/IECore/IndexedIO.h
@@ -40,7 +40,12 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <map>

--- a/include/IECore/KDTree.h
+++ b/include/IECore/KDTree.h
@@ -39,7 +39,12 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <set>

--- a/include/IECore/LineSegment.h
+++ b/include/IECore/LineSegment.h
@@ -39,8 +39,14 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathPlane.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathPlane.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/LineSegment.inl
+++ b/include/IECore/LineSegment.inl
@@ -35,7 +35,12 @@
 #ifndef IECORE_LINESEGMENT_INL
 #define IECORE_LINESEGMENT_INL
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/Lookup.h
+++ b/include/IECore/Lookup.h
@@ -39,7 +39,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathColor.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/function.hpp"

--- a/include/IECore/Lookup.inl
+++ b/include/IECore/Lookup.inl
@@ -38,7 +38,12 @@
 
 #include "IECore/FastFloat.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/MatrixAlgo.h
+++ b/include/IECore/MatrixAlgo.h
@@ -43,7 +43,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/MatrixInterpolator.inl
+++ b/include/IECore/MatrixInterpolator.inl
@@ -35,11 +35,21 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathMatrixAlgo.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/MatrixTraits.h
+++ b/include/IECore/MatrixTraits.h
@@ -38,7 +38,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <cassert>

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -38,12 +38,22 @@
 #include "IECore/InternedString.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/ImathEuler.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#include "Imath/ImathEuler.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECore/NumericParameter.h
+++ b/include/IECore/NumericParameter.h
@@ -38,7 +38,12 @@
 #include "IECore/Parameter.h"
 #include "IECore/TypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/PointDistribution.h
+++ b/include/IECore/PointDistribution.h
@@ -38,8 +38,14 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/noncopyable.hpp"

--- a/include/IECore/PolygonAlgo.h
+++ b/include/IECore/PolygonAlgo.h
@@ -42,7 +42,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/PolygonAlgo.inl
+++ b/include/IECore/PolygonAlgo.inl
@@ -37,7 +37,12 @@
 
 #include "IECore/CircularIterator.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVecAlgo.h"
+#else
+#include "Imath/ImathVecAlgo.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/QuatAlgo.h
+++ b/include/IECore/QuatAlgo.h
@@ -42,8 +42,14 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathMath.h"
+#else
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathMath.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/QuatInterpolator.inl
+++ b/include/IECore/QuatInterpolator.inl
@@ -36,7 +36,12 @@
 #include "IECore/QuatAlgo.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathQuat.h"
+#else
+#include "Imath/ImathQuat.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/RandomAlgo.h
+++ b/include/IECore/RandomAlgo.h
@@ -35,7 +35,12 @@
 #ifndef IECORE_RANDOMALGO_H
 #define IECORE_RANDOMALGO_H
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/RandomAlgo.inl
+++ b/include/IECore/RandomAlgo.inl
@@ -38,7 +38,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/RandomRotationOp.inl
+++ b/include/IECore/RandomRotationOp.inl
@@ -39,10 +39,19 @@
 #include "IECore/Math.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathQuat.h"
+#else
+#include "Imath/ImathQuat.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 namespace IECore
 {

--- a/include/IECore/SimpleTypedData.h
+++ b/include/IECore/SimpleTypedData.h
@@ -42,12 +42,22 @@
 #include "IECore/TypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/half.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECore/SphericalToEuclideanTransform.inl
+++ b/include/IECore/SphericalToEuclideanTransform.inl
@@ -39,8 +39,14 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <cassert>

--- a/include/IECore/Spline.h
+++ b/include/IECore/Spline.h
@@ -40,7 +40,12 @@
 #include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathColor.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/numeric/interval.hpp"

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -37,7 +37,12 @@
 
 #include "IECore/Exception.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 
 #include "boost/format.hpp"
 

--- a/include/IECore/TransformationMatrix.h
+++ b/include/IECore/TransformationMatrix.h
@@ -39,10 +39,18 @@
 #include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathEuler.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathEuler.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/TriangleAlgo.h
+++ b/include/IECore/TriangleAlgo.h
@@ -43,7 +43,12 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/TriangleAlgo.inl
+++ b/include/IECore/TriangleAlgo.inl
@@ -37,7 +37,12 @@
 
 #include "IECore/VectorOps.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathLineAlgo.h"
+#else
+#include "Imath/ImathLineAlgo.h"
+#endif
 
 #include <cassert>
 

--- a/include/IECore/VecAlgo.h
+++ b/include/IECore/VecAlgo.h
@@ -42,7 +42,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 // Putting these operators in the Imath namespace so that the compiler can find them

--- a/include/IECore/VectorTypedData.h
+++ b/include/IECore/VectorTypedData.h
@@ -40,11 +40,20 @@
 #include "IECore/TypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/half.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECoreGL/Camera.h
+++ b/include/IECoreGL/Camera.h
@@ -41,8 +41,14 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/GL.h
+++ b/include/IECoreGL/GL.h
@@ -44,8 +44,14 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathColor.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "GL/glew.h"

--- a/include/IECoreGL/Group.h
+++ b/include/IECoreGL/Group.h
@@ -41,7 +41,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <list>

--- a/include/IECoreGL/NumericTraits.h
+++ b/include/IECoreGL/NumericTraits.h
@@ -41,7 +41,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Primitive.h
+++ b/include/IECoreGL/Primitive.h
@@ -48,7 +48,12 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Renderable.h
+++ b/include/IECoreGL/Renderable.h
@@ -42,7 +42,12 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -42,8 +42,14 @@
 #include "IECore/RefCounted.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECoreGL/TypedStateComponent.h
+++ b/include/IECoreGL/TypedStateComponent.h
@@ -42,8 +42,14 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/private/RendererImplementation.h
+++ b/include/IECoreGL/private/RendererImplementation.h
@@ -45,7 +45,12 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreHoudini/Convert.h
+++ b/include/IECoreHoudini/Convert.h
@@ -41,12 +41,22 @@
 #include "IECore/Data.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathEuler.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathEuler.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "UT/UT_BoundingBox.h"

--- a/include/IECoreImage/DisplayDriver.h
+++ b/include/IECoreImage/DisplayDriver.h
@@ -46,7 +46,12 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/function.hpp"

--- a/include/IECoreImage/Font.h
+++ b/include/IECoreImage/Font.h
@@ -42,8 +42,14 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreImage

--- a/include/IECoreImage/ImagePrimitive.inl
+++ b/include/IECoreImage/ImagePrimitive.inl
@@ -40,7 +40,12 @@
 #include "IECore/TypeTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/format.hpp"

--- a/include/IECoreMaya/Convert.h
+++ b/include/IECoreMaya/Convert.h
@@ -41,12 +41,22 @@
 #include "IECore/Data.h"
 #include "IECore/TransformationMatrix.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathEuler.h"
+#else
+#include "Imath/ImathVec.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathBox.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathEuler.h"
+#endif
 
 #include "maya/MString.h"
 #include "maya/MBoundingBox.h"

--- a/include/IECoreMaya/NumericTraits.h
+++ b/include/IECoreMaya/NumericTraits.h
@@ -38,8 +38,14 @@
 #include "boost/static_assert.hpp"
 
 #include "maya/MFnNumericData.h"
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathVec.h"
+#include "Imath/ImathColor.h"
+#endif
 
 namespace IECoreMaya
 {

--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -40,7 +40,12 @@
 #include "IECoreMaya/Export.h"
 
 #include <map>
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 #include "IECoreGL/IECoreGL.h"
 #include "maya/MPxComponentShape.h"
 

--- a/include/IECoreMaya/SceneShapeInterfaceComponentBoundIterator.h
+++ b/include/IECoreMaya/SceneShapeInterfaceComponentBoundIterator.h
@@ -40,7 +40,12 @@
 #include "maya/MBoundingBox.h"
 #include "maya/MObjectArray.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 
 #include "IECoreMaya/SceneShapeInterface.h"
 

--- a/include/IECoreNuke/Box3ParameterHandler.h
+++ b/include/IECoreNuke/Box3ParameterHandler.h
@@ -37,7 +37,12 @@
 
 #include "IECoreNuke/ParameterHandler.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 
 namespace IECoreNuke
 {

--- a/include/IECoreNuke/Color3fParameterHandler.h
+++ b/include/IECoreNuke/Color3fParameterHandler.h
@@ -37,7 +37,12 @@
 
 #include "IECoreNuke/ParameterHandler.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
+#else
+#include "Imath/ImathColor.h"
+#endif
 
 namespace IECoreNuke
 {

--- a/include/IECoreNuke/Convert.h
+++ b/include/IECoreNuke/Convert.h
@@ -47,10 +47,18 @@
 #include "DDImage/Vector4.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 /// Specialising in the IECore namespace. This is OK because the Nuke types

--- a/include/IECoreNuke/CurveLookup.inl
+++ b/include/IECoreNuke/CurveLookup.inl
@@ -35,7 +35,12 @@
 #ifndef IECORENUKE_CURVELOOKUP_INL
 #define IECORENUKE_CURVELOOKUP_INL
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 #include <cassert>
 #include <vector>

--- a/include/IECoreNuke/DrawableHolder.h
+++ b/include/IECoreNuke/DrawableHolder.h
@@ -42,7 +42,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/Hash.h
+++ b/include/IECoreNuke/Hash.h
@@ -40,10 +40,18 @@
 #include "DDImage/Hash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/SceneCacheReader.h
+++ b/include/IECoreNuke/SceneCacheReader.h
@@ -54,7 +54,12 @@
 #include "DDImage/ViewerContext.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/Warp.h
+++ b/include/IECoreNuke/Warp.h
@@ -42,7 +42,12 @@
 #include "DDImage/Iop.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreScene/Font.h
+++ b/include/IECoreScene/Font.h
@@ -42,8 +42,14 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/OBJReader.h
+++ b/include/IECoreScene/OBJReader.h
@@ -42,7 +42,12 @@
 #include "IECore/Reader.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECoreScene/ParticleReader.inl
+++ b/include/IECoreScene/ParticleReader.inl
@@ -38,7 +38,12 @@
 #include "IECore/Convert.h"
 #include "IECore/MessageHandler.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 namespace IECoreScene
 {

--- a/include/IECoreScene/PrimitiveEvaluator.h
+++ b/include/IECoreScene/PrimitiveEvaluator.h
@@ -42,8 +42,14 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathColor.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECoreScene/Renderer.h
+++ b/include/IECoreScene/Renderer.h
@@ -47,8 +47,14 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <set>

--- a/include/IECoreScene/SceneInterface.h
+++ b/include/IECoreScene/SceneInterface.h
@@ -46,8 +46,14 @@
 #include "IECore/PathMatcher.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/Transform.h
+++ b/include/IECoreScene/Transform.h
@@ -41,7 +41,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/VisibleRenderable.h
+++ b/include/IECoreScene/VisibleRenderable.h
@@ -41,7 +41,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/private/TransformStack.h
+++ b/include/IECoreScene/private/TransformStack.h
@@ -40,7 +40,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <stack>

--- a/include/IECoreVDB/VDBObject.h
+++ b/include/IECoreVDB/VDBObject.h
@@ -50,7 +50,12 @@
 #include "openvdb/openvdb.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "tbb/recursive_mutex.h"

--- a/src/IECore/PointDistribution.cpp
+++ b/src/IECore/PointDistribution.cpp
@@ -2,7 +2,12 @@
 #include "IECore/Exception.h"
 #include "IECore/ImathRandAdapter.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 #include <fstream>
 #include <algorithm>

--- a/src/IECoreGL/Camera.cpp
+++ b/src/IECoreGL/Camera.cpp
@@ -39,7 +39,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace IECoreGL;

--- a/src/IECoreGL/CurvesPrimitive.cpp
+++ b/src/IECoreGL/CurvesPrimitive.cpp
@@ -45,9 +45,16 @@
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrixAlgo.h"
 #include "OpenEXR/ImathVecAlgo.h"
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathMatrixAlgo.h"
+#include "Imath/ImathVecAlgo.h"
+#include "Imath/ImathFun.h"
+#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreGL/Group.cpp
+++ b/src/IECoreGL/Group.cpp
@@ -37,7 +37,12 @@
 #include "IECoreGL/GL.h"
 #include "IECoreGL/State.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreGL/MeshPrimitive.cpp
+++ b/src/IECoreGL/MeshPrimitive.cpp
@@ -39,7 +39,12 @@
 
 #include "IECore/DespatchTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMath.h"
+#else
+#include "Imath/ImathMath.h"
+#endif
 
 #include <cassert>
 

--- a/src/IECoreGL/PointsPrimitive.cpp
+++ b/src/IECoreGL/PointsPrimitive.cpp
@@ -49,8 +49,14 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
 #include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathFun.h"
+#include "Imath/ImathMatrixAlgo.h"
+#endif
 
 using namespace IECoreGL;
 using namespace IECore;

--- a/src/IECoreGL/Renderer.cpp
+++ b/src/IECoreGL/Renderer.cpp
@@ -77,7 +77,12 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/SplineData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include <mutex>
 #include <stack>

--- a/src/IECoreGL/SpherePrimitive.cpp
+++ b/src/IECoreGL/SpherePrimitive.cpp
@@ -41,7 +41,12 @@
 #include "IECore/Math.h"
 #include "IECore/MessageHandler.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -42,8 +42,14 @@
 #include "IECore/TransformationMatrixData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
 #include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#include "Imath/ImathMatrixAlgo.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "MGR/MGR_Node.h"

--- a/src/IECoreHoudini/SOP_SceneCacheSource.cpp
+++ b/src/IECoreHoudini/SOP_SceneCacheSource.cpp
@@ -50,7 +50,12 @@
 #include "IECore/DespatchTypedData.h"
 #include "IECore/TypeTraits.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathMatrixAlgo.h"
+#endif
 
 #include "GA/GA_Names.h"
 #include "OP/OP_NodeInfoParms.h"

--- a/src/IECoreImageBindings/ImagePrimitiveBinding.cpp
+++ b/src/IECoreImageBindings/ImagePrimitiveBinding.cpp
@@ -34,7 +34,12 @@
 
 #include "boost/python.hpp"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 
 #include "IECoreImage/ImagePrimitive.h"
 

--- a/src/IECoreMaya/FromMayaImageConverter.cpp
+++ b/src/IECoreMaya/FromMayaImageConverter.cpp
@@ -46,7 +46,12 @@
 #include "IECoreMaya/FromMayaImageConverter.h"
 #include "IECoreMaya/MImageAccessor.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
+#else
+#include "Imath/ImathBox.h"
+#endif
 
 using namespace IECore;
 using namespace IECoreImage;

--- a/src/IECoreMaya/FromMayaLocatorConverter.cpp
+++ b/src/IECoreMaya/FromMayaLocatorConverter.cpp
@@ -35,8 +35,14 @@
 #include "IECoreMaya/FromMayaLocatorConverter.h"
 #include "IECoreMaya/Convert.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathVec.h"
+#include "Imath/ImathMatrix.h"
+#endif
 #include "IECoreScene/CoordinateSystem.h"
 #include "IECoreScene/MatrixTransform.h"
 

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -75,7 +75,12 @@
 #include "maya/MFnSet.h"
 #include "maya/MFnInstancer.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "boost/algorithm/string.hpp"
 #include "boost/tokenizer.hpp"

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -40,8 +40,14 @@
 #include "boost/python.hpp"
 #include "boost/tokenizer.hpp"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrixAlgo.h"
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathMatrixAlgo.h"
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "IECoreGL/Renderer.h"
 #include "IECoreGL/Scene.h"

--- a/src/IECoreMaya/ToMayaLocatorConverter.cpp
+++ b/src/IECoreMaya/ToMayaLocatorConverter.cpp
@@ -39,7 +39,12 @@
 #include "maya/MFnTransform.h"
 #include "maya/MPlug.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrixAlgo.h"
+#else
+#include "Imath/ImathMatrixAlgo.h"
+#endif
 #include "IECore/AngleConversion.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"

--- a/src/IECoreNuke/LiveScene.cpp
+++ b/src/IECoreNuke/LiveScene.cpp
@@ -43,7 +43,12 @@
 #include "IECore/NullObject.h"
 #include "IECore/TransformationMatrixData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "boost/algorithm/string.hpp"
 #include "boost/format.hpp"

--- a/src/IECorePython/AngleConversionBinding.cpp
+++ b/src/IECorePython/AngleConversionBinding.cpp
@@ -42,7 +42,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/HalfBinding.cpp
+++ b/src/IECorePython/HalfBinding.cpp
@@ -39,7 +39,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/half.h"
+#else
+#include "Imath/half.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/HenyeyGreensteinBinding.cpp
+++ b/src/IECorePython/HenyeyGreensteinBinding.cpp
@@ -42,7 +42,12 @@
 #include "IECore/HenyeyGreenstein.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/IECoreBinding.cpp
+++ b/src/IECorePython/IECoreBinding.cpp
@@ -37,12 +37,22 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathColor.h"
 #include "OpenEXR/ImathEuler.h"
 #include "OpenEXR/ImathMatrix.h"
 #include "OpenEXR/ImathPlane.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathColor.h"
+#include "Imath/ImathEuler.h"
+#include "Imath/ImathMatrix.h"
+#include "Imath/ImathPlane.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;

--- a/src/IECorePython/VectorTypedDataBinding.cpp
+++ b/src/IECorePython/VectorTypedDataBinding.cpp
@@ -51,9 +51,16 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBox.h"
 #include "OpenEXR/ImathQuat.h"
 #include "OpenEXR/ImathVec.h"
+#else
+#include "Imath/ImathBox.h"
+#include "Imath/ImathQuat.h"
+#include "Imath/ImathVec.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/numeric/conversion/cast.hpp"

--- a/src/IECorePythonModule/IECore.cpp
+++ b/src/IECorePythonModule/IECore.cpp
@@ -41,7 +41,12 @@
 
 #include "TBBBinding.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathEuler.h"
+#else
+#include "Imath/ImathEuler.h"
+#endif
 
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"

--- a/src/IECoreScene/CurveExtrudeOp.cpp
+++ b/src/IECoreScene/CurveExtrudeOp.cpp
@@ -49,7 +49,12 @@
 #include "IECore/TypedObjectParameter.h"
 #include "IECore/VectorTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFrame.h"
+#else
+#include "Imath/ImathFrame.h"
+#endif
 
 #include <algorithm>
 #include <cassert>

--- a/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
@@ -42,7 +42,12 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/IECoreScene/Group.cpp
+++ b/src/IECoreScene/Group.cpp
@@ -40,7 +40,12 @@
 
 #include "IECore/MurmurHash.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"

--- a/src/IECoreScene/MatrixMotionTransform.cpp
+++ b/src/IECoreScene/MatrixMotionTransform.cpp
@@ -38,7 +38,12 @@
 
 #include "IECore/MurmurHash.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 #include "boost/format.hpp"
 

--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -43,11 +43,21 @@
 #include "IECore/TriangleAlgo.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathMatrix.h"
+#else
+#include "Imath/ImathMatrix.h"
+#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
 #include "OpenEXR/ImathLineAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#include "Imath/ImathLineAlgo.h"
+#endif
 
 #include <cassert>
 

--- a/src/IECoreScene/NParticleReader.cpp
+++ b/src/IECoreScene/NParticleReader.cpp
@@ -42,7 +42,12 @@
 #include "IECore/Timer.h"
 #include "IECore/VectorTypedData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 

--- a/src/IECoreScene/SceneCache.cpp
+++ b/src/IECoreScene/SceneCache.cpp
@@ -50,7 +50,12 @@
 #include "IECore/TransformationMatrixData.h"
 #include "IECore/PathMatcherData.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#endif
 
 #include "boost/core/demangle.hpp"
 #include "boost/tuple/tuple.hpp"

--- a/src/IECoreScene/SpherePrimitiveEvaluator.cpp
+++ b/src/IECoreScene/SpherePrimitiveEvaluator.cpp
@@ -41,8 +41,14 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/TriangleAlgo.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathBoxAlgo.h"
 #include "OpenEXR/ImathLineAlgo.h"
+#else
+#include "Imath/ImathBoxAlgo.h"
+#include "Imath/ImathLineAlgo.h"
+#endif
 
 #include <cassert>
 

--- a/src/IECoreScene/TransformStack.cpp
+++ b/src/IECoreScene/TransformStack.cpp
@@ -39,7 +39,12 @@
 #include "IECore/Exception.h"
 #include "IECore/Interpolator.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathFun.h"
+#else
+#include "Imath/ImathFun.h"
+#endif
 
 using namespace Imath;
 using namespace IECore;

--- a/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
+++ b/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
@@ -42,7 +42,12 @@
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"
 
+#include "OpenEXR/OpenEXRConfig.h"
+#if OPENEXR_VERSION_MAJOR < 3
 #include "OpenEXR/ImathRandom.h"
+#else
+#include "Imath/ImathRandom.h"
+#endif
 
 #include "tbb/parallel_for.h"
 


### PR DESCRIPTION
I was saddened to realize that you were totally right that there's no way to use macros to play with includes, so there isn't a particularly elegant solution here.

I considered creating dummy headers like "IECoreImath/ImathBBox.h" for each Imath header we use, which would just redirect to Imath or OpenEXR ... that would work, but kinda muddies things, and requires a dummy header for each header we import ...

So then I just tried doing it the brute force way, and I guess it's not THAT bad.  Happy to change the name of the flag, or switch it to an ifndef if you prefer, that would be easy to automate ( I did realize afterwards that if you prefer the other order for the if clauses, that would be kinda annoying to switch ).

There are some questions about how the flag should work ... currently this implementation requires Gaffer to also set CORTEX_USE_IMATH2, which is kind of ugly.  Maybe the name should match between Cortex / Gaffer?  Ideally, I guess you'd just drive it from the version of Imath, but it's not clear how that would work - we can't get the Imath version from an Imath header until after we know where to look for Imath.  We could use the OpenEXR version, but that feels a little weird when the point of this is that Imath shouldn't depend on OpenEXR ... actually, maybe that's just sophistry, and using OPENEXR_VERSION_MAJOR < 3 totally makes sense?  That would be an easy change.

