### PR TITLE
ie/options : ensure a valid environment for running post scripts

### DIFF
--- a/config/ie/options
+++ b/config/ie/options
@@ -313,7 +313,11 @@ if targetApp=="maya" :
 	INSTALL_MEL_DIR = os.path.join( appPrefix, "mel", "$IECORE_NAME" )
 	INSTALL_MAYAPLUGIN_NAME = os.path.join( appPrefix, "plugins", "$IECORE_NAME" )
 	INSTALL_MAYAICON_DIR = os.path.join( appPrefix, "icons" )
-	INSTALL_COREMAYA_POST_COMMAND="scons -i -f config/ie/postCoreMayaInstall MAYA_VERSION='" + mayaVersion + "' INSTALLPREFIX="+appPrefix+" install"
+	INSTALL_COREMAYA_POST_COMMAND="ieEnvExec {workingPath} scons -i -f config/ie/postCoreMayaInstall MAYA_VERSION='{mayaVersion}' INSTALLPREFIX={appPrefix} install".format(
+		workingPath = os.environ["IEENV_WORKING_PATH"],
+		mayaVersion = mayaVersion,
+		appPrefix = appPrefix
+	)
 	WITH_MAYA_PLUGIN_LOADER = 1
 
 	mayaUsdVersion = mayaReg.get( "mayaUsdVersion" )
@@ -497,8 +501,12 @@ else :
 	INSTALL_USDLIB_NAME = os.path.join( basePrefix, "lib", compiler, compilerVersion, "$IECORE_NAME-$IECORE_COMPATIBILITY_VERSION" )
 
 	# only installing for the base installation as the CORTEX_STARTUP_PATHS will load these within target apps as well
-	INSTALL_CORESCENE_POST_COMMAND = "scons -i -f config/ie/postCoreSceneInstall INSTALLPREFIX={prefix} install".format( prefix = basePrefix )
-	INSTALL_COREIMAGE_POST_COMMAND = "scons -i -f config/ie/postCoreImageInstall INSTALLPREFIX={prefix} install".format( prefix = basePrefix )
+	INSTALL_CORESCENE_POST_COMMAND = "ieEnvExec {workingPath} scons -i -f config/ie/postCoreSceneInstall INSTALLPREFIX={prefix} install".format(
+		workingPath = os.environ["IEENV_WORKING_PATH"], prefix = basePrefix
+	)
+	INSTALL_COREIMAGE_POST_COMMAND = "ieEnvExec {workingPath} scons -i -f config/ie/postCoreImageInstall INSTALLPREFIX={prefix} install".format(
+		workingPath = os.environ["IEENV_WORKING_PATH"], prefix = basePrefix
+	)
 
 INSTALL_GLSL_HEADER_DIR =  os.path.join( basePrefix, "glsl" )
 INSTALL_GLSL_SHADER_DIR =  os.path.join( basePrefix, "glsl" )


### PR DESCRIPTION
Backport of #1355 for RB-10.4 (which was the initially intended target, but I messed up the PR).

This change is needed in order to allow cortex to be built at IE using python 3.

Since it's an IE-specific change, there is no need to alter the Changes file.
### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
