### PR TITLE
Prioritize source tree includes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1226,6 +1226,20 @@ else:
 				"/Fd${TARGET}.pdb",
 			],
 		)
+	
+	# Reorder build commands so that `/external:I` includes come after `/I` includes.
+	# Otherwise we'll pick up the Gaffer includes from the build directory, and not
+	# the ones in the source tree.
+
+	for command, cxxFlags in [
+		( "CXXCOM", "$CXXFLAGS" ),
+		( "SHCXXCOM", "$SHCXXFLAGS" )
+	] :
+		if env[command].index( cxxFlags ) < env[command].index( "$_CCCOMCOM" ) :
+			# `$_CCCOMCOM` contains the preprocessor flags, including `/I`. Swap
+			# it with `cxxFlags`, which contains `/external:I`.
+			env[command] = env[command].replace( cxxFlags, "<>" ).replace( "$_CCCOMCOM", cxxFlags ).replace( "<>",  "$_CCCOMCOM" )
+
 
 
 # autoconf-like checks for stuff.


### PR DESCRIPTION
This copies the approach taken in https://github.com/GafferHQ/gaffer/pull/5375 to make sure includes on Windows are taken from the source tree before those in other directories. It has the benefit of picking the correct headers as well as resolving a frequent error on many-core systems when the file was being included and copied to the build directory at the same time.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
