### PR TITLE
AlembicSceneTest::testCancel : Loosen timing tolerance

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -3253,6 +3253,7 @@ if doConfigure :
 		alembicTestEnv["ENV"][alembicTestEnv["TEST_LIBRARY_PATH_ENV_VAR"]] += os.pathsep + alembicTestLibPaths
 		alembicTestEnv["ENV"]["PYTHONPATH"] += os.pathsep + "./contrib/IECoreAlembic/python"
 		alembicTest = alembicTestEnv.Command( "contrib/IECoreAlembic/test/IECoreAlembic/results.txt", alembicPythonModule, "$PYTHON $TEST_ALEMBIC_SCRIPT --verbose" )
+		alembicTestEnv.Depends( alembicTest, [ corePythonModule ] )
 		NoCache( alembicTest )
 		alembicTestEnv.Alias( "testAlembic", alembicTest )
 

--- a/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
+++ b/contrib/IECoreAlembic/test/IECoreAlembic/AlembicSceneTest.py
@@ -1934,7 +1934,7 @@ class AlembicSceneTest( unittest.TestCase ) :
 		canceller.cancel()
 		thread.join()
 
-		self.assertLess( time.time() - startTime, 0.06 )
+		self.assertLess( time.time() - startTime, 0.1 if IECore.isDebug() else 0.06 )
 		self.assertTrue( cancelled[0] )
 
 	def testIndexedCurveUVs( self ) :


### PR DESCRIPTION
Ivan was complaining about this test triggering spurious CI failures ( always on the debug build ).

By loosening the timing, I'm making the actual test a bunch less meaningful, but it should get rid of the spurious failures.

A better solution might be just disable cancel tests on debug? Or maybe I should be trying to repro exactly where the debug build is failing, and maybe I could add an extra canceller test somewhere to fix it?

In general, our cancellation tests aren't great - if we really wanted to exercise the code, we should be cancelling at a range of times, and checking that the time to cancel is always low.

But for now, maybe this is good enough to just prevent the CI failures.