### PR TITLE
OStreamMessageHandler : Prefix every line with message level

### DIFF
--- a/src/IECore/OStreamMessageHandler.cpp
+++ b/src/IECore/OStreamMessageHandler.cpp
@@ -67,7 +67,24 @@ OStreamMessageHandler::~OStreamMessageHandler()
 
 void OStreamMessageHandler::handle( Level level, const std::string &context, const std::string &message )
 {
-	*m_stream << levelAsString( level ) << " : " << context << " : " << message << endl;
+	const string levelString = levelAsString( level );
+	// Output the message a line at a time.
+	for( size_t lineBegin = 0; lineBegin < message.size(); )
+	{
+		// Find span to the next newline.
+		const size_t f = message.find( '\n', lineBegin );
+		const size_t lineEnd = f == string::npos ? message.size() : f;
+		// Prefix every line with the level
+		*m_stream << levelString << " : ";
+		// Only prefix the first line with the context
+		if( lineBegin == 0 )
+		{
+			*m_stream << context << " : ";
+		}
+		// Output line and set up for next one.
+		*m_stream << std::string_view( message.data() + lineBegin, lineEnd - lineBegin ) << endl;
+		lineBegin = lineEnd + 1;
+	}
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/test/IECore/MessageHandler.py
+++ b/test/IECore/MessageHandler.py
@@ -34,7 +34,11 @@
 
 from __future__ import with_statement
 import gc
+import inspect
 import unittest
+import pathlib
+import subprocess
+import sys
 import threading
 import time
 import weakref
@@ -265,6 +269,27 @@ class TestMessageHandler( unittest.TestCase ) :
 				# there were, that would indicate a reference counting error in
 				# `ExceptionAlgo::translatePythonException()`.
 				self.assertEqual( [ o for o in gc.get_objects() if isinstance( o, Exception ) ], [] )
+
+	def testOStreamLineSplitting( self ) :
+
+		output = subprocess.check_output(
+			[ sys.executable, str( pathlib.Path( __file__ ).parent / "scripts" / "messages.py" ) ],
+			text = True, stderr = subprocess.STDOUT
+		)
+
+		self.assertEqual(
+			output.split( "\n" ),
+			[
+				"ERROR : Context : Simple message",
+				"ERROR : Context : Two line",
+				"ERROR : message",
+				"ERROR : Context : Terminating newline",
+				"ERROR : Context : Blank",
+				"ERROR : ",
+				"ERROR : lines",
+				"",
+			]
+		)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/IECore/scripts/messages.py
+++ b/test/IECore/scripts/messages.py
@@ -1,0 +1,6 @@
+import IECore
+
+IECore.msg( IECore.Msg.Level.Error, "Context", "Simple message" )
+IECore.msg( IECore.Msg.Level.Error, "Context", "Two line\nmessage" )
+IECore.msg( IECore.Msg.Level.Error, "Context", "Terminating newline\n" )
+IECore.msg( IECore.Msg.Level.Error, "Context", "Blank\n\nlines" )


### PR DESCRIPTION
This allows log parsers to correctly identify the type of each line for syntax highlighting and the like. The immediate motivation is for a new LocalJobs panel in Gaffer, that captures the output from LocalDispatcher subprocesses and turns it back into messages for display into a GafferUI.MessagesWidget.
