### PR TITLE
SConstruct : Improve OpenEXR version detection

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Improvements
 
 - DisplayDriverServer : Fixed delays connecting to the server on Windows.
 
+Build
+-----
+
+- SConstruct : Support detection of OpenEXR versions with a patch version containing multiple digits.
+
 10.5.6.0 (relative to 10.5.5.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -1308,7 +1308,7 @@ if doConfigure :
 
 	exrMajorVersion = None
 	for line in open( str( exrVersionHeader ) ) :
-		m = re.match( r'^#define OPENEXR_VERSION_STRING "(\d)\.(\d)\.(\d)"$', line )
+		m = re.match( r'^#define OPENEXR_VERSION_STRING "(\d)\.(\d)\.(\d+)"$', line )
 		if m :
 			exrMajorVersion = int( m.group( 1 ) )
 


### PR DESCRIPTION
Recent OpenEXR 3.1.x releases have patch versions in the double-digits.