### PR TITLE
USD CurvesAlgo : Add basic support for reading UsdGeomNurbsCurves

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.4.2)
 ========
 
+Improvements
+------------
 
+- USDScene : Added basic loading of UsdGeomNurbsCurves, converting them to CurvesPrimitives.
 
 10.5.4.2 (relative to 10.5.4.1)
 ========


### PR DESCRIPTION
We don't have a NURBS curve in Cortex, and one isn't supported by any of the renderers we connect to. So we just do a very basic conversion to CurvesPrimitive instead.