### PR TITLE
IECoreGL::Selector : Camera-space depth sampling

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 10.5.x.x (relative to 10.5.5.0)
 ========
 
+API
+------------
+
+- `IECoreGL::Selector`: Added constructor overload that accepts a boolean indicating a more precise, camera-space depth sample will be used to sample depth instead of OpenGL's depth buffer.
+- `IECoreGL::ColorTexture`: Added new constructor that accepts an argument specifying the internal storage format to use.
+
 
 
 10.5.5.0 (relative to 10.5.4.2)

--- a/include/IECoreGL/ColorTexture.h
+++ b/include/IECoreGL/ColorTexture.h
@@ -51,8 +51,11 @@ class IECOREGL_API ColorTexture : public Texture
 
 		IE_CORE_DECLARERUNTIMETYPEDEXTENSION( IECoreGL::ColorTexture, ColorTextureTypeId, Texture );
 
-		/// Constructs an empty texture of the specified dimensions.
+		/// \todo Remove this constructor when client code has transitioned to the one
+		/// specifying the internal storage format.
 		ColorTexture( unsigned int width, unsigned int height );
+		/// Constructs an empty texture of the specified dimensions and internal storage format.
+		ColorTexture( unsigned int width, unsigned int height, const GLint internalFormat );
 		/// Constructs a new ColorTexture. All channels must be of the same type, and must
 		/// be some form of numeric VectorData.
 		ColorTexture( unsigned int width, unsigned int height, const IECore::Data *r,

--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -99,6 +99,13 @@ class IECOREGL_API Selector : boost::noncopyable
 		/// responsibility to keep the hits vector alive for the lifetime
 		/// of the Selector.
 		Selector( const Imath::Box2f &region, Mode mode, std::vector<HitRecord> &hits );
+		/// Same as above, and if `useCameraDepth` is `true`, the depth
+		/// values in `hits` will be taken from the camera-space Z coordinate
+		/// instead of the less precise OpenGL depth buffer.
+
+		/// \todo Remove when client code has migrated and use the more
+		/// precise alternative exclusively.
+		Selector( const Imath::Box2f &region, Mode mode, std::vector<HitRecord> &hits, bool useCameraDepth );
 		/// Completes the selection operation, filling in the vector
 		/// of hits that was passed to the constructor.
 		virtual ~Selector();

--- a/src/IECoreGL/ColorTexture.cpp
+++ b/src/IECoreGL/ColorTexture.cpp
@@ -48,7 +48,12 @@ using namespace boost;
 
 IE_CORE_DEFINERUNTIMETYPED( ColorTexture );
 
-ColorTexture::ColorTexture( unsigned int width, unsigned int height )
+ColorTexture::ColorTexture( unsigned int width, unsigned int height ) :
+	ColorTexture( width, height, GL_RGBA )
+{
+}
+
+ColorTexture::ColorTexture( unsigned int width, unsigned int height, const GLint internalFormat )
 {
 	glGenTextures( 1, &m_texture );
 	ScopedBinding binding( *this );
@@ -58,7 +63,7 @@ ColorTexture::ColorTexture( unsigned int width, unsigned int height )
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST );
 	glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST );
 
-	glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA,
+	glTexImage2D( GL_TEXTURE_2D, 0, internalFormat, width, height, 0, GL_RGBA,
 		GL_FLOAT, nullptr );
 }
 

--- a/src/IECoreGL/bindings/ColorTextureBinding.cpp
+++ b/src/IECoreGL/bindings/ColorTextureBinding.cpp
@@ -50,6 +50,7 @@ void bindColorTexture()
 {
 	IECorePython::RunTimeTypedClass<ColorTexture>()
 		.def( init<unsigned int, unsigned int>() )
+		.def( init<unsigned int, unsigned int, const GLint>() )
 		.def( init<unsigned int, unsigned int, const IECore::Data *, const IECore::Data *, const IECore::Data *, const IECore::Data *>() )
 		.def( init<const IECoreImage::ImagePrimitive *>() )
 	;


### PR DESCRIPTION
Previously, we were using OpenGL's depth buffer to sample depths. OpenGL stores depth samples in a quasi-NDC space range [0.0, 1.0]. This must then be converted to camera-space using a series of multiplication and additions, which accumulate floating point error. The end result can have significant error, especially when clipping planes are set far apart.

This solution uses `geometryP` output from vertex shaders to get the camera-space Z value without precision-reducing floating point operations.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
