### PR TITLE
VDBObject bindings : Adapt for OpenVDB 10.1

### DIFF
--- a/Changes
+++ b/Changes
@@ -15,6 +15,7 @@ Fixes
 -----
 
 - CompoundObject : Fixed crashes in Python bindings caused by passing `None` as a key.
+- VDBObject : Fixed Python bindings for OpenVDB 10.1.
 
 10.5.4.2 (relative to 10.5.4.1)
 ========

--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.5.x.x (relative to 10.5.4.2)
 ========
 
+Features
+--------
+
+- PyBindConverter : Added new class providing interoperability between Boost Python bindings and PyBind11 bindings.
+
 Improvements
 ------------
 

--- a/include/IECorePython/PyBindConverter.h
+++ b/include/IECorePython/PyBindConverter.h
@@ -1,0 +1,102 @@
+
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_PYBINDCONVERTER_H
+#define IECOREPYTHON_PYBINDCONVERTER_H
+
+#include "boost/python.hpp"
+
+#include "pybind11/pybind11.h"
+
+namespace IECorePython
+{
+
+// Registers `boost::python` converters for types
+// wrapped using PyBind11.
+template<typename T>
+struct PyBindConverter
+{
+
+	static void registerConverters()
+	{
+		boost::python::to_python_converter<T, ToPyBind>();
+		boost::python::converter::registry::push_back(
+			&FromPyBind::convertible,
+			&FromPyBind::construct,
+			boost::python::type_id<T>()
+		);
+	}
+
+	private :
+
+		struct ToPyBind
+		{
+			static PyObject *convert( const T &t )
+			{
+				pybind11::object o = pybind11::cast( t );
+				Py_INCREF( o.ptr() );
+				return o.ptr();
+			}
+		};
+
+		struct FromPyBind
+		{
+
+			static void *convertible( PyObject *object )
+			{
+				pybind11::handle handle( object );
+				return handle.cast<T>() ? object : nullptr;
+			}
+
+			static void construct( PyObject *object, boost::python::converter::rvalue_from_python_stage1_data *data )
+			{
+				void *storage = ( ( boost::python::converter::rvalue_from_python_storage<T> * ) data )->storage.bytes;
+				T *t = new( storage ) T;
+				data->convertible = storage;
+
+				pybind11::handle handle( object );
+				*t = handle.cast<T>();
+			}
+
+		};
+
+};
+
+} // namespace IECorePython
+
+#endif // IECOREPYTHON_PYBINDCONVERTER_H
+

--- a/test/IECoreVDB/VDBObjectTest.py
+++ b/test/IECoreVDB/VDBObjectTest.py
@@ -35,6 +35,7 @@
 ##########################################################################
 
 import os
+import unittest
 import imath
 
 import IECore
@@ -240,10 +241,10 @@ class VDBObjectTest( VDBTestCase ) :
 
 		d = smoke.findGrid( "density" )
 
-		d2Value = list( d2.citerAllValues() )[0]
-		dValue = list( d.citerAllValues() )[0]
+		d2Value = next( d2.citerAllValues() )
+		dValue = next( d.citerAllValues() )
 
-		self.assertEqual( d2Value['value'], dValue['value'] + 1 )
+		self.assertEqual( d2Value.value, dValue.value + 1 )
 
 		# we've requested mutable grids from both vdb objects so they could have been edited.
 		self.assertFalse( smoke.unmodifiedFromFile() )


### PR DESCRIPTION
OpenVDB 10.1 switched from Boost to PyBind11 for its bindings, so we need to bind VDBObject differently based on which version of OpenVDB we're building for. But with the new PyBindConverter class, the new bindings actually come out simpler than the old ones.