### PR TITLE
Support "primitiveVariables" argument to distributePoints

### DIFF
--- a/include/IECore/PointDistribution.h
+++ b/include/IECore/PointDistribution.h
@@ -84,7 +84,7 @@ class IECORE_API PointDistribution : public boost::noncopyable
 		///
 		/// pointEmitter is called for each point generated and must have the signature void( const Imath::V2f &pos ).
 		template<typename DensityFunction, typename PointFunction>
-		void operator () ( const Imath::Box2f &bounds, float density, DensityFunction &densitySampler, PointFunction &pointEmitter ) const;
+		void operator () ( const Imath::Box2f &bounds, float density, DensityFunction &&densitySampler, PointFunction &&pointEmitter ) const;
 		/// Variation on the function above for times when the density function isn't available to be evaluated on a point
 		/// by point basis - perhaps because it is best evaluated in SIMD (as the IECoreRI::SXRenderer would do).
 		///
@@ -94,7 +94,7 @@ class IECORE_API PointDistribution : public boost::noncopyable
 		/// densityThreshold allows for deferred rejection of the points using a density function evaluated later - if the density evaluated
 		/// is less than densityThreshold then that point should be rejected.
 		template<typename PointFunction>
-		void operator () ( const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const;
+		void operator () ( const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const;
 
 		/// Returns a reference to a static PointDistribution which can be shared by anyone who needs one. This
 		/// distribution uses the tile set pointed to by the CORTEX_POINTDISTRIBUTION_TILESET environment variable.
@@ -108,10 +108,10 @@ class IECORE_API PointDistribution : public boost::noncopyable
 		struct DensityThresholdedEmitter;
 
 		template<typename PointFunction>
-		void processTile( const Tile &tile, const Imath::V2f &bottomLeft, const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const;
+		void processTile( const Tile &tile, const Imath::V2f &bottomLeft, const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const;
 
 		template<typename PointFunction>
-		void recurseTile( const Tile &tile, const Imath::V2f &bottomLeft, unsigned level, const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const;
+		void recurseTile( const Tile &tile, const Imath::V2f &bottomLeft, unsigned level, const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const;
 
 		typedef std::vector<Tile> TileVector;
 		TileVector m_tiles;

--- a/include/IECore/PointDistribution.inl
+++ b/include/IECore/PointDistribution.inl
@@ -56,7 +56,7 @@ struct PointDistribution::Tile
 template<typename DensityFunction, typename PointFunction>
 struct PointDistribution::DensityThresholdedEmitter
 {
-	DensityThresholdedEmitter( DensityFunction &densitySampler, PointFunction &pointEmitter )
+	DensityThresholdedEmitter( DensityFunction &&densitySampler, PointFunction &&pointEmitter )
 		:	m_densitySampler( densitySampler ), m_pointEmitter( pointEmitter )
 	{
 	}
@@ -77,14 +77,14 @@ struct PointDistribution::DensityThresholdedEmitter
 };
 
 template<typename DensityFunction, typename PointFunction>
-void PointDistribution::operator () ( const Imath::Box2f &bounds, float density, DensityFunction &densitySampler, PointFunction &pointEmitter ) const
+void PointDistribution::operator () ( const Imath::Box2f &bounds, float density, DensityFunction &&densitySampler, PointFunction &&pointEmitter ) const
 {
 	DensityThresholdedEmitter<DensityFunction, PointFunction> thresholdedEmitter( densitySampler, pointEmitter );
 	(*this)( bounds, density, thresholdedEmitter );
 }
 
 template<typename PointFunction>
-void PointDistribution::operator () ( const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const
+void PointDistribution::operator () ( const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const
 {
 	Imath::Box2i bi;
 	bi.min.x = fastFloatFloor( bounds.min.x );
@@ -117,7 +117,7 @@ void PointDistribution::operator () ( const Imath::Box2f &bounds, float density,
 }
 
 template<typename PointFunction>
-void PointDistribution::processTile( const Tile &tile, const Imath::V2f &bottomLeft, const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const
+void PointDistribution::processTile( const Tile &tile, const Imath::V2f &bottomLeft, const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const
 {
 	unsigned potentialPoints = std::min( tile.points.size(), (size_t)density );
 	float factor = 1.0f / density;
@@ -136,7 +136,7 @@ void PointDistribution::processTile( const Tile &tile, const Imath::V2f &bottomL
 }
 
 template<typename PointFunction>
-void PointDistribution::recurseTile( const Tile &tile, const Imath::V2f &bottomLeft, unsigned level, const Imath::Box2f &bounds, float density, PointFunction &pointEmitter ) const
+void PointDistribution::recurseTile( const Tile &tile, const Imath::V2f &bottomLeft, unsigned level, const Imath::Box2f &bounds, float density, PointFunction &&pointEmitter ) const
 {
 	float tileSize = 1.0f / powf( (float)m_numSubTiles, (float)level );
 

--- a/include/IECore/TriangleAlgo.inl
+++ b/include/IECore/TriangleAlgo.inl
@@ -77,30 +77,34 @@ Vec trianglePoint( const Vec &v0, const Vec &v1, const Vec &v2, const Imath::Vec
 
 /// Implementation derived from Wild Magic (Version 2) Software Library, available
 /// from http://www.geometrictools.com/Downloads/WildMagic2p5.zip under free license
+/// This link is now offline, but it was presumably similar to the code now found here:
+/// https://www.geometrictools.com/GTE/Mathematics/DistPointTriangle.h
+/// with explanation here:
+/// https://www.geometrictools.com/Documentation/DistancePoint3Triangle3.pdf
 template<class Vec>
 typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, const Vec &v1, const Vec &v2, const Vec &p, Imath::Vec3<typename VectorTraits<Vec>::BaseType> &barycentric )
 {
 	typedef typename VectorTraits<Vec>::BaseType Real;
 
-	Vec triOrigin = v0;
 	Vec triEdge0, triEdge1;
 
+	// \todo - do we really need to support vector types that don't have a subtraction operator?
+	// This would be clearer if rewritten to use the operators on the types instead of these VectorOps,
+	// and more consistent with everything else we do.
 	vecSub( v1, v0, triEdge0 );
 	vecSub( v2, v0, triEdge1 );
 
 	Vec kDiff;
-	vecSub( triOrigin, p, kDiff );
+	vecSub( v0, p, kDiff );
 
 	Real a00 = vecDot( triEdge0, triEdge0 );
 	Real a01 = vecDot( triEdge0, triEdge1 );
 	Real a11 = vecDot( triEdge1, triEdge1 );
 	Real b0 = vecDot( kDiff, triEdge0 );
 	Real b1 = vecDot( kDiff, triEdge1 );
-	Real c = vecDot( kDiff, kDiff );
 	Real det = Real(fabs(a00*a11-a01*a01));
 	Real s = a01*b1-a11*b0;
 	Real t = a01*b0-a00*b1;
-	Real distSqrd;
 
 	if ( s + t <= det )
 	{
@@ -114,12 +118,10 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 					if ( -b0 >= a00 )
 					{
 						s = Real(1.0);
-						distSqrd = a00+Real(2.0)*b0+c;
 					}
 					else
 					{
 						s = -b0/a00;
-						distSqrd = b0*s+c;
 					}
 				}
 				else
@@ -128,17 +130,14 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 					if ( b1 >= Real(0.0) )
 					{
 						t = Real(0.0);
-						distSqrd = c;
 					}
 					else if ( -b1 >= a11 )
 					{
 						t = Real(1.0);
-						distSqrd = a11+Real(2.0)*b1+c;
 					}
 					else
 					{
 						t = -b1/a11;
-						distSqrd = b1*t+c;
 					}
 				}
 			}
@@ -148,17 +147,14 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				if ( b1 >= Real(0.0) )
 				{
 					t = Real(0.0);
-					distSqrd = c;
 				}
 				else if ( -b1 >= a11 )
 				{
 					t = Real(1.0);
-					distSqrd = a11+Real(2.0)*b1+c;
 				}
 				else
 				{
 					t = -b1/a11;
-					distSqrd = b1*t+c;
 				}
 			}
 		}
@@ -168,17 +164,14 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 			if ( b0 >= Real(0.0) )
 			{
 				s = Real(0.0);
-				distSqrd = c;
 			}
 			else if ( -b0 >= a00 )
 			{
 				s = Real(1.0);
-				distSqrd = a00+Real(2.0)*b0+c;
 			}
 			else
 			{
 				s = -b0/a00;
-				distSqrd = b0*s+c;
 			}
 		}
 		else  // region 0
@@ -188,15 +181,12 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 			{
 				s = Real(0.0);
 				t = Real(0.0);
-				distSqrd = std::numeric_limits<Real>::max();
 			}
 			else
 			{
 				Real invDet = Real(1.0)/det;
 				s *= invDet;
 				t *= invDet;
-				distSqrd = s*(a00*s+a01*t+Real(2.0)*b0) +
-				           t*(a01*s+a11*t+Real(2.0)*b1)+c;
 			}
 		}
 	}
@@ -216,14 +206,11 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				{
 					s = Real(1.0);
 					t = Real(0.0);
-					distSqrd = a00+Real(2.0)*b0+c;
 				}
 				else
 				{
 					s = numer/denom;
 					t = Real(1.0) - s;
-					distSqrd = s*(a00*s+a01*t+Real(2.0)*b0) +
-					           t*(a01*s+a11*t+Real(2.0)*b1)+c;
 				}
 			}
 			else
@@ -232,17 +219,14 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				if ( tmp1 <= Real(0.0) )
 				{
 					t = Real(1.0);
-					distSqrd = a11+Real(2.0)*b1+c;
 				}
 				else if ( b1 >= Real(0.0) )
 				{
 					t = Real(0.0);
-					distSqrd = c;
 				}
 				else
 				{
 					t = -b1/a11;
-					distSqrd = b1*t+c;
 				}
 			}
 		}
@@ -258,14 +242,11 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				{
 					t = Real(1.0);
 					s = Real(0.0);
-					distSqrd = a11+Real(2.0)*b1+c;
 				}
 				else
 				{
 					t = numer/denom;
 					s = Real(1.0) - t;
-					distSqrd = s*(a00*s+a01*t+Real(2.0)*b0) +
-					           t*(a01*s+a11*t+Real(2.0)*b1)+c;
 				}
 			}
 			else
@@ -274,17 +255,14 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				if ( tmp1 <= Real(0.0) )
 				{
 					s = Real(1.0);
-					distSqrd = a00+Real(2.0)*b0+c;
 				}
 				else if ( b0 >= Real(0.0) )
 				{
 					s = Real(0.0);
-					distSqrd = c;
 				}
 				else
 				{
 					s = -b0/a00;
-					distSqrd = b0*s+c;
 				}
 			}
 		}
@@ -295,7 +273,6 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 			{
 				s = Real(0.0);
 				t = Real(1.0);
-				distSqrd = a11+Real(2.0)*b1+c;
 			}
 			else
 			{
@@ -304,14 +281,11 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 				{
 					s = Real(1.0);
 					t = Real(0.0);
-					distSqrd = a00+Real(2.0)*b0+c;
 				}
 				else
 				{
 					s = numer/denom;
 					t = Real(1.0) - s;
-					distSqrd = s*(a00*s+a01*t+Real(2.0)*b0) +
-					           t*(a01*s+a11*t+Real(2.0)*b1)+c;
 				}
 			}
 		}
@@ -321,7 +295,9 @@ typename VectorTraits<Vec>::BaseType triangleClosestBarycentric( const Vec &v0, 
 	barycentric.z = t;
 	barycentric.x = 1 - s - t;
 
-	return Real(fabs(distSqrd));
+	Vec closest = vecAdd( vecAdd( v0, vecMul( triEdge0, s ) ), vecMul(triEdge1, t ) );
+	Vec diff = vecSub( closest, p );
+	return vecDot( diff, diff );
 }
 
 template<class Vec>

--- a/include/IECore/TriangleAlgo.inl
+++ b/include/IECore/TriangleAlgo.inl
@@ -399,13 +399,13 @@ bool triangleContainsPoint( const Vec &v0, const Vec &v1, const Vec &v2, const V
 	Real d = Real( 1 ) / ( dotAA * dotBB - dotAB * dotAB );
 
 	barycentric.z = (dotBB * dotAC - dotAB * dotBC) * d;
-	if( barycentric.z < Real( 0 ) || barycentric.z > Real( 1 ) )
+	if( !( barycentric.z >= Real( 0 ) && barycentric.z <= Real( 1 ) ) )
 	{
 		return false;
 	}
 
 	barycentric.y = (dotAA * dotBC - dotAB * dotAC) * d;
-	if( barycentric.y < Real( 0 ) || barycentric.z + barycentric.y > Real( 1 ) )
+	if( !( barycentric.y >= Real( 0 ) && barycentric.z + barycentric.y <= Real( 1 ) ) )
 	{
 		return false;
 	}

--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -37,6 +37,7 @@
 
 #include "IECore/Canceller.h"
 #include "IECore/ImathHash.h"
+#include "IECore/StringAlgo.h"
 #include "IECoreScene/MeshPrimitive.h"
 #include "IECoreScene/PointsPrimitive.h"
 #include "IECoreScene/PrimitiveVariable.h"
@@ -94,6 +95,9 @@ IECORESCENE_API void reorderVertices( MeshPrimitive *mesh, int id0, int id1, int
 /// Distributes points over a mesh using an IECore::PointDistribution in UV space
 /// and mapping it to 3d space. It gives a fairly even distribution regardless of
 /// vertex spacing, provided the UVs are well layed out.
+IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &refPosition = "P", const IECore::StringAlgo::MatchPattern &primitiveVariables = "", const IECore::Canceller *canceller = nullptr );
+
+// Deprecated signature without support for primitiveVariables
 IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &refPosition = "P", const IECore::Canceller *canceller = nullptr );
 
 

--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -94,7 +94,7 @@ IECORESCENE_API void reorderVertices( MeshPrimitive *mesh, int id0, int id1, int
 /// Distributes points over a mesh using an IECore::PointDistribution in UV space
 /// and mapping it to 3d space. It gives a fairly even distribution regardless of
 /// vertex spacing, provided the UVs are well layed out.
-IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &position = "P", const IECore::Canceller *canceller = nullptr );
+IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &refPosition = "P", const IECore::Canceller *canceller = nullptr );
 
 
 /// Split the input mesh in to N meshes based on the N unique values contained in a segment primitive variable.

--- a/src/IECoreScene/MeshAlgoDistributePoints.cpp
+++ b/src/IECoreScene/MeshAlgoDistributePoints.cpp
@@ -384,12 +384,7 @@ void distributePointsInTriangle(
 			densityInterpolation, densityView, vertexIds, faceIdx,
 			cornerDensities[0], cornerDensities[1], cornerDensities[2]
 		);
-		float maxDensity = std::max( std::max( cornerDensities[0], cornerDensities[1] ), cornerDensities[2] );
-
-		// This matches previous behaviour where a density primvar value over 1.0 does nothing, because it
-		// cannot increase the number of points generated. Maybe this is valuable as a safety mechanism?
-		// We could just delete this line, and then densities greater than 1 would work how you would expect.
-		maxDensity = std::min( 1.0f, std::max( 0.0f, maxDensity ) );
+		float maxDensity = std::max( 0.0f, std::max( std::max( cornerDensities[0], cornerDensities[1] ), cornerDensities[2] ) );
 
 		// Apply the max density from the primvar to the density passed in to PointDistribution
 		finalDensity *= maxDensity;
@@ -466,7 +461,7 @@ PointsPrimitivePtr MeshAlgo::distributePoints( const MeshPrimitive *mesh, float 
 	PrimitiveVariable::IndexedView<float> densityView;
 	if( densityVar.interpolation == PrimitiveVariable::Constant )
 	{
-		density *= std::min( 1.0f, std::max( 0.0f, (IECore::runTimeCast<FloatData>(densityVar.data.get()))->readable() ) );
+		density *= std::max( 0.0f, (IECore::runTimeCast<FloatData>(densityVar.data.get()))->readable() );
 	}
 	else
 	{

--- a/src/IECoreScene/MeshAlgoDistributePoints.cpp
+++ b/src/IECoreScene/MeshAlgoDistributePoints.cpp
@@ -294,7 +294,7 @@ void distributePointsInTriangle(
 				if( densityView )
 				{
 					float d = triangleInterpolatedPrimVarValue( densityInterpolation, densityView, vertexIds, faceIdx, bary );
-					if( d < densityThreshold )
+					if( d <= densityThreshold )
 					{
 						return;
 					}

--- a/src/IECoreScene/MeshAlgoDistributePoints.cpp
+++ b/src/IECoreScene/MeshAlgoDistributePoints.cpp
@@ -221,14 +221,14 @@ struct Generator
 
 } // namespace
 
-PointsPrimitivePtr MeshAlgo::distributePoints( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &position, const Canceller *canceller )
+PointsPrimitivePtr MeshAlgo::distributePoints( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &refPosition, const Canceller *canceller )
 {
 	if( density < 0 )
 	{
 		throw InvalidArgumentException( "MeshAlgo::distributePoints : The density of the distribution cannot be negative." );
 	}
 
-	MeshPrimitivePtr updatedMesh = processMesh( mesh, densityMask, uvSet, position, canceller );
+	MeshPrimitivePtr updatedMesh = processMesh( mesh, densityMask, uvSet, refPosition, canceller );
 	MeshPrimitiveEvaluatorPtr meshEvaluator = new MeshPrimitiveEvaluator( updatedMesh );
 
 	bool faceVaryingUVs = true;

--- a/src/IECoreScene/MeshAlgoTriangulate.cpp
+++ b/src/IECoreScene/MeshAlgoTriangulate.cpp
@@ -142,6 +142,24 @@ void triangulateMeshIndices(
 	}
 }
 
+DataPtr newMatchingData( const Data *source )
+{
+	return dispatch( source,
+		[]( const auto *typedSource ) -> DataPtr
+		{
+			using DataType = typename std::remove_const_t< std::remove_pointer_t< decltype( typedSource ) > >;
+			typename DataType::Ptr result = new DataType();
+
+			if constexpr( TypeTraits::IsGeometricTypedData< DataType >::value )
+			{
+				result->setInterpretation( typedSource->getInterpretation() );
+			}
+
+			return result;
+		}
+	);
+}
+
 
 /// A functor for use with despatchTypedData, which copies elements from another vector, as specified by an array of indices into that data
 struct TriangleDataRemap
@@ -243,7 +261,7 @@ struct TriangulateFn
 			}
 
 			const Data *inputData = it->second.indices ? it->second.indices.get() : it->second.data.get();
-			DataPtr result = inputData->copy();
+			DataPtr result = newMatchingData( inputData );
 			remap->m_other = inputData;
 
 			// \todo - using this to reindex data is a waste of time and memory.  If there are no indices,

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -155,10 +155,10 @@ void reorderVerticesWrapper( MeshPrimitive *mesh, int id0, int id1, int id2, con
 	return MeshAlgo::reorderVertices( mesh, id0, id1, id2, canceller );
 }
 
-PointsPrimitivePtr distributePointsWrapper( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &position, const IECore::Canceller *canceller )
+PointsPrimitivePtr distributePointsWrapper( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &refPosition, const IECore::Canceller *canceller )
 {
 	ScopedGILRelease gilRelease;
-	return MeshAlgo::distributePoints( mesh, density, offset, densityMask, uvSet, position, canceller );
+	return MeshAlgo::distributePoints( mesh, density, offset, densityMask, uvSet, refPosition, canceller );
 }
 
 boost::python::list segmentWrapper(const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues = nullptr, const IECore::Canceller *canceller = nullptr )
@@ -247,7 +247,7 @@ void bindMeshAlgo()
 	def( "deleteFaces", &deleteFacesWrapper, ( arg_( "meshPrimitive" ), arg_( "facesToDelete" ), arg_( "invert" ) = false, arg_( "canceller" ) = object() ) );
 	def( "reverseWinding", &reverseWindingWrapper, ( arg_( "meshPrimitive" ), arg_( "canceller" ) = object() ) );
 	def( "reorderVertices", &reorderVerticesWrapper, ( arg_( "mesh" ), arg_( "id0" ), arg_( "id1" ), arg_( "id2" ), arg_( "canceller" ) = object() ) );
-	def( "distributePoints", &distributePointsWrapper, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "position" ) = "P", arg_( "canceller" ) = object() ) );
+	def( "distributePoints", &distributePointsWrapper, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "refPosition" ) = "P", arg_( "canceller" ) = object() ) );
 	def( "segment", &::segmentWrapper, segmentOverLoads() );
 	def( "merge", &::mergeWrapper, ( arg_( "meshes" ), arg_( "canceller" ) = object() ) );
 	def( "triangulate", &triangulateWrapper, (arg_("mesh"), arg_( "canceller" ) = object() ) );

--- a/src/IECoreScene/bindings/MeshAlgoBinding.cpp
+++ b/src/IECoreScene/bindings/MeshAlgoBinding.cpp
@@ -155,10 +155,10 @@ void reorderVerticesWrapper( MeshPrimitive *mesh, int id0, int id1, int id2, con
 	return MeshAlgo::reorderVertices( mesh, id0, id1, id2, canceller );
 }
 
-PointsPrimitivePtr distributePointsWrapper( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &refPosition, const IECore::Canceller *canceller )
+PointsPrimitivePtr distributePointsWrapper( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &refPosition, const IECore::StringAlgo::MatchPattern &primitiveVariables, const IECore::Canceller *canceller )
 {
 	ScopedGILRelease gilRelease;
-	return MeshAlgo::distributePoints( mesh, density, offset, densityMask, uvSet, refPosition, canceller );
+	return MeshAlgo::distributePoints( mesh, density, offset, densityMask, uvSet, refPosition, primitiveVariables, canceller );
 }
 
 boost::python::list segmentWrapper(const MeshPrimitive *mesh, const PrimitiveVariable &primitiveVariable, const IECore::Data *segmentValues = nullptr, const IECore::Canceller *canceller = nullptr )
@@ -247,7 +247,7 @@ void bindMeshAlgo()
 	def( "deleteFaces", &deleteFacesWrapper, ( arg_( "meshPrimitive" ), arg_( "facesToDelete" ), arg_( "invert" ) = false, arg_( "canceller" ) = object() ) );
 	def( "reverseWinding", &reverseWindingWrapper, ( arg_( "meshPrimitive" ), arg_( "canceller" ) = object() ) );
 	def( "reorderVertices", &reorderVerticesWrapper, ( arg_( "mesh" ), arg_( "id0" ), arg_( "id1" ), arg_( "id2" ), arg_( "canceller" ) = object() ) );
-	def( "distributePoints", &distributePointsWrapper, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "refPosition" ) = "P", arg_( "canceller" ) = object() ) );
+	def( "distributePoints", &distributePointsWrapper, ( arg_( "mesh" ), arg_( "density" ) = 100.0, arg_( "offset" ) = Imath::V2f( 0 ), arg_( "densityMask" ) = "density", arg_( "uvSet" ) = "uv", arg_( "refPosition" ) = "P", arg( "primitiveVariables" ) = "", arg_( "canceller" ) = object() ) );
 	def( "segment", &::segmentWrapper, segmentOverLoads() );
 	def( "merge", &::mergeWrapper, ( arg_( "meshes" ), arg_( "canceller" ) = object() ) );
 	def( "triangulate", &triangulateWrapper, (arg_("mesh"), arg_( "canceller" ) = object() ) );

--- a/test/IECore/TriangleAlgoTest.py
+++ b/test/IECore/TriangleAlgoTest.py
@@ -96,6 +96,20 @@ class TriangleAlgoTest( unittest.TestCase ) :
 				bb = IECore.triangleContainsPoint( v0, v1, v2, p )
 				self.assertTrue( bb.equalWithAbsError( b, 0.0001 ) )
 
+	def testContainsPointZeroArea( self ) :
+		v0 = imath.V3f( 0, 0, 0 )
+		v1 = imath.V3f( 1, 0, 0 )
+		v2 = imath.V3f( 1, 0, 0 )
+
+		# These points are definitely outside the triangle
+		self.assertFalse( IECore.triangleContainsPoint( v0, v1, v2, imath.V3f( 2, 0, 0 ) ) )
+		self.assertFalse( IECore.triangleContainsPoint( v0, v1, v2, imath.V3f( 0.5, 1, 0 ) ) )
+
+		# This point is theoretically included in the triangle - if we add a special case for zero
+		# area triangles, maybe we would want to include it.  But as a simple solution, it is a lot
+		# more accurate to say that a zero area triangle contains nothing than that it contains
+		# everything ( which was the result of a previous bug ).
+		self.assertFalse( IECore.triangleContainsPoint( v0, v1, v2, imath.V3f( 0, 0, 0 ) ) )
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -68,7 +68,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		for f in range( 0, mesh.verticesPerFace.size() ) :
 			if "density" in mesh :
 				density = mesh["density"].data[f] * origDensity
-			self.assertTrue( abs( pointsPerFace[f] - density * mesh['faceArea'].data[f] ) <= density * error + len(positions) * error * error )
+			self.assertLessEqual( abs( pointsPerFace[f] - density * mesh['faceArea'].data[f] ), density * error + len(positions) * error * error )
 
 	def testSimple( self ) :
 
@@ -133,7 +133,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 			self.assertTrue( i in neighbours )
 			neighbours.remove( i )
 			for n in neighbours :
-				self.assertTrue( ( positions[i] - positions[n] ).length() > 1.0 / density )
+				self.assertGreater( ( positions[i] - positions[n] ).length(), 1.0 / density )
 
 	def testPointOrder( self ) :
 

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -60,7 +60,7 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 		## test that the points are on the mesh
 		for p in positions :
-			self.assertAlmostEqual( meshEvaluator.signedDistance( p, result ), 0.0, 3 )
+			self.assertAlmostEqual( meshEvaluator.signedDistance( p, result ), 0.0, 6 )
 			pointsPerFace[result.triangleIndex()] += 1
 
 		## test that we have roughly the expected density per face
@@ -82,7 +82,6 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 100 )
 		self.pointTest( m, p, 100 )
 
-
 	def testRaisesExceptionIfInvalidUVs( self ) :
 
 		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
@@ -96,8 +95,14 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 
 		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 50000, offset = imath.V2f( 0.0001, 0.0001 ) )
-
 		self.pointTest( m, p, 50000 )
+
+	def testSphere( self ) :
+		# This is mostly just to make sure that the points we're generating lie on the sphere according to
+		# meshEvaluator.signedDistance for triangles that aren't axis aligned
+		m = IECoreScene.MeshPrimitive.createSphere( 0.3 )
+		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 5000 )
+		self.pointTest( m, p, 5000 )
 
 	def testDensityMaskPrimVar( self ) :
 

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -135,6 +135,19 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		p = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 1000 )
 		self.assertEqual( p.numPoints, 0 )
 
+	def testDensityMatches( self ):
+		# Make sure that for exactly representable densities, setting the density using a primvar
+		# yields the same result as setting it with an argument ( this checks for a previous situation
+		# where PointDistribution used an exclusive threshold, but distributePoints used an inclusive
+		# threshold when comparing to a primvar )
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 1 ) )
+		p1 = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 128 )
+
+		m['density'] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Uniform, IECore.FloatVectorData( [ 0.25 ] ) )
+		p2 = IECoreScene.MeshAlgo.distributePoints( mesh = m, density = 512 )
+
+		self.assertEqual( p1, p2 )
+
 	def testOffsetParameter( self ) :
 
 		m = IECore.Reader.create( os.path.join( "test", "IECore", "data", "cobFiles", "pCubeShape1.cob" ) ).read()

--- a/test/IECoreScene/MeshAlgoDistributePointsTest.py
+++ b/test/IECoreScene/MeshAlgoDistributePointsTest.py
@@ -112,11 +112,9 @@ class MeshAlgoDistributePointsTest( unittest.TestCase ) :
 		for f in range( 0, mesh.verticesPerFace.size() ) :
 			if "density" in mesh :
 				if mesh["density"].interpolation == IECoreScene.PrimitiveVariable.Interpolation.Constant:
-					# For consistency, no primitive variable may increase the density, only decrease it.
-					# At least currently, we could just fix this now.
-					density = min( 1, mesh["density"].data.value ) * origDensity
+					density = mesh["density"].data.value * origDensity
 				else:
-					density = min( 1, mesh["density"].data[f] ) * origDensity
+					density = mesh["density"].data[f] * origDensity
 			self.assertLessEqual( abs( pointsPerFace[f] - density * mesh['faceArea'].data[f] ), density * error + len(positions) * error * error )
 
 	def testSimple( self ) :

--- a/test/IECoreScene/MeshAlgoTriangulateTest.py
+++ b/test/IECoreScene/MeshAlgoTriangulateTest.py
@@ -256,6 +256,26 @@ class MeshAlgoTriangulateTest( unittest.TestCase ) :
 			print( "time / object: {0} milliseconds".format( 1000.0 * t /  len(objects) ) )
 			print( "time / triangle: {0} microseconds".format( 1000000.0 * t /  totalNumTriangles ) )
 
+	@unittest.skipIf( True, "Not running slow perf tests by default" )
+	def testPerformance( self ) :
+
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 4000 ) )
+		startTime = time.time()
+		m2 = IECoreScene.MeshAlgo.triangulate( m )
+		elapsed = time.time() - startTime
+		print( "\nTime for 16000000 faces", elapsed )
+
+		m = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( -1 ), imath.V2f( 1 ) ), imath.V2i( 4000 ) )
+
+		convertToFaceVarying = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, m["P"].data, m.vertexIds )
+
+		m["testPrimVar"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.FaceVarying, convertToFaceVarying.expandedData() )
+
+		startTime = time.time()
+		m2 = IECoreScene.MeshAlgo.triangulate( m )
+		elapsed = time.time() - startTime
+		print( "Time for 16000000 faces with heavy, unindexed, face-varying primvar", elapsed )
+
 	@unittest.skipIf( ( IECore.TestUtil.inMacCI() or IECore.TestUtil.inWindowsCI() ), "Mac and Windows CI are too slow for reliable timing" )
 	def testCancel( self ) :
 		canceller = IECore.Canceller()

--- a/test/IECoreScene/MeshPrimitiveEvaluator.py
+++ b/test/IECoreScene/MeshPrimitiveEvaluator.py
@@ -437,6 +437,15 @@ class TestMeshPrimitiveEvaluator( unittest.TestCase ) :
 					m["faceVarying"].data[m["faceVarying"].indices[triangleIndex*3+corner]]
 				)
 
+	def testSignedDistanceWeirdness( self ) :
+		# Previously, numerical precision problems meant that this point on the cube was reported to be
+		# 0.0005 away from the cube
+		m = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -0.5 ), imath.V3f( 0.5 ) ) )
+		mt = IECoreScene.MeshAlgo.triangulate( m )
+		meshEvaluator = IECoreScene.MeshPrimitiveEvaluator( mt )
+		result = meshEvaluator.createResult()
+		self.assertAlmostEqual( meshEvaluator.signedDistance( imath.V3f( 0.23601509630680084, -0.5, 0.23528452217578888), result ), 0 )
+
 if __name__ == "__main__":
 	unittest.main()
 


### PR DESCRIPTION
... and some odds and ends that came up along the way.  I think based on our previous conversations, it's probably fairly clear where most of this came from.

The final commit can safely be dropped as out of scope - it isn't necessary.  Though I do consider it pretty wrong that we potentially waste a lot of time generating points that will necessarily be rejected based on the densities of all the vertices of the current triangle.  The test case shows a factor of 2 speedup, but that could be a lot more dramatic if you wanted to generate millions of points one small area of a large mesh, so you used an extremely high global density, and then had a primitive variable that is zero for most of the mesh ... this case doesn't seem that implausible if you were using Seeds for environment layout.  I've left a test failure in though, illustrating that shifting the test inside PointsDistribution changes the behaviour for points that are exactly on the threshold of being accepted ( because distributePoints uses an inclusive comparison, but PointsDistribution seems to implicitly use an exclusive comparison ... floating point error could result in points being rejected that were previously on the threshold anyway ).  If we're planning to alter the algorithm for PointsDistribution at some point, I guess that would be the time to merge this.  That also might be a good time to get rid of the duplicate points that PointsDistribution generates, which I noticed looking at the test data.