### PR TITLE
TypedData : Add move constructors

### DIFF
--- a/include/IECore/GeometricTypedData.h
+++ b/include/IECore/GeometricTypedData.h
@@ -83,6 +83,8 @@ class IECORE_EXPORT GeometricTypedData : public TypedData<T>
 		GeometricTypedData();
 		GeometricTypedData( const ValueType &data );
 		GeometricTypedData( const ValueType &data, GeometricData::Interpretation interpretation );
+		GeometricTypedData( ValueType &&data );
+		GeometricTypedData( ValueType &&data, GeometricData::Interpretation interpretation );
 
 		IECORE_RUNTIMETYPED_DECLARETEMPLATE( GeometricTypedData<T>, TypedData<T> );
 

--- a/include/IECore/GeometricTypedData.inl
+++ b/include/IECore/GeometricTypedData.inl
@@ -60,6 +60,18 @@ GeometricTypedData<T>::GeometricTypedData( const ValueType &data, GeometricData:
 }
 
 template<class T>
+GeometricTypedData<T>::GeometricTypedData( ValueType &&data )
+	: TypedData<T>( std::move( data ) ), m_interpretation( GeometricData::None )
+{
+}
+
+template<class T>
+GeometricTypedData<T>::GeometricTypedData( ValueType &&data, GeometricData::Interpretation interpretation )
+	: TypedData<T>( std::move( data ) ), m_interpretation( interpretation )
+{
+}
+
+template<class T>
 GeometricTypedData<T>::~GeometricTypedData()
 {
 }

--- a/include/IECore/TypedData.h
+++ b/include/IECore/TypedData.h
@@ -71,6 +71,9 @@ class IECORE_EXPORT TypedData : public Data
 		TypedData();
 		/// Constructor based on the stored data type.
 		TypedData(const T &data);
+		/// Move constructor, to allow efficient construction if the caller
+		/// uses std::move or calls an in-place constructor for the stored type
+		TypedData(T &&data);
 
 		IECORE_RUNTIMETYPED_DECLARETEMPLATE( TypedData<T>, Data );
 

--- a/include/IECore/TypedData.inl
+++ b/include/IECore/TypedData.inl
@@ -97,6 +97,11 @@ TypedData<T>::TypedData(const T &data) : m_data ( data )
 }
 
 template<class T>
+TypedData<T>::TypedData(T &&data) : m_data ( std::move( data ) )
+{
+}
+
+template<class T>
 TypedData<T>::~TypedData()
 {
 }

--- a/include/IECore/TypedDataInternals.h
+++ b/include/IECore/TypedDataInternals.h
@@ -56,6 +56,11 @@ class IECORE_EXPORT SimpleDataHolder
 		{
 		}
 
+		SimpleDataHolder( T &&data )
+			: m_data( std::move( data ) )
+		{
+		}
+
 		const T &readable() const
 		{
 			return m_data;
@@ -95,6 +100,11 @@ class IECORE_EXPORT SharedDataHolder
 
 		SharedDataHolder( const T &data )
 			: m_data( new Shareable( data ) )
+		{
+		}
+
+		SharedDataHolder( T &&data )
+			: m_data( new Shareable( std::move( data ) ) )
 		{
 		}
 
@@ -162,6 +172,7 @@ class IECORE_EXPORT SharedDataHolder
 
 				Shareable() : data(), hashValid( false ) {}
 				Shareable( const T &initData ) : data( initData ), hashValid( false ) {}
+				Shareable( T &&initData ) : data( std::move( initData ) ), hashValid( false ) {}
 
 				T data;
 				MurmurHash hash;


### PR DESCRIPTION
I feel like I should really think more about this, given that it potentially touches a lot of things, but a basic implementation successfully knocks a second-and-a-half off my USD load test.