### PR TITLE
DisplayDriverServer : Create IPv6 endpoint

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 10.5.x.x (relative to 10.5.6.0)
 ========
 
+
+Improvements
+------------
+
+- DisplayDriverServer : Fixed delays connecting to the server on Windows.
+
 10.5.6.0 (relative to 10.5.5.0)
 ========
 
@@ -9,7 +15,6 @@ Improvements
 
 - `IECoreGL::Selector`: Added constructor overload that accepts a boolean indicating a more precise, camera-space depth sample will be used to sample depth instead of OpenGL's depth buffer.
 - `IECoreGL::ColorTexture`: Added new constructor that accepts an argument specifying the internal storage format to use.
-
 
 
 10.5.5.0 (relative to 10.5.4.2)

--- a/src/IECoreImage/DisplayDriverServer.cpp
+++ b/src/IECoreImage/DisplayDriverServer.cpp
@@ -175,7 +175,7 @@ class DisplayDriverServer::PrivateData : public RefCounted
 
 		void openPort( DisplayDriverServer::Port portNumber )
 		{
-			m_endpoint = boost::asio::ip::tcp::endpoint( tcp::v4(), portNumber );
+			m_endpoint = boost::asio::ip::tcp::endpoint( tcp::v6(), portNumber );
 			m_acceptor.open(  m_endpoint.protocol() );
 #ifdef _MSC_VER
 			m_acceptor.set_option( boost::asio::ip::tcp::acceptor::reuse_address( false ) );
@@ -184,6 +184,7 @@ class DisplayDriverServer::PrivateData : public RefCounted
 #else
 			m_acceptor.set_option( boost::asio::ip::tcp::acceptor::reuse_address( true ) );
 #endif
+			m_acceptor.set_option( boost::asio::ip::v6_only( false ) );
 			m_acceptor.bind( m_endpoint );
 			m_acceptor.listen();
 		}


### PR DESCRIPTION
This avoids delays on Windows, where the ClientDisplayDriver was first trying a V6 connection and then only making a V4 connection if that failed (after a timeout). I don't know enough about this stuff yet to know if this is a good thing to do generally, or if it could cause problems somewhere. But I'm making a draft PR in the hope that @ericmehl can at least confirm that it improves things for him too. For me the difference is very noticeable when running `gaffer test GafferImageTest.CatalogueTest`.
