### PR TITLE
ie options: Remove setting `OCIO` path for test environment

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -432,9 +432,6 @@ if targetApp=="rv" :
 # find doxygen
 DOXYGEN = os.path.join( "/software/apps/doxygen", os.environ["DOXYGEN_VERSION"], platform, "bin", "doxygen" )
 
-# we need this so IECoreImage tests use a standard color conversion config
-os.environ["OCIO"] = "/software/config/openColorIO/nuke-default/config.ocio"
-
 # import vars we need to get our doxygen and python wrappers working
 envVarsToImport = [
 	"PATH",


### PR DESCRIPTION
The path is pointing to a deprecated config that doesn't reflect our current color pipeline or CI/testing environment anymore.

It created additional issues when running the `IECoreMaya` tests because autodesk's color management prints exception and error strings during the test run if the file path is invalid

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
