### PR TITLE
Build : Fix errors from Dependencies 8.x

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.5.x.x (relative to 10.5.6.0)
 ========
 
+Fixes
+-----
+
+- Fixed building with Gaffer Dependencies 8.x.
+
 10.5.6.0 (relative to 10.5.5.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -1174,7 +1174,9 @@ else:
 				# that "C4275 can be ignored if you are deriving from a type in the
 				# C++ Standard Library", which is the case
 				"/wd4275",
+				"/wd4003",  # suppress warning "not enough arguments for function-like macro invocation 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'"
 				"/D_CRT_SECURE_NO_WARNINGS",  # suppress warnings about getenv and similar
+				"/DHAVE_SNPRINTF",  # Fixes error "multiple definitions of snprintf"
 			]
 		)
 


### PR DESCRIPTION
The latest update to the dependencies package, `8.0.0a5`, caused a couple of new warnings treated as errors from USD. This fixes those so Cortex builds with that dependencies package.

For the `8.0.0a5` binary package, this is done as a patch to the Cortex package so not a huge rush to get this merged.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
