### PR TITLE
IECoreBinding : Use `Py_ssize_t`

### DIFF
--- a/include/IECorePython/IECoreBinding.h
+++ b/include/IECorePython/IECoreBinding.h
@@ -79,9 +79,9 @@ IECOREPYTHON_API std::string repr( T &x );
 
 /// For backwards compatibility with older versions of boost,
 /// which don't provide boost::python::len
-IECOREPYTHON_API inline ssize_t len( const boost::python::object &obj )
+IECOREPYTHON_API inline Py_ssize_t len( const boost::python::object &obj )
 {
-	ssize_t result = PyObject_Length( obj.ptr() );
+	Py_ssize_t result = PyObject_Length( obj.ptr() );
 
 	if( PyErr_Occurred() )
 	{


### PR DESCRIPTION
MSVC has `SSIZE_T`, but not `ssize_t`, which is not part of the standard it seems. Python's `pyport.h` file does a `typedef` for it (`typedef ssize_t Py_ssize_t`), but something must have changed between Python `3.7` and `3.10` that causes that to not be included from what we're using. It does seem that the official recommendation is to use `Py_ssize_t` now.

This is needed for building Cortex with Python 3.10 dependencies packages.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
