### PR TITLE
SceneShape: Fix reading of time samples for expanded link locations

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.4.x.x (relative to 10.4.9.1)
 ========
 
+Fixes
+---
+
+- IECoreMaya.SceneShape : Fixed reading of time samples for expanded link locations
+  - Traverse the time plug connections to check for a maya global time connection
 
 10.4.9.1 (relative to 10.4.9.0)
 ========

--- a/test/IECoreMaya/LiveSceneTest.py
+++ b/test/IECoreMaya/LiveSceneTest.py
@@ -556,9 +556,7 @@ class LiveSceneTest( IECoreMaya.TestCase ) :
 		self.assertFalse( spheresScene.hasAttribute( IECoreScene.LinkedScene.linkAttribute ) )
 		leafScene = spheresScene.child("A").child("a")
 		self.assertTrue( leafScene.hasAttribute( IECoreScene.LinkedScene.linkAttribute ) )
-		# When expanding, we connect the child time attributes to their scene shape parent time attribute to propagate time remapping. When checking for time remapping, the scene shape
-		# currently only checks the direct connection, so we have here time in the link attributes. Will have to look out for performance issues.
-		self.assertEqual( leafScene.readAttribute( IECoreScene.LinkedScene.linkAttribute, 0 ), IECore.CompoundData( { "fileName":IECore.StringData('test/IECore/data/sccFiles/animatedSpheres.scc'), "root":IECore.InternedStringVectorData([ 'A', 'a' ]), 'time':IECore.DoubleData( 0 ) } ) )
+		self.assertEqual( leafScene.readAttribute( IECoreScene.LinkedScene.linkAttribute, 0 ), IECore.CompoundData( { "fileName":IECore.StringData('test/IECore/data/sccFiles/animatedSpheres.scc'), "root":IECore.InternedStringVectorData([ 'A', 'a' ]) } ) )
 		self.assertFalse( leafScene.hasObject() )
 
 		# expand scene to meshes

--- a/test/IECoreMaya/SceneShapeProxyTest.py
+++ b/test/IECoreMaya/SceneShapeProxyTest.py
@@ -42,7 +42,8 @@ class SceneShapeProxyTest( SceneShapeTest.SceneShapeTest ):
 
 	def setUp( self ):
 		IECoreMaya.TestCase.setUp(self)
-		self._node = maya.cmds.createNode( "ieSceneShapeProxy" )
+		self._shapeType = "ieSceneShapeProxy"
+		self._node = maya.cmds.createNode( self._shapeType )
 
 if __name__ == "__main__":
 	IECoreMaya.TestProgram( plugins = [ "ieCore" ] )


### PR DESCRIPTION
When reading a link at a location the determination if time is added to the `linkAttributeData` was solely based on the connection of the time plug. In case the time plug of the scene shape is not connected to maya's global time output, we assumed a time remapping to happen.

This leads to adding the current time to the `linkAttributeData` if the location is an expanded child location, because we connect the out time of a scene shape to it's childs in time on expansion, which breaks this assumption.

We address this issue by traversing the time plug's connection chain and check if the plug is connected to any scene shape or maya's global time

## Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
