### PR TITLE
USDScene : Optimise set reading for instanced prims

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,7 +4,14 @@
 Improvements
 ------------
 
-- USDScene : Improved performance of `setNames( includeDescendantSets = True )` substantially for compositions with instanced prims.
+- USDScene :
+  - Improved performance of `setNames( includeDescendantSets = True )` substantially for compositions with instanced prims.
+  - Improved performance of `readSet( includeDescendantSets = True )` substantially for compositions with instanced prims.
+
+Fixes
+-----
+
+- USDScene : Fixed loading of `__cameras`, `__lights` and `usd:pointInstancers` sets from within instanced prims.
 
 10.4.8.0 (relative to 10.4.7.1)
 ========

--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.4.x.x (relative to 10.4.8.0)
 ========
 
+Improvements
+------------
+
+- USDScene : Improved performance of `setNames( includeDescendantSets = True )` substantially for compositions with instanced prims.
+
 10.4.8.0 (relative to 10.4.7.1)
 ========
 


### PR DESCRIPTION
This gives us substantial performance improvements when reading sets from USD compositions that make heavy use of instanced prims. Before, we were traversing all descendants of each instance, but now we do that only once for each prototype, reusing the results on the corresponding instances.