### PR TITLE
Caribou follow up

### DIFF
--- a/src/IECoreNuke/FromNukePointsConverter.cpp
+++ b/src/IECoreNuke/FromNukePointsConverter.cpp
@@ -71,9 +71,9 @@ IECore::ObjectPtr FromNukePointsConverter::doConversion( IECore::ConstCompoundOb
 	const DD::Image::Attribute *colorAttr = m_geo->get_typed_attribute( "Cf", DD::Image::VECTOR4_ATTRIB );
 	if( colorAttr && colorAttr->size() == result->getNumPoints() )
 	{
-		Color4fVectorDataPtr colorData = new Color4fVectorData();
+		Color3fVectorDataPtr colorData = new Color3fVectorData();
 		colorData->writable().resize( result->getNumPoints() );
-		std::transform( colorAttr->vector4_list->begin(), colorAttr->vector4_list->end(), colorData->writable().begin(), IECore::convert<Imath::Color4f, DD::Image::Vector4> );
+		std::transform( colorAttr->vector4_list->begin(), colorAttr->vector4_list->end(), colorData->writable().begin(), IECore::convert<Imath::Color3f, DD::Image::Vector4> );
 		result->variables["Cs"] = PrimitiveVariable( PrimitiveVariable::Vertex, colorData );
 
 		// Adding a separate alpha primvar as according to my test

--- a/src/IECoreNuke/SceneCacheReader.cpp
+++ b/src/IECoreNuke/SceneCacheReader.cpp
@@ -818,7 +818,12 @@ void SceneCacheReader::filterScene( const std::string &filterText, const std::st
 	m_data->m_itemToFiltered.clear();
 
 	// Set the filtered items.
-	sceneView->setImportedItems( filteredIndices );
+	std::vector<unsigned int> currentIndices;
+	sceneView->getImportedItems( currentIndices );
+	if( currentIndices != filteredIndices )
+	{
+		sceneView->setImportedItems( filteredIndices );
+	}
 
 	// Create a mapping of item indices to filtered indices.
 	for( std::vector<unsigned int>::const_iterator it( filteredIndices.begin() ); it != filteredIndices.end(); ++it )


### PR DESCRIPTION
Fixes
---

- IECoreNuke::FromNukePointsConverter: Use `Color3f` instead of `Color4f` to be compatible with `Gaffer`(#1377)
- Fix crash with `SceneCacheReader` when widget updates while Caribou updates (#1377).

### Related Issues ###

- List any Issues this PR addresses or solves

### Dependencies ###

- List any other unmerged PRs that this PR depends on

### Breaking Changes ###

- List any breaking API/ABI changes

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
