### PR TITLE
USDScene : Improve performance when reading instanced materials

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Improvements
 - USDScene :
   - Improved performance of `setNames( includeDescendantSets = True )` substantially for compositions with instanced prims.
   - Improved performance of `readSet( includeDescendantSets = True )` substantially for compositions with instanced prims.
+- SceneInterface : Added `_copy` argument to Python bindings for `readAttribute()`, `readTransform()` and `readObject()`. Pass `_copy = False` to receive the original constant result directly instead of a mutable copy. Use with care (typically only for debugging and testing)!
 
 Fixes
 -----

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Improvements
 - USDScene :
   - Improved performance of `setNames( includeDescendantSets = True )` substantially for compositions with instanced prims.
   - Improved performance of `readSet( includeDescendantSets = True )` substantially for compositions with instanced prims.
+  - Improved performance when reading materials from instanced prims.
 - SceneInterface : Added `_copy` argument to Python bindings for `readAttribute()`, `readTransform()` and `readObject()`. Pass `_copy = False` to receive the original constant result directly instead of a mutable copy. Use with care (typically only for debugging and testing)!
 
 Fixes

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -640,6 +640,14 @@ class USDScene::IO : public RefCounted
 				// and then allow people to manage them after loading.
 				return pxr::UsdShadeMaterial();
 			}
+
+			if( material.GetPrim().IsInstanceProxy() )
+			{
+				// Use the prototype so that we only load once in `readShaderNetwork()`,
+				// and so instanced locations have the same `attributesHash()`.
+				return pxr::UsdShadeMaterial( material.GetPrim().GetPrimInPrototype() );
+			}
+
 			return material;
 		}
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -3564,5 +3564,24 @@ class USDSceneTest( unittest.TestCase ) :
 		root = IECoreScene.SceneInterface.create( compositionFileName, IECore.IndexedIO.OpenMode.Read )
 		self.assertEqual( root.readSet( "__cameras" ), IECore.PathMatcher( [ "/instance0/camera", "/instance1/camera" ] ) )
 
+	def testMaterialBindingInsideInstance( self ) :
+
+		root = IECoreScene.SceneInterface.create(
+			os.path.join( os.path.dirname( __file__ ), "data", "materialBindingInsideInstance.usda" ),
+			IECore.IndexedIO.OpenMode.Read
+		)
+
+		instance1 = root.scene( [ "instance1", "cube" ] )
+		instance2 = root.scene( [ "instance2", "cube" ] )
+
+		self.assertEqual(
+			instance1.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0.0 ),
+			instance2.hash( IECoreScene.SceneInterface.HashType.AttributesHash, 0.0 ),
+		)
+
+		shader1 = instance1.readAttribute( "surface", 0.0, _copy = False )
+		shader2 = instance2.readAttribute( "surface", 0.0, _copy = False )
+		self.assertTrue( shader1.isSame( shader2 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/data/materialBindingInsideInstance.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/materialBindingInsideInstance.usda
@@ -1,0 +1,37 @@
+#usda 1.0
+
+over "prototype"
+{
+	def Material "redMaterial"
+	{
+		token outputs:surface.connect = </prototype/redMaterial/surface.outputs:surface>
+
+		def Shader "surface"
+		{
+			uniform token info:id = "UsdPreviewSurface"
+			color3f inputs:diffuseColor = (1, 0, 0)
+			token outputs:surface
+		}
+	}
+
+	def Cube "cube" (
+	    prepend apiSchemas = ["MaterialBindingAPI"]
+	)
+	{
+		rel material:binding = </prototype/redMaterial>
+	}
+}
+
+def Xform "instance1" (
+	instanceable = true
+	prepend references = </prototype>
+)
+{
+}
+
+def Xform "instance2" (
+	instanceable = true
+	prepend references = </prototype>
+)
+{
+}

--- a/src/IECoreScene/bindings/SceneInterfaceBinding.cpp
+++ b/src/IECoreScene/bindings/SceneInterfaceBinding.cpp
@@ -160,33 +160,33 @@ void writeTags( SceneInterface &m, list tagList )
 	m.writeTags( v );
 }
 
-DataPtr readTransform( SceneInterface &m, double time )
+DataPtr readTransform( SceneInterface &m, double time, bool copy )
 {
 	ConstDataPtr t = m.readTransform( time );
 	if( t )
 	{
-		return t->copy();
+		return copy ? t->copy() : boost::const_pointer_cast<Data>( t );
 	}
 	return nullptr;
 }
 
-ObjectPtr readAttribute( SceneInterface &m, const SceneInterface::Name &name, double time )
+ObjectPtr readAttribute( SceneInterface &m, const SceneInterface::Name &name, double time, bool copy )
 {
 	ConstObjectPtr o = m.readAttribute( name, time );
 	if( o )
 	{
-		return o->copy();
+		return copy ? o->copy() : boost::const_pointer_cast<Object>( o );
 	}
 	return nullptr;
 }
 
-ObjectPtr readObject( SceneInterface &m, double time, const IECore::Canceller *canceller )
+ObjectPtr readObject( SceneInterface &m, double time, const IECore::Canceller *canceller, bool copy )
 {
 	ScopedGILRelease gilRelease;
 	ConstObjectPtr o = m.readObject( time, canceller );
 	if( o )
 	{
-		return o->copy();
+		return copy ? o->copy() : boost::const_pointer_cast<Object>( o );
 	}
 	return nullptr;
 }
@@ -260,12 +260,12 @@ void bindSceneInterface()
 		.def( "hasBound", &SceneInterface::hasBound )
 		.def( "readBound", &SceneInterface::readBound )
 		.def( "writeBound", &SceneInterface::writeBound )
-		.def( "readTransform", &readTransform )
+		.def( "readTransform", &readTransform, ( arg( "time" ), arg( "_copy" ) = true ) )
 		.def( "readTransformAsMatrix", &SceneInterface::readTransformAsMatrix )
 		.def( "writeTransform", &SceneInterface::writeTransform )
 		.def( "hasAttribute", &SceneInterface::hasAttribute )
 		.def( "attributeNames", attributeNames )
-		.def( "readAttribute", &readAttribute )
+		.def( "readAttribute", &readAttribute, ( arg( "name" ), arg( "time" ), arg( "_copy" ) = true ) )
 		.def( "writeAttribute", &SceneInterface::writeAttribute )
 		.def( "hasTag", &SceneInterface::hasTag, ( arg( "name" ), arg( "filter" ) = SceneInterface::LocalTag ) )
 		.def( "readTags", readTags, ( arg( "filter" ) = SceneInterface::LocalTag ) )
@@ -274,7 +274,7 @@ void bindSceneInterface()
 		.def( "writeSet", &SceneInterface::writeSet )
 		.def( "hashSet", &hashSet )
 		.def( "readSet", &SceneInterface::readSet, ( arg_("name"), arg_( "includeDescendantSets" ) = true, arg_( "canceller" ) = object() ) )
-		.def( "readObject", &readObject, ( arg_( "time" ), arg_( "canceller" ) = object() ) )
+		.def( "readObject", &readObject, ( arg_( "time" ), arg_( "canceller" ) = object(), arg( "_copy" ) = true ) )
 		.def( "readObjectPrimitiveVariables", &readObjectPrimitiveVariables )
 		.def( "writeObject", &SceneInterface::writeObject )
 		.def( "hasObject", &SceneInterface::hasObject )

--- a/test/IECoreScene/SceneCacheTest.py
+++ b/test/IECoreScene/SceneCacheTest.py
@@ -1200,6 +1200,42 @@ class SceneCacheTest( unittest.TestCase ) :
 		for a in nonShaderAttributes :
 			self.assertEqual( c.readAttribute( a, 0 ), objectVector )
 
+	def testCopyReturnValues( self ):
+
+		fileName = os.path.join( self.tempDir, "test.scc" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		child = root.createChild( "child" )
+		child.writeObject( IECoreScene.SpherePrimitive( 1 ), 1.0 )
+		child.writeAttribute( "test", IECore.IntVectorData( range( 0, 100 ) ), 1.0 )
+		child.writeTransform( IECore.M44dData(), 1.0 )
+
+		del root, child
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		child = root.child( "child" )
+
+		self.assertFalse(
+			child.readObject( 1 ).isSame( child.readObject( 1 ) )
+		)
+		self.assertTrue(
+			child.readObject( 1, _copy = False ).isSame( child.readObject( 1, _copy = False ) )
+		)
+
+		self.assertFalse(
+			child.readAttribute( "test", 1 ).isSame( child.readAttribute( "test", 1 ) )
+		)
+		self.assertTrue(
+			child.readAttribute( "test", 1, _copy = False ).isSame( child.readAttribute( "test", 1, _copy = False ) )
+		)
+
+		self.assertFalse(
+			child.readTransform( 1 ).isSame( child.readTransform( 1 ) )
+		)
+		self.assertTrue(
+			child.readTransform( 1, _copy = False ).isSame( child.readTransform( 1, _copy = False ) )
+		)
+
+
 	def setUp( self ) :
 		self.tempDir = tempfile.mkdtemp()
 


### PR DESCRIPTION
This yields modest reductions in runtime and cache memory usage when loading the Moana island in Gaffer (of ~9% and 5% respectively). I think there's a reasonable chance it will give greater gains in production scenes containing more complex shading networks.