### PR TITLE
IECoreUSD : Import some core USD modules before _IECoreUSD

### DIFF
--- a/contrib/IECoreUSD/python/IECoreUSD/__init__.py
+++ b/contrib/IECoreUSD/python/IECoreUSD/__init__.py
@@ -32,6 +32,14 @@
 #
 ##########################################################################
 
+# In the ImageEngine env, if _IECoreUSD is imported before these pxr modules,
+# we get a weird exception when we later load the pxr modules. We're not
+# 100% sure why this is happening, but importing them first isn't
+# unreasonable.
+__import__( "pxr.Kind" )
+__import__( "pxr.Vt" )
+__import__( "pxr.Sdf" )
+
 from ._IECoreUSD import *
 
 __import__( "IECore" ).loadConfig( "CORTEX_STARTUP_PATHS", subdirectory = "IECoreUSD" )


### PR DESCRIPTION
I have no idea if this is the right solution, but I figured I'd PR it for discussion.

In the IE Gaffer 1.3 env, when launching Gaffer, I get this printed to console:

```
ERROR : IECore.loadConfig : Error executing file "/home/danield/apps/gaffer/1.3.0.0dev/cent7.x86_64/cortex/10.5/gaffer/py3/startup/gui/menus.py" - "initialization of _tf raised unreported exception".
 Traceback (most recent call last):
  File "/home/danield/apps/cortex/10.5.0.0dev/cent7.x86_64/base/python/3.7/gcc/9.3.1/IECore/ConfigLoader.py", line 78, in loadConfig
    fileContextDict, fileContextDict
  File "/home/danield/apps/gaffer/1.3.0.0dev/cent7.x86_64/cortex/10.5/gaffer/py3/startup/gui/menus.py", line 515, in <module>
    import GafferUSDUI
  File "/software/apps/PySide/5.15.2/qt5.15.2/python3.7/cent7.x86_64/gcc/9.3.1/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/home/danield/apps/gaffer/1.3.0.0dev/cent7.x86_64/cortex/10.5/gaffer/py3/python/GafferUSDUI/__init__.py", line 37, in <module>
    from . import USDAttributesUI
  File "/software/apps/PySide/5.15.2/qt5.15.2/python3.7/cent7.x86_64/gcc/9.3.1/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/home/danield/apps/gaffer/1.3.0.0dev/cent7.x86_64/cortex/10.5/gaffer/py3/python/GafferUSDUI/USDAttributesUI.py", line 42, in <module>
    import pxr.Kind
  File "/software/apps/PySide/5.15.2/qt5.15.2/python3.7/cent7.x86_64/gcc/9.3.1/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/software/apps/usd/22.03-gaffer-1.3/cent7.x86_64/gcc/9.3.1/python/3.7/cortex/10.5/lib/python/pxr/Kind/__init__.py", line 26, in <module>
    from pxr import Tf
  File "/software/apps/PySide/5.15.2/qt5.15.2/python3.7/cent7.x86_64/gcc/9.3.1/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/software/apps/usd/22.03-gaffer-1.3/cent7.x86_64/gcc/9.3.1/python/3.7/cortex/10.5/lib/python/pxr/Tf/__init__.py", line 163, in <module>
    PreparePythonModule()
  File "/software/apps/usd/22.03-gaffer-1.3/cent7.x86_64/gcc/9.3.1/python/3.7/cortex/10.5/lib/python/pxr/Tf/__init__.py", line 89, in PreparePythonModule
    "." + moduleName, f_locals["__name__"])
  File "/software/apps/python/3.7/cent7.x86_64/gcc/9.3.1/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
SystemError: initialization of _tf raised unreported exception
```

It appears that importing _IECoreUSD before initializing some of the USD stuff is causing things to get initialized in the wrong order or something, and it then causes problems when the pxr module goes to actually initialize things.

This does not seem to be happening in public Gaffer. IE is on USD 22.03, so maybe newer USD has fixed this, intentionally or unintentionally?

It doesn't seem unreasonable to import a couple of USD modules first ... maybe this is a reasonable solution even if it's not totally clear why it's needed?

