### PR TITLE
Enable building Cortex for EL9.x86_64 platform

### DIFF
--- a/config/ie/buildAll
+++ b/config/ie/buildAll
@@ -115,30 +115,24 @@ nukeVersions = IEBuild.utils.versionsToInstall( "nuke" )
 houdiniVersions = IEBuild.utils.versionsToInstall( "houdini" )
 rvVersions = IEBuild.utils.versionsToInstall( "rv" )
 
-if platform in ( "cent7.x86_64", ) :
 
-	for compilerVersion in compilerVersions:
-		for pythonVersion in pythonVersions :
-			build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "DL_VERSION=UNDEFINED" ] )
+for compilerVersion in compilerVersions:
+	for pythonVersion in pythonVersions :
+		build( [ "COMPILER_VERSION="+compilerVersion, "PYTHON_VERSION="+pythonVersion, "DL_VERSION=UNDEFINED" ] )
 
-	for mayaVersion in mayaVersions :
-		compilerVersion = IEEnv.registry["apps"]["maya"][mayaVersion][platform]["compilerVersion"]
-		build( [ "APP=maya", "APP_VERSION="+mayaVersion ] )
+for mayaVersion in mayaVersions :
+	compilerVersion = IEEnv.registry["apps"]["maya"][mayaVersion][platform]["compilerVersion"]
+	build( [ "APP=maya", "APP_VERSION="+mayaVersion ] )
 
-	for nukeVersion in nukeVersions :
-		compilerVersion = IEEnv.registry["apps"]["nuke"][nukeVersion][platform]["compilerVersion"]
-		build( [ "APP=nuke", "APP_VERSION="+nukeVersion ] )
+for nukeVersion in nukeVersions :
+	compilerVersion = IEEnv.registry["apps"]["nuke"][nukeVersion][platform]["compilerVersion"]
+	build( [ "APP=nuke", "APP_VERSION="+nukeVersion ] )
 
-	for houdiniVersion in houdiniVersions :
-		compilerVersion = IEEnv.registry["apps"]["houdini"][houdiniVersion][platform]["compilerVersion"]
-		build( [ "APP=houdini", "APP_VERSION="+houdiniVersion ] )
+for houdiniVersion in houdiniVersions :
+	compilerVersion = IEEnv.registry["apps"]["houdini"][houdiniVersion][platform]["compilerVersion"]
+	build( [ "APP=houdini", "APP_VERSION="+houdiniVersion ] )
 
-	for rvVersion in rvVersions :
-		build( [ "APP=rv", "APP_VERSION="+rvVersion, "DL_VERSION=UNDEFINED" ] )
+for rvVersion in rvVersions :
+	build( [ "APP=rv", "APP_VERSION="+rvVersion, "DL_VERSION=UNDEFINED" ] )
 
-	installDocs()
-
-else :
-
-	raise RuntimeError( "Unknown platform" )
-
+installDocs()


### PR DESCRIPTION
IE-Build : use current platform unconditionally and build based on active app versions

---

Generally describe what this PR will do, and why it is needed.

- Currently the build process will run only if the platform of the current machine matches the hard-coded list of platforms. With new changes it will allow running the build process on any platform and the amount of work done will be decided by active versions available for the current platform.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
