### PR TITLE
USDScene : Apply UsdShadeMaterialBindingAPI schema as necessary

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 10.4.x.x (relative to 10.4.7.0)
 ========
 
+Fixes
+-----
+
+- USDScene : The UsdShadeMaterialBindingAPI schema is now applied to all prims with material bindings, making the written files compatible with `USD_SHADE_MATERIAL_BINDING_API_CHECK=strict` mode.
 
 10.4.7.0 (relative to 10.4.6.0)
 ========

--- a/SConstruct
+++ b/SConstruct
@@ -3121,6 +3121,7 @@ if doConfigure :
 
 		usdTestEnv["ENV"]["PYTHONPATH"] += os.pathsep + usdPythonPath
 		usdTestEnv["ENV"][testEnv["TEST_LIBRARY_PATH_ENV_VAR"]] += os.pathsep + usdLibPath
+		usdTestEnv["ENV"]["USD_SHADE_MATERIAL_BINDING_API_CHECK"] = "strict"
 
 		# setup pluginInfo for custom file format registration
 		testSdfPlugInfo = os.path.join( os.getcwd(), "plugins", "usd", "plugInfo.json" )

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -667,7 +667,9 @@ USDScene::~USDScene()
 				}
 
 				// Bind the material to this location
-				pxr::UsdShadeMaterialBindingAPI( m_location->prim ).Bind( mat, pxr::UsdShadeTokens->fallbackStrength, purpose );
+				pxr::UsdShadeMaterialBindingAPI::Apply( m_location->prim ).Bind(
+					mat, pxr::UsdShadeTokens->fallbackStrength, purpose
+				);
 			}
 		}
 		catch( std::exception &e )

--- a/contrib/IECoreUSD/test/IECoreUSD/data/arnoldArrayInputs.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/arnoldArrayInputs.usda
@@ -1,6 +1,8 @@
 #usda 1.0
 
-def Sphere "sphere"
+def Sphere "sphere" (
+    prepend apiSchemas = ["MaterialBindingAPI"]
+)
 {
     rel material:binding = </rampSurface>
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/data/exposedShaderInput.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/exposedShaderInput.usda
@@ -3,7 +3,9 @@
 def "model"
 {
 
-	def Sphere "sphere"
+	def Sphere "sphere" (
+		prepend apiSchemas = ["MaterialBindingAPI"]
+	)
 	{
 		rel material:binding = </model/materials/material1>
 	}

--- a/contrib/IECoreUSD/test/IECoreUSD/data/materialPurpose.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/materialPurpose.usda
@@ -3,7 +3,9 @@
 def "model"
 {
 
-	def Sphere "sphere"
+	def Sphere "sphere" (
+		prepend apiSchemas = ["MaterialBindingAPI"]
+	)
 	{
 		rel material:binding = </model/materials/material>
 		rel material:binding:full = </model/materials/fullMaterial>

--- a/contrib/IECoreUSD/test/IECoreUSD/data/shaderParentLoc.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/shaderParentLoc.usda
@@ -1,6 +1,8 @@
 #usda 1.0
 
-def Xform "shaderLocation"
+def Xform "shaderLocation" (
+    prepend apiSchemas = ["MaterialBindingAPI"]
+)
 {
     rel material:binding = </shaderLocation/materials/testMat>
 

--- a/contrib/IECoreUSD/test/IECoreUSD/data/textureParameters.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/textureParameters.usda
@@ -3,7 +3,9 @@
 def "model"
 {
 
-	def Sphere "sphere"
+	def Sphere "sphere" (
+		prepend apiSchemas = ["MaterialBindingAPI"]
+	)
 	{
 		rel material:binding = </model/materials/textureParameterTest>
 	}


### PR DESCRIPTION
This prevents warnings like the following :

```
Found material bindings on prim...but MaterialBindingAPI is not applied on the prim
```

We now run the tests with `USD_SHADE_MATERIAL_BINDING_API_CHECK=strict` so that they would fail if we didn't apply the schema, preparing us for a future USD version where `strict` becomes the default behaviour.
