### PR TITLE
LinkedScene : Fix incorrect `linkLocations` attribute value

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 10.4.x.x (relative to 10.4.10.1)
 ========
 
+Fixes
+-----
+
+- LinkedScene : Fixed bug where `linkLocations` attribute was baked incorrectly if the link target location wasn't the ROOT
+  - This in turn caused LinkedScene::setNames() and LinkedScene::readSet() to error
+
 10.4.10.1 (relative to 10.4.10.0)
 ========
 

--- a/src/IECoreScene/LinkedScene.cpp
+++ b/src/IECoreScene/LinkedScene.cpp
@@ -700,6 +700,7 @@ void LinkedScene::writeAttribute( const Name &name, const Object *attribute, dou
 		{
 			throw Exception( "Trying to store a broken link!" );
 		}
+		m_rootLinkDepth = linkDepth;
 
 		// check for child name clashes:
 		NameList mainSceneChildren;


### PR DESCRIPTION
The old code was incorrectly appending the target's location to the `linkLocations`.

The `linkLocations` are expected to hold the locations in the current LinkedScene that contain links to other files. These paths are expected to exist in the LinkedScene itself.

Everything worked fine if the target location was set to the ROOT, but if it was targeting an internal location, that would be appended which would result in an invalid path.

The cause for that bug was that we were updating `m_linkedScene`, which is used to compute LinkedScene::path(), but not updating the `m_rootLinkDepth` property, which is also used to compute the path, by stripping out part of it based on the depth of the link.

For `linkLocations`, that depth should generally be expected to completely remove any contributions from `m_linkedScene`, since this is the location where the link is being created, and therefore the `m_rootLinkDepth` will match the length of the path inside the target linked scene that we are linking to.

Note that existing saved `lscc` files have the attribute baked in, and are therefore not fixed by this commit. A new export is necessary in order to fix it.

### Related Issues ###

Error messages complaining about non-existent children of a location when trying to call either `LinkedScene::setNames()` or `LinkedScenes::readSet()`, if the links were targeting something other than the root of the target scene.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
