### PR TITLE
OpenImageIOAlgo : Properly handle empty metadata values

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.4.0)
 ========
 
+Fixes
+-----
 
+- OpenImageIOAlgo : Properly handle empty metadata values
 
 10.5.4.0 (relative to 10.5.3.0)
 ========

--- a/src/IECoreImage/OpenImageIOAlgo.cpp
+++ b/src/IECoreImage/OpenImageIOAlgo.cpp
@@ -584,7 +584,7 @@ IECore::DataPtr data( const OIIO::ParamValue &value )
 			{
 				if ( type.arraylen == 0 )
 				{
-					return new StringData( static_cast<const ustring *>( value.data() )->c_str() );
+					return new StringData( static_cast<const ustring *>( value.data() )->string() );
 				}
 				else
 				{


### PR DESCRIPTION
`ustring::c_str()` returns a `NULL` pointer for empty strings.

https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/src/include/OpenImageIO/ustring.h#L139-L143 https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/src/include/OpenImageIO/ustring.h#L290

This error was noticed when other OIIO changes started returning new metadata keys for which the values were empty strings, and thus causing segfaults when the `NULL` pointer wasn't handled properly (`RuntimeError: basic_string::_S_construct null not valid`).

The solution here is to use `string()` instead of `c_str()`, which returns an empty string in those cases, and is expected to be equally performant since the std strings are already stored in the internal `ustring` table:
https://github.com/AcademySoftwareFoundation/OpenImageIO/blob/master/src/include/OpenImageIO/ustring.h#L760

The image that was causing the errors is a large one and I couldn't easily create an alternative one to include as a `unittest`.
For reference though, the image being read was a `tiff` and the offending metadata key was `ICCProfile:platform_signature`.

Also, there are other references to `ustring::c_str()` in this file. Those however are likely expecting basic c-string pointers, so I didn't change them. @johnhaddon, if you think that any of those would also cause issues if they got a `NULL` pointer back, we probably want to address them too, likely by checking for the `NULL` value specifically and handling that differently.


### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
