### PR TITLE
USD PrimitiveAlgo : Improve primitive variable validity checks

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,13 +1,15 @@
 10.5.x.x (relative to 10.5.1.0)
 ========
 
+Fixes
+-----
+
+- ToMayaMeshConverter : No longer locks normals set on the Mesh from the scc.
+
 Breaking Changes
 ----------------
-- IECoreMaya : Maya meshes converted from Cortex data no longer have normals set explicitly and instead relies on Maya to calculate them.
 
-Fixes
----
-- ToMayaMeshConverter : No longer locks normals set on the Mesh from the scc.
+- IECoreMaya : Maya meshes converted from Cortex data no longer have normals set explicitly and instead relies on Maya to calculate them.
 
 10.5.1.0 (relative to 10.5.0.0)
 ========

--- a/Changes
+++ b/Changes
@@ -1,9 +1,20 @@
 10.5.x.x (relative to 10.5.1.0)
 ========
 
+Improvements
+------------
+
+- USD PrimitiveAlgo : Added `readPrimitiveVariable()` utility method for reading from regular `UsdAttributes`.
+
 Fixes
 -----
 
+- USDScene : Fixed handling of invalid values on the following attributes :
+  - PointBased : `positions`, `normals`, `velocities`, `accelerations`.
+  - Curves : `widths`.
+  - PointInstancer : `ids`, `protoIndices`, `orientations`, `scales`, `velocities`, `accelerations`, `angularVelocities`.
+  - Points : `ids`, `widths`.
+  Invalid values are now ignored with a warning, instead of loading as invalid primitive variables.
 - ToMayaMeshConverter : No longer locks normals set on the Mesh from the scc.
 
 Breaking Changes

--- a/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/PrimitiveAlgo.h
@@ -75,6 +75,8 @@ IECOREUSD_API pxr::TfToken toUSD( IECoreScene::PrimitiveVariable::Interpolation 
 IECOREUSD_API void readPrimitiveVariables( const pxr::UsdGeomPrimvarsAPI &primvarsAPI, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive, const IECore::Canceller *canceller = nullptr );
 /// As above, but also reads "P", "N" etc from `pointBased`.
 IECOREUSD_API void readPrimitiveVariables( const pxr::UsdGeomPointBased &pointBased, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive, const IECore::Canceller *canceller = nullptr );
+/// Reads the value for `attribute`, adding it as a primitive variable with the specified `name` and `interpolation`.
+IECOREUSD_API void readPrimitiveVariable( const pxr::UsdAttribute &attribute, pxr::UsdTimeCode timeCode, IECoreScene::Primitive *primitive, const std::string &name, IECoreScene::PrimitiveVariable::Interpolation interpolation = IECoreScene::PrimitiveVariable::Vertex );
 /// Returns true if any of the primitive variables might be animated.
 IECOREUSD_API bool primitiveVariablesMightBeTimeVarying( const pxr::UsdGeomPrimvarsAPI &primvarsAPI );
 /// Returns true if any of the primitive variables might be animated, including the

--- a/contrib/IECoreUSD/src/IECoreUSD/CurvesAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/CurvesAlgo.cpp
@@ -109,12 +109,9 @@ IECore::ObjectPtr readCurves( pxr::UsdGeomBasisCurves &curves, pxr::UsdTimeCode 
 	PrimitiveAlgo::readPrimitiveVariables( curves, time, newCurves.get(), canceller );
 
 	Canceller::check( canceller );
-	PrimitiveVariable::Interpolation widthInterpolation = PrimitiveAlgo::fromUSD( curves.GetWidthsInterpolation() );
-	DataPtr widthData = DataAlgo::fromUSD( curves.GetWidthsAttr(), time, /* arrayAccepted = */ widthInterpolation != PrimitiveVariable::Constant );
-	if( widthData )
-	{
-		newCurves->variables["width"] = PrimitiveVariable( widthInterpolation, widthData );
-	}
+	PrimitiveAlgo::readPrimitiveVariable(
+		curves.GetWidthsAttr(), time, newCurves.get(), "width", PrimitiveAlgo::fromUSD( curves.GetWidthsInterpolation() )
+	);
 
 	return newCurves;
 }

--- a/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
@@ -65,47 +65,26 @@ IECore::ObjectPtr readPointInstancer( pxr::UsdGeomPointInstancer &pointInstancer
 
 	// Per point attributes
 
-	if( auto protoIndicesData = DataAlgo::fromUSD( pointInstancer.GetProtoIndicesAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["prototypeIndex"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, protoIndicesData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetProtoIndicesAttr(), time, newPoints.get(), "prototypeIndex" );
 
-	if( auto idsData = DataAlgo::fromUSD( pointInstancer.GetIdsAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["instanceId"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, idsData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetIdsAttr(), time, newPoints.get(), "instanceId" );
 
-	if( auto orientationData = DataAlgo::fromUSD( pointInstancer.GetOrientationsAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["orientation"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, orientationData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetOrientationsAttr(), time, newPoints.get(), "orientation" );
 
-	if( auto scaleData = DataAlgo::fromUSD( pointInstancer.GetScalesAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["scale"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, scaleData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetScalesAttr(), time, newPoints.get(), "scale" );
 
-	if( auto velocityData = DataAlgo::fromUSD( pointInstancer.GetVelocitiesAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["velocity"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, velocityData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetVelocitiesAttr(), time, newPoints.get(), "velocity" );
 
-	if( auto accelerationData = DataAlgo::fromUSD( pointInstancer.GetAccelerationsAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["acceleration"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, accelerationData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetAccelerationsAttr(), time, newPoints.get(), "acceleration" );
 
-	if( auto angularVelocityData = DataAlgo::fromUSD( pointInstancer.GetAngularVelocitiesAttr(), time ) )
-	{
-		Canceller::check( canceller );
-		newPoints->variables["angularVelocity"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, angularVelocityData );
-	}
+	Canceller::check( canceller );
+	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetAngularVelocitiesAttr(), time, newPoints.get(), "angularVelocity" );
 
 	// Prototype paths
 

--- a/contrib/IECoreUSD/src/IECoreUSD/PointsAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointsAlgo.cpp
@@ -61,18 +61,12 @@ IECore::ObjectPtr readPoints( pxr::UsdGeomPoints &points, pxr::UsdTimeCode time,
 	PrimitiveAlgo::readPrimitiveVariables( points, time, newPoints.get(), canceller );
 
 	Canceller::check( canceller );
-	if( auto i = boost::static_pointer_cast<Int64VectorData>( DataAlgo::fromUSD( points.GetIdsAttr(), time ) ) )
-	{
-		newPoints->variables["id"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Vertex, i );
-	}
+	PrimitiveAlgo::readPrimitiveVariable( points.GetIdsAttr(), time, newPoints.get(), "id" );
 
-	PrimitiveVariable::Interpolation widthInterpolation = PrimitiveAlgo::fromUSD( points.GetWidthsInterpolation() );
 	Canceller::check( canceller );
-	DataPtr widthData = DataAlgo::fromUSD( points.GetWidthsAttr(), time, /* arrayAccepted = */ widthInterpolation != PrimitiveVariable::Constant );
-	if( widthData )
-	{
-		newPoints->variables["width"] = PrimitiveVariable( widthInterpolation, widthData );
-	}
+	PrimitiveAlgo::readPrimitiveVariable(
+		points.GetWidthsAttr(), time, newPoints.get(), "width", PrimitiveAlgo::fromUSD( points.GetWidthsInterpolation() )
+	);
 
 	return newPoints;
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -736,10 +736,11 @@ class USDSceneTest( unittest.TestCase ) :
 		for i in range( 16 ) :
 			for j in range( 16 ) :
 				vertsPerCurveData.append( 4 );
-				for k in range( 3 ) :
+				for k in range( 4 ) :
 					positionData.append( imath.V3f( [i, j, k] ) )
 
 		curvesPrimitive = IECoreScene.CurvesPrimitive( IECore.IntVectorData( vertsPerCurveData ), IECore.CubicBasisf.linear(), False, IECore.V3fVectorData( positionData ) )
+		self.assertTrue( curvesPrimitive.arePrimitiveVariablesValid() )
 
 		root.writeObject( curvesPrimitive, 0.0 )
 
@@ -3544,7 +3545,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 		self.assertEqual( len( mh.messages ), 1 )
 		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Warning )
-		self.assertEqual( mh.messages[0].message, "Skipping invalid UsdGeomPrimvar \"/pCube1.primvars:st\"" )
+		self.assertEqual( mh.messages[0].message, "Ignoring invalid primitive variable \"/pCube1.primvars:st\"" )
 
 		self.assertNotIn( "uv", badCube )
 		self.assertTrue( badCube.arePrimitiveVariablesValid() )
@@ -3552,6 +3553,82 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertNotEqual( goodCube, badCube )
 		del goodCube["uv"]
 		self.assertEqual( goodCube, badCube )
+
+	def testInvalidPointBasedAttributes( self ) :
+
+		fileName = os.path.join( self.temporaryDirectory(), "pointBased.usda" )
+		stage = pxr.Usd.Stage.CreateNew( fileName )
+
+		curves = pxr.UsdGeom.BasisCurves.Define( stage, "/curves" )
+		curves.CreateCurveVertexCountsAttr().Set( [ 4 ] )
+		curves.CreatePointsAttr().Set( [ ( 1, 1, 1 ), ( 2, 2, 2 ) ] )
+		curves.CreateVelocitiesAttr().Set( [ ( 1, 1, 1 ) ] )
+		curves.CreateAccelerationsAttr().Set( [ ( 0, 0, 0 ) ] )
+		curves.CreateNormalsAttr().Set( [ ( 1, 0, 0 ) ] )
+
+		stage.GetRootLayer().Save()
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		with IECore.CapturingMessageHandler() as mh :
+			curves = root.child( "curves" ).readObject( 0 )
+
+		# No valid primitive variables.
+		self.assertEqual( curves.keys(), [] )
+		# And a warning message for every one we tried to load.
+		messages = { m.message for m in mh.messages }
+		for attribute in [
+			"/curves.points",
+			"/curves.velocities",
+			"/curves.accelerations",
+			"/curves.normals",
+		] :
+			self.assertIn(
+				f"Ignoring invalid primitive variable \"{attribute}\"",
+				messages
+			)
+
+	def testInvalidCurvesAttributes( self ) :
+
+		fileName = os.path.join( self.temporaryDirectory(), "curves.usda" )
+		stage = pxr.Usd.Stage.CreateNew( fileName )
+
+		curves = pxr.UsdGeom.BasisCurves.Define( stage, "/curves" )
+		curves.CreateCurveVertexCountsAttr().Set( [ 4 ] )
+		curves.CreateWidthsAttr().Set( [ 1, 2 ] )
+
+		stage.GetRootLayer().Save()
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		with IECore.CapturingMessageHandler() as mh :
+			curves = root.child( "curves" ).readObject( 0 )
+
+		self.assertEqual( len( mh.messages ), 1 )
+		self.assertEqual(
+			mh.messages[0].message, f"Ignoring invalid primitive variable \"/curves.widths\"",
+		)
+		self.assertNotIn( "width", curves )
+
+	def testInvalidPointsAttributes( self ) :
+
+		fileName = os.path.join( self.temporaryDirectory(), "points.usda" )
+		stage = pxr.Usd.Stage.CreateNew( fileName )
+
+		points = pxr.UsdGeom.Points.Define( stage, "/points" )
+		points.CreatePointsAttr().Set( [ ( 1, 1, 1 ), ( 2, 2, 2 ), ( 3, 3, 3 ) ] )
+		points.CreateWidthsAttr().Set( [ 1, 2 ] )
+		points.CreateIdsAttr().Set( [ 1, 2 ] )
+
+		stage.GetRootLayer().Save()
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		with IECore.CapturingMessageHandler() as mh :
+			points = root.child( "points" ).readObject( 0 )
+
+		self.assertEqual( len( mh.messages ), 2 )
+		self.assertEqual( mh.messages[0].message, f"Ignoring invalid primitive variable \"/points.ids\"" )
+		self.assertEqual( mh.messages[1].message, f"Ignoring invalid primitive variable \"/points.widths\"" )
+		self.assertNotIn( "id", points )
+		self.assertNotIn( "width", points )
 
 	def testNormalsPrimVar( self ) :
 

--- a/contrib/IECoreUSD/test/IECoreUSD/data/curves.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/curves.usda
@@ -3,6 +3,7 @@
 def BasisCurves "borderLines"
 {
     float3[] extent = [(-5, -5, -0), (5, 5, 0)]
+    int[] curveVertexCounts = [ 4 ]
     point3f[] points.timeSamples = {
         1.0000000298023224: [(-5, -5, 0), (5, -5, 0), (5, 5, 0), (-5, 5, 0)],
     }


### PR DESCRIPTION
We were already doing checks when loading from `UsdGeomPrimvar`, but not from the special attributes like `UsdGeomCurves.GetWidthsAttr()` or `UsdGeomPointBased.GetVelocitiesAttr()`.
