### PR TITLE
OpenImageIOAlgo : `InternedStringVectorData`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.5.x.x (relative to 10.5.2.1)
 ========
 
+Improvements
+------------
+
+- OpenImageIOAlgo : Added support for `InternedStringVectorData` to `DataView`.
+
 10.5.2.1 (relative to 10.5.2.0)
 ========
 

--- a/src/IECoreImage/OpenImageIOAlgo.cpp
+++ b/src/IECoreImage/OpenImageIOAlgo.cpp
@@ -49,6 +49,42 @@
 using namespace OIIO;
 using namespace IECore;
 
+namespace
+{
+
+template<typename T>
+OIIO::TypeDesc extractStringCharPointers( const std::vector<T> &strings, std::vector<const char *> &charPointers, bool createUStrings )
+{
+	size_t numStrings = strings.size();
+	OIIO::TypeDesc type = TypeDesc(
+		TypeDesc::STRING,
+		TypeDesc::SCALAR,
+		TypeDesc::NOSEMANTICS,
+		numStrings
+	);
+
+	charPointers.resize( numStrings );
+
+	if ( createUStrings )
+	{
+		for(size_t i = 0; i < numStrings; ++i)
+		{
+			charPointers[i] = ustring( strings[i].c_str() ).c_str();
+		}
+	}
+	else
+	{
+		for(size_t i = 0; i < numStrings; ++i)
+		{
+			charPointers[i] = strings[i].c_str();
+		}
+	}
+
+	return type;
+}
+
+}  // namespace
+
 namespace IECoreImage
 {
 
@@ -501,30 +537,15 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 		case StringVectorDataTypeId:
 		{
 			const auto &readableStrings = static_cast<const StringVectorData *>( d )->readable();
-			size_t numStrings = readableStrings.size();
-			type = TypeDesc(
-				TypeDesc::STRING,
-				TypeDesc::SCALAR,
-				TypeDesc::NOSEMANTICS,
-				numStrings
-			);
+			type = extractStringCharPointers( readableStrings, m_charPointers, createUStrings );
 
-			m_charPointers.resize( numStrings );
-
-			if ( createUStrings )
-			{
-				for(size_t i = 0; i < numStrings; ++i)
-				{
-					m_charPointers[i] = ustring( readableStrings[i].c_str() ).c_str();
-				}
-			}
-			else
-			{
-				for(size_t i = 0; i < numStrings; ++i)
-				{
-					m_charPointers[i] = readableStrings[i].c_str();
-				}
-			}
+			data = &m_charPointers[0];
+		}
+			break;
+		case InternedStringVectorDataTypeId:
+		{
+			const auto &readableStrings = static_cast<const InternedStringVectorData *>( d )->readable();
+			type = extractStringCharPointers( readableStrings, m_charPointers, createUStrings );
 
 			data = &m_charPointers[0];
 		}


### PR DESCRIPTION
This adds support for `InternedStringVectorData` to `OpenImageIOAlgo::DataView`. This is motivated by the need for querying `scene:path` from an OSL expression in Gaffer implemented in https://github.com/GafferHQ/gaffer/pull/5515.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
