### PR TITLE
MurmurHash : Add std::hash specialization, for use in std::unordered_map

### DIFF
--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -461,4 +461,13 @@ inline void murmurHashAppend( MurmurHash &h, const T *data, size_t numElements )
 
 } // namespace IECore
 
+template <>
+struct std::hash<IECore::MurmurHash>
+{
+	std::size_t operator()( const IECore::MurmurHash& h ) const
+	{
+		return h.h1() ^ h.h2();
+	}
+};
+
 #endif // IECORE_MURMURHASH_INL

--- a/test/IECore/IECoreTest.cpp
+++ b/test/IECore/IECoreTest.cpp
@@ -69,6 +69,7 @@ IECORE_POP_DEFAULT_VISIBILITY
 #include "CompoundDataTest.h"
 #include "CompoundObjectTest.h"
 #include "ComputationCacheTest.h"
+#include "MurmurHashTest.h"
 
 using namespace boost::unit_test;
 
@@ -102,6 +103,7 @@ bool init()
 		addCompoundDataTest(test);
 		addCompoundObjectTest(test);
 		addComputationCacheTest(test);
+		addMurmurHashTest(test);
 	}
 	catch (std::exception &ex)
 	{

--- a/test/IECore/MurmurHashTest.cpp
+++ b/test/IECore/MurmurHashTest.cpp
@@ -1,0 +1,91 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#include "MurmurHashTest.h"
+
+#include "IECore/MurmurHash.h"
+
+#include <unordered_set>
+
+using namespace boost;
+using namespace boost::unit_test;
+
+namespace IECore
+{
+
+struct MurmurHashTest
+{
+
+	void testUnorderedSet()
+	{
+		std::unordered_set< IECore::MurmurHash > set;
+		for( size_t i = 0; i < 1000000; i++ )
+		{
+			IECore::MurmurHash h;
+			h.append( i );
+			set.insert( h );
+		}
+
+		BOOST_CHECK( set.size() == 1000000 );
+
+		size_t maxBucketOccupancy = 0;
+		for( size_t i = 0; i < set.bucket_count(); i++ )
+		{
+			maxBucketOccupancy = std::max( maxBucketOccupancy, set.bucket_size( i ) );
+		}
+
+		// If our hash function is good, then there shouldn't be any bucket that gets way too
+		// many elements in it - currently, I'm seeing a max occupancy of 8.
+		BOOST_CHECK( maxBucketOccupancy < 16 );
+	}
+};
+
+
+struct MurmurHashTestSuite : public boost::unit_test::test_suite
+{
+
+	MurmurHashTestSuite() : boost::unit_test::test_suite( "MurmurHashTestSuite" )
+	{
+		boost::shared_ptr<MurmurHashTest> instance( new MurmurHashTest() );
+
+		add( BOOST_CLASS_TEST_CASE( &MurmurHashTest::testUnorderedSet, instance ) );
+	}
+};
+
+void addMurmurHashTest(boost::unit_test::test_suite* test)
+{
+	test->add( new MurmurHashTestSuite( ) );
+}
+
+} // namespace IECore

--- a/test/IECore/MurmurHashTest.h
+++ b/test/IECore/MurmurHashTest.h
@@ -1,0 +1,52 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2023, Image Engine Design Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+//     * Neither the name of Image Engine Design nor the names of any
+//       other contributors to this software may be used to endorse or
+//       promote products derived from this software without specific prior
+//       written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECORE_MURMURHASHTEST_H
+#define IECORE_MURMURHASHTEST_H
+
+#include "IECore/Export.h"
+
+IECORE_PUSH_DEFAULT_VISIBILITY
+#include "boost/test/unit_test.hpp"
+IECORE_POP_DEFAULT_VISIBILITY
+
+namespace IECore
+{
+
+void addMurmurHashTest( boost::unit_test::test_suite *test );
+
+}
+
+#endif // IECORE_MURMURHASHTEST_H
+


### PR DESCRIPTION
John requested I add this, when I needed to hack around it for a Gaffer PR. That Gaffer PR is now using an LRUCache instead of an std::unordered_map, so it wasn't needed there, but I might as well still add this.