### PR TITLE
USD ShaderAlgo : Improve shader type heuristics

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.6.1)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed round-tripping of `ai:light` shader type for the output shader of light networks.
 
 10.5.6.1 (relative to 10.5.6.0)
 ========

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -3977,7 +3977,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 		lightShader = IECoreScene.ShaderNetwork(
 			shaders = {
-				"light" : IECoreScene.Shader( "distant_light", parameters = { "exposure" : 2.0 } )
+				"light" : IECoreScene.Shader( "distant_light", "ai:light", parameters = { "exposure" : 2.0 } )
 			},
 			output = "light",
 		)


### PR DESCRIPTION
This lets us round-trip the `Shader::getType()` for Arnold lights, which is necessary for Gaffer features like visualisations and the LightTool.

This is nasty stuff really, and in the long term we just want to stop using shader types completely. We need the fix here in the short term because the longer term fix in Gaffer (not using the type at all) requires an ABI break, and isn't suitable for release in Gaffer 1.3. I intend to do that work next though, so things are moving in the right direction for 1.4.