### PR TITLE
MeshAlgo : Remove deprecated distributePoints signature

### DIFF
--- a/include/IECoreScene/MeshAlgo.h
+++ b/include/IECoreScene/MeshAlgo.h
@@ -97,10 +97,6 @@ IECORESCENE_API void reorderVertices( MeshPrimitive *mesh, int id0, int id1, int
 /// vertex spacing, provided the UVs are well layed out.
 IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &refPosition = "P", const IECore::StringAlgo::MatchPattern &primitiveVariables = "", const IECore::Canceller *canceller = nullptr );
 
-// Deprecated signature without support for primitiveVariables
-IECORESCENE_API PointsPrimitivePtr distributePoints( const MeshPrimitive *mesh, float density = 100.0, const Imath::V2f &offset = Imath::V2f( 0 ), const std::string &densityMask = "density", const std::string &uvSet = "uv", const std::string &refPosition = "P", const IECore::Canceller *canceller = nullptr );
-
-
 /// Split the input mesh in to N meshes based on the N unique values contained in a segment primitive variable.
 /// Using a class allows for the initialization work to be done once, and shared when actually splitting
 /// ( splitting may be performed on multiple threads )

--- a/src/IECoreScene/MeshAlgoDistributePoints.cpp
+++ b/src/IECoreScene/MeshAlgoDistributePoints.cpp
@@ -643,9 +643,3 @@ PointsPrimitivePtr MeshAlgo::distributePoints( const MeshPrimitive *mesh, float 
 	);
 	return result;
 }
-
-//Old signature for backwards compatibility
-PointsPrimitivePtr MeshAlgo::distributePoints( const MeshPrimitive *mesh, float density, const Imath::V2f &offset, const std::string &densityMask, const std::string &uvSet, const std::string &refPosition, const Canceller *canceller )
-{
-	return MeshAlgo::distributePoints( mesh, density, offset, densityMask, uvSet, refPosition, "", canceller );
-}


### PR DESCRIPTION
This should be fine - our only concern was that IE might have some C++ projects using this signature, but on further inspection, I was just remember a dependency on PointDistribution, IE does not seem to be using this signature anywhere.