### PR TITLE
ToMayaMeshConverter : No longer set normals

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,13 @@
 10.5.x.x (relative to 10.5.1.0)
 ========
 
+Breaking Changes
+----------------
+- IECoreMaya : Maya meshes converted from Cortex data no longer have normals set explicitly and instead relies on Maya to calculate them.
+
+Fixes
+---
+- ToMayaMeshConverter : No longer locks normals set on the Mesh from the scc.
 
 10.5.1.0 (relative to 10.5.0.0)
 ========

--- a/src/IECoreMaya/ToMayaMeshConverter.cpp
+++ b/src/IECoreMaya/ToMayaMeshConverter.cpp
@@ -183,6 +183,10 @@ void ToMayaMeshConverter::addUVSet( MFnMesh &fnMesh, const MIntArray &polygonCou
 
 bool ToMayaMeshConverter::doConversion( IECore::ConstObjectPtr from, MObject &to, IECore::ConstCompoundObjectPtr operands ) const
 {
+	// Note: Normals are not set on the Mesh from the scc as by setting them 
+	// explicitly we are implying they should be locked which is not 
+	// supported, instead we rely on Maya computing the normals everytime
+	
 	MStatus s;
 
 	IECoreScene::ConstMeshPrimitivePtr mesh = IECore::runTimeCast<const IECoreScene::MeshPrimitive>( from );
@@ -261,79 +265,6 @@ bool ToMayaMeshConverter::doConversion( IECore::ConstObjectPtr from, MObject &to
 	if (!s)
 	{
 		return false;
-	}
-
-	it = mesh->variables.find("N");
-	if ( it != mesh->variables.end() )
-	{
-		if (it->second.interpolation == IECoreScene::PrimitiveVariable::FaceVarying )
-		{
-			/// \todo Employ some M*Array converters to simplify this
-			MVectorArray vertexNormalsArray;
-			IECore::ConstV3fVectorDataPtr n = IECore::runTimeCast<const IECore::V3fVectorData>(it->second.data);
-			if (n)
-			{
-				IECoreScene::PrimitiveVariable::IndexedView<Imath::V3f> normalView = IECoreScene::PrimitiveVariable::IndexedView<Imath::V3f>( it->second );
-				vertexNormalsArray.setLength( normalView.size() );
-
-				size_t i = 0;
-				for(const auto& normal : normalView)
-				{
-					vertexNormalsArray[i++] = IECore::convert<MVector, Imath::V3f>( normal );
-				}
-			}
-			else
-			{
-				IECore::ConstV3dVectorDataPtr n = IECore::runTimeCast<const IECore::V3dVectorData>(it->second.data);
-				if (n)
-				{
-					IECoreScene::PrimitiveVariable::IndexedView<Imath::V3d> normalView = IECoreScene::PrimitiveVariable::IndexedView<Imath::V3d>( it->second );
-					vertexNormalsArray.setLength( normalView.size() );
-
-					size_t i = 0;
-					for(const auto& normal : normalView)
-					{
-						vertexNormalsArray[i++] = IECore::convert<MVector, Imath::V3d>( normal );
-					}
-				}
-				else
-				{
-					IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::doConversion", boost::format( "PrimitiveVariable \"N\" has unsupported type \"%s\"." ) % it->second.data->typeName() );
-				}
-			}
-
-			if ( vertexNormalsArray.length() )
-			{
-				MStatus status;
-				MItMeshPolygon itPolygon( mObj, &status );
-				if( status != MS::kSuccess )
-				{
-					IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::doConversion", "Failed to create mesh iterator" );
-				}
-
-				unsigned v = 0;
-				MIntArray vertexIds;
-				MIntArray faceIds;
-
-				for ( ; !itPolygon.isDone(); itPolygon.next() )
-				{
-					for ( v=0; v < itPolygon.polygonVertexCount(); ++v )
-					{
-						faceIds.append( itPolygon.index() );
-						vertexIds.append( itPolygon.vertexIndex( v ) );
-					}
-				}
-
-				if( !fnMesh.setFaceVertexNormals( vertexNormalsArray, faceIds, vertexIds ) )
-				{
-					IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::doConversion", "Setting normals failed" );
-				}
-			}
-		}
-		else
-		{
-			IECore::msg( IECore::Msg::Warning, "ToMayaMeshConverter::doConversion", "PrimitiveVariable \"N\" has unsupported interpolation (expected FaceVarying)." );
-		}
 	}
 
 	/// Add UV sets

--- a/test/IECoreMaya/ParameterisedHolder.py
+++ b/test/IECoreMaya/ParameterisedHolder.py
@@ -286,7 +286,6 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		op = fnOP.getOp()
 
 		mesh = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 2, 3, 4 ) ) )
-		mesh[ "N" ] = IECoreScene.PrimitiveVariable( mesh[ "N" ].interpolation, mesh[ "N" ].expandedData() )
 		op.parameters()[ "input" ].setValue( mesh )
 		fnOP.setNodeValues()
 
@@ -301,7 +300,13 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		op = fnOP.getOp()
 
 		mesh2 = op.parameters()["input"].getValue()
+
 		self.assertTrue( mesh2.arePrimitiveVariablesValid() )
+		# The ToMayaMeshConverter relies on Maya to calculate the normals
+		# whereas createBox uses indexed normals so we cannot include them
+		# in the comparison otherwise they will never be the same
+		del mesh[ "N" ]
+		del mesh2[ "N" ]
 		self.assertEqual( mesh2, mesh )
 
 	def testOpHolder( self ) :

--- a/test/IECoreMaya/ToMayaMeshConverterTest.py
+++ b/test/IECoreMaya/ToMayaMeshConverterTest.py
@@ -308,6 +308,9 @@ class ToMayaMeshConverterTest( IECoreMaya.TestCase ) :
 				self.assertAlmostEqual( origNormal[j], normal3f[j], 6 )
 				self.assertAlmostEqual( origNormal[j], normal3d[j], 6 )
 
+		# normals should always be unlocked when reading from scc
+		self.assertFalse( any( maya.cmds.polyNormalPerVertex( newSphere+".vtx[*]", query=True, allLocked=True ) ) )
+
 	def testSetMeshInterpolation( self ) :
 
 		sphere = maya.cmds.polySphere( subdivisionsX=10, subdivisionsY=5, constructionHistory=False )


### PR DESCRIPTION
Currently, when converting from a Cortex object to a Maya Mesh we set the normals anytime the normals were stored on the scc but by doing so we imply these are static values and so Maya locks them. Locked normals are undesirable in many parts of the Pipeline especially when deforming meshes as forcing the normal to stay the same causes unexpected results. Unlocked normals make more sense in most cases as they are computed values. This change willl stop setting normals so they are unlocked and instead rely on Maya to compute them.

Breaking Changes
----------------
- IECoreMaya : Maya meshes converted from Cortex data no longer have normals set explicitly and instead relies on Maya to calculate them.

Fixes
---
- ToMayaMeshConverter : No longer locks normals set on the Mesh from the scc (#1386)

### Related Issues ###

- Solves issues when reading an SCC written out from a Mesh that stored normals, the normals were than locked on read since the values were baked and treated as non-computed by Maya which is undesirable for deformation rigs.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.