### PR TITLE
Drop support for OpenEXR/Imath 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1301,23 +1301,6 @@ if doConfigure :
 		sys.stderr.write( "ERROR : unable to determine boost version from \"%s\".\n" % boostVersionHeader )
 		Exit( 1 )
 
-	# Figure out the OpenEXR version
-
-	exrVersionHeader = env.FindFile( "OpenEXR/OpenEXRConfig.h", dependencyIncludes )
-	if exrVersionHeader is None :
-		sys.stderr.write( "ERROR : unable to find `OpenEXR/OpenEXRConfig.h`, check OPENEXR_INCLUDE_PATH.\n" )
-		Exit( 1 )
-
-	exrMajorVersion = None
-	for line in open( str( exrVersionHeader ) ) :
-		m = re.match( r'^#define OPENEXR_VERSION_STRING "(\d)\.(\d)\.(\d+)"$', line )
-		if m :
-			exrMajorVersion = int( m.group( 1 ) )
-
-	if exrMajorVersion is None :
-		sys.stderr.write( "ERROR : unable to determine OpenEXR version from \"{}\".\n".format( exrVersionHeader ) )
-		Exit( 1 )
-
 	env.Append( LIBS = [
 			"boost_filesystem" + env["BOOST_LIB_SUFFIX"],
 			"boost_regex" + env["BOOST_LIB_SUFFIX"],
@@ -1357,23 +1340,13 @@ if doConfigure :
 
 	c.Finish()
 
-if exrMajorVersion >= 3 :
-	env.Append( LIBS = [ "OpenEXR" + env["OPENEXR_LIB_SUFFIX"] ] )
-else :
-	env.Append(
-		LIBS = [
-			"IlmImf" + env["OPENEXR_LIB_SUFFIX"],
-			# Windows OpenEXR adds version numbers to all libraries except Half.
-			"Half" + ( env["OPENEXR_LIB_SUFFIX"] if env["PLATFORM"] != "win32" else "" )
-		]
-	)
-
 env.Append( LIBS = [
 		"tbb" + env["TBB_LIB_SUFFIX"],
 		"blosc" + env["BLOSC_LIB_SUFFIX"],
 		"Iex" + env["OPENEXR_LIB_SUFFIX"],
 		"Imath" + env["OPENEXR_LIB_SUFFIX"],
 		"IlmThread" + env["OPENEXR_LIB_SUFFIX"],
+		"OpenEXR" + env["OPENEXR_LIB_SUFFIX"],
 		# Link Windows zlib against static library to avoid potential conflicts
 		# with system provided version.
 		"z" if env["PLATFORM"] != "win32" else "zlibstatic"

--- a/contrib/IECoreUSD/include/IECoreUSD/TypeTraits.h
+++ b/contrib/IECoreUSD/include/IECoreUSD/TypeTraits.h
@@ -44,20 +44,11 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/base/vt/value.h"
 IECORE_POP_DEFAULT_VISIBILITY
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/half.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
-#endif
 
 namespace IECoreUSD
 {

--- a/include/IECore/BezierAlgo.inl
+++ b/include/IECore/BezierAlgo.inl
@@ -37,12 +37,7 @@
 
 #include "IECore/LineSegment.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/BoundedKDTree.h
+++ b/include/IECore/BoundedKDTree.h
@@ -39,12 +39,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECore/BoxAlgo.h
+++ b/include/IECore/BoxAlgo.h
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <iostream>

--- a/include/IECore/BoxInterpolator.inl
+++ b/include/IECore/BoxInterpolator.inl
@@ -35,12 +35,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/BoxTraits.h
+++ b/include/IECore/BoxTraits.h
@@ -39,19 +39,10 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/static_assert.hpp"
 

--- a/include/IECore/CubicBasis.h
+++ b/include/IECore/CubicBasis.h
@@ -38,12 +38,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/DimensionTraits.inl
+++ b/include/IECore/DimensionTraits.inl
@@ -40,16 +40,9 @@
 #include "IECore/TypeTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathPlane.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathPlane.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/static_assert.hpp"

--- a/include/IECore/HalfTypeTraits.h
+++ b/include/IECore/HalfTypeTraits.h
@@ -38,12 +38,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/type_traits/is_arithmetic.hpp"

--- a/include/IECore/IFFFile.h
+++ b/include/IECore/IFFFile.h
@@ -39,12 +39,7 @@
 #include "IECore/RefCounted.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <fstream>

--- a/include/IECore/ImathHash.h
+++ b/include/IECore/ImathHash.h
@@ -36,22 +36,12 @@
 #define IE_CORE_IMATHHASH_H
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/half.h"
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/ImathRandAdapter.h
+++ b/include/IECore/ImathRandAdapter.h
@@ -35,12 +35,7 @@
 #ifndef IE_CORE_IMATHRANDADAPTER_H
 #define IE_CORE_IMATHRANDADAPTER_H
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/IndexedIO.h
+++ b/include/IECore/IndexedIO.h
@@ -40,12 +40,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <map>

--- a/include/IECore/KDTree.h
+++ b/include/IECore/KDTree.h
@@ -39,12 +39,7 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <set>

--- a/include/IECore/LineSegment.h
+++ b/include/IECore/LineSegment.h
@@ -39,14 +39,8 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathPlane.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathPlane.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/LineSegment.inl
+++ b/include/IECore/LineSegment.inl
@@ -35,12 +35,7 @@
 #ifndef IECORE_LINESEGMENT_INL
 #define IECORE_LINESEGMENT_INL
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/Lookup.h
+++ b/include/IECore/Lookup.h
@@ -39,12 +39,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/function.hpp"

--- a/include/IECore/Lookup.inl
+++ b/include/IECore/Lookup.inl
@@ -38,12 +38,7 @@
 
 #include "IECore/FastFloat.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/MatrixAlgo.h
+++ b/include/IECore/MatrixAlgo.h
@@ -43,12 +43,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/MatrixInterpolator.inl
+++ b/include/IECore/MatrixInterpolator.inl
@@ -35,21 +35,11 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/MatrixTraits.h
+++ b/include/IECore/MatrixTraits.h
@@ -38,12 +38,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <cassert>

--- a/include/IECore/MurmurHash.inl
+++ b/include/IECore/MurmurHash.inl
@@ -38,22 +38,12 @@
 #include "IECore/InternedString.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
 #include "Imath/ImathEuler.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECore/NumericParameter.h
+++ b/include/IECore/NumericParameter.h
@@ -38,12 +38,7 @@
 #include "IECore/Parameter.h"
 #include "IECore/TypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/PointDistribution.h
+++ b/include/IECore/PointDistribution.h
@@ -38,14 +38,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/noncopyable.hpp"

--- a/include/IECore/PolygonAlgo.h
+++ b/include/IECore/PolygonAlgo.h
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/PolygonAlgo.inl
+++ b/include/IECore/PolygonAlgo.inl
@@ -37,12 +37,7 @@
 
 #include "IECore/CircularIterator.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVecAlgo.h"
-#else
 #include "Imath/ImathVecAlgo.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/QuatAlgo.h
+++ b/include/IECore/QuatAlgo.h
@@ -42,14 +42,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathMath.h"
-#else
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathMath.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/QuatInterpolator.inl
+++ b/include/IECore/QuatInterpolator.inl
@@ -36,12 +36,7 @@
 #include "IECore/QuatAlgo.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathQuat.h"
-#else
 #include "Imath/ImathQuat.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/RandomAlgo.h
+++ b/include/IECore/RandomAlgo.h
@@ -35,12 +35,7 @@
 #ifndef IECORE_RANDOMALGO_H
 #define IECORE_RANDOMALGO_H
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/RandomAlgo.inl
+++ b/include/IECore/RandomAlgo.inl
@@ -38,12 +38,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/RandomRotationOp.inl
+++ b/include/IECore/RandomRotationOp.inl
@@ -39,19 +39,10 @@
 #include "IECore/Math.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathQuat.h"
-#else
 #include "Imath/ImathQuat.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 namespace IECore
 {

--- a/include/IECore/SimpleTypedData.h
+++ b/include/IECore/SimpleTypedData.h
@@ -42,22 +42,12 @@
 #include "IECore/TypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/half.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECore/SphericalToEuclideanTransform.inl
+++ b/include/IECore/SphericalToEuclideanTransform.inl
@@ -39,14 +39,8 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <cassert>

--- a/include/IECore/Spline.h
+++ b/include/IECore/Spline.h
@@ -40,12 +40,7 @@
 #include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/numeric/interval.hpp"

--- a/include/IECore/Spline.inl
+++ b/include/IECore/Spline.inl
@@ -37,12 +37,7 @@
 
 #include "IECore/Exception.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 
 #include "boost/format.hpp"
 

--- a/include/IECore/TransformationMatrix.h
+++ b/include/IECore/TransformationMatrix.h
@@ -39,18 +39,10 @@
 #include "IECore/MurmurHash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/TriangleAlgo.h
+++ b/include/IECore/TriangleAlgo.h
@@ -43,12 +43,7 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECore

--- a/include/IECore/TriangleAlgo.inl
+++ b/include/IECore/TriangleAlgo.inl
@@ -37,12 +37,7 @@
 
 #include "IECore/VectorOps.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathLineAlgo.h"
-#else
 #include "Imath/ImathLineAlgo.h"
-#endif
 
 #include <cassert>
 

--- a/include/IECore/VecAlgo.h
+++ b/include/IECore/VecAlgo.h
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 // Putting these operators in the Imath namespace so that the compiler can find them

--- a/include/IECore/VectorTypedData.h
+++ b/include/IECore/VectorTypedData.h
@@ -40,20 +40,11 @@
 #include "IECore/TypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/half.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECoreGL/Camera.h
+++ b/include/IECoreGL/Camera.h
@@ -41,14 +41,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/GL.h
+++ b/include/IECoreGL/GL.h
@@ -44,14 +44,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathColor.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "GL/glew.h"

--- a/include/IECoreGL/Group.h
+++ b/include/IECoreGL/Group.h
@@ -41,12 +41,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <list>

--- a/include/IECoreGL/NumericTraits.h
+++ b/include/IECoreGL/NumericTraits.h
@@ -41,12 +41,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Primitive.h
+++ b/include/IECoreGL/Primitive.h
@@ -48,12 +48,7 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Renderable.h
+++ b/include/IECoreGL/Renderable.h
@@ -42,12 +42,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/Selector.h
+++ b/include/IECoreGL/Selector.h
@@ -42,14 +42,8 @@
 #include "IECore/RefCounted.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECoreGL/TypedStateComponent.h
+++ b/include/IECoreGL/TypedStateComponent.h
@@ -42,14 +42,8 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreGL/private/RendererImplementation.h
+++ b/include/IECoreGL/private/RendererImplementation.h
@@ -45,12 +45,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreGL

--- a/include/IECoreHoudini/Convert.h
+++ b/include/IECoreHoudini/Convert.h
@@ -41,22 +41,12 @@
 #include "IECore/Data.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "UT/UT_BoundingBox.h"

--- a/include/IECoreImage/DisplayDriver.h
+++ b/include/IECoreImage/DisplayDriver.h
@@ -46,12 +46,7 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/function.hpp"

--- a/include/IECoreImage/Font.h
+++ b/include/IECoreImage/Font.h
@@ -42,14 +42,8 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreImage

--- a/include/IECoreImage/ImagePrimitive.inl
+++ b/include/IECoreImage/ImagePrimitive.inl
@@ -40,12 +40,7 @@
 #include "IECore/TypeTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/format.hpp"

--- a/include/IECoreMaya/Convert.h
+++ b/include/IECoreMaya/Convert.h
@@ -41,22 +41,12 @@
 #include "IECore/Data.h"
 #include "IECore/TransformationMatrix.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathVec.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathBox.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathEuler.h"
-#endif
 
 #include "maya/MString.h"
 #include "maya/MBoundingBox.h"

--- a/include/IECoreMaya/NumericTraits.h
+++ b/include/IECoreMaya/NumericTraits.h
@@ -38,14 +38,8 @@
 #include "boost/static_assert.hpp"
 
 #include "maya/MFnNumericData.h"
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathVec.h"
 #include "Imath/ImathColor.h"
-#endif
 
 namespace IECoreMaya
 {

--- a/include/IECoreMaya/SceneShapeInterface.h
+++ b/include/IECoreMaya/SceneShapeInterface.h
@@ -40,12 +40,7 @@
 #include "IECoreMaya/Export.h"
 
 #include <map>
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 #include "IECoreGL/IECoreGL.h"
 #include "maya/MPxComponentShape.h"
 

--- a/include/IECoreMaya/SceneShapeInterfaceComponentBoundIterator.h
+++ b/include/IECoreMaya/SceneShapeInterfaceComponentBoundIterator.h
@@ -40,12 +40,7 @@
 #include "maya/MBoundingBox.h"
 #include "maya/MObjectArray.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 
 #include "IECoreMaya/SceneShapeInterface.h"
 

--- a/include/IECoreNuke/Box3ParameterHandler.h
+++ b/include/IECoreNuke/Box3ParameterHandler.h
@@ -37,12 +37,7 @@
 
 #include "IECoreNuke/ParameterHandler.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 
 namespace IECoreNuke
 {

--- a/include/IECoreNuke/Color3fParameterHandler.h
+++ b/include/IECoreNuke/Color3fParameterHandler.h
@@ -37,12 +37,7 @@
 
 #include "IECoreNuke/ParameterHandler.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 
 namespace IECoreNuke
 {

--- a/include/IECoreNuke/Convert.h
+++ b/include/IECoreNuke/Convert.h
@@ -47,18 +47,10 @@
 #include "DDImage/Vector4.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 /// Specialising in the IECore namespace. This is OK because the Nuke types

--- a/include/IECoreNuke/CurveLookup.inl
+++ b/include/IECoreNuke/CurveLookup.inl
@@ -35,12 +35,7 @@
 #ifndef IECORENUKE_CURVELOOKUP_INL
 #define IECORENUKE_CURVELOOKUP_INL
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include <cassert>
 #include <vector>

--- a/include/IECoreNuke/DrawableHolder.h
+++ b/include/IECoreNuke/DrawableHolder.h
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/Hash.h
+++ b/include/IECoreNuke/Hash.h
@@ -40,18 +40,10 @@
 #include "DDImage/Hash.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/SceneCacheReader.h
+++ b/include/IECoreNuke/SceneCacheReader.h
@@ -54,12 +54,7 @@
 #include "DDImage/ViewerContext.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreNuke/Warp.h
+++ b/include/IECoreNuke/Warp.h
@@ -42,12 +42,7 @@
 #include "DDImage/Iop.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreNuke

--- a/include/IECoreScene/Font.h
+++ b/include/IECoreScene/Font.h
@@ -42,14 +42,8 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/OBJReader.h
+++ b/include/IECoreScene/OBJReader.h
@@ -42,12 +42,7 @@
 #include "IECore/Reader.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <vector>

--- a/include/IECoreScene/ParticleReader.inl
+++ b/include/IECoreScene/ParticleReader.inl
@@ -38,12 +38,7 @@
 #include "IECore/Convert.h"
 #include "IECore/MessageHandler.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 namespace IECoreScene
 {

--- a/include/IECoreScene/PrimitiveEvaluator.h
+++ b/include/IECoreScene/PrimitiveEvaluator.h
@@ -42,14 +42,8 @@
 #include "IECore/RunTimeTyped.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathColor.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <string>

--- a/include/IECoreScene/Renderer.h
+++ b/include/IECoreScene/Renderer.h
@@ -47,14 +47,8 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <set>

--- a/include/IECoreScene/SceneInterface.h
+++ b/include/IECoreScene/SceneInterface.h
@@ -46,14 +46,8 @@
 #include "IECore/PathMatcher.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/Transform.h
+++ b/include/IECoreScene/Transform.h
@@ -41,12 +41,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/VisibleRenderable.h
+++ b/include/IECoreScene/VisibleRenderable.h
@@ -41,12 +41,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 namespace IECoreScene

--- a/include/IECoreScene/private/TransformStack.h
+++ b/include/IECoreScene/private/TransformStack.h
@@ -40,12 +40,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <stack>

--- a/include/IECoreVDB/VDBObject.h
+++ b/include/IECoreVDB/VDBObject.h
@@ -50,12 +50,7 @@
 #include "openvdb/openvdb.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "tbb/recursive_mutex.h"

--- a/src/IECore/PointDistribution.cpp
+++ b/src/IECore/PointDistribution.cpp
@@ -2,12 +2,7 @@
 #include "IECore/Exception.h"
 #include "IECore/ImathRandAdapter.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include <fstream>
 #include <algorithm>

--- a/src/IECoreGL/Camera.cpp
+++ b/src/IECoreGL/Camera.cpp
@@ -39,12 +39,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace IECoreGL;

--- a/src/IECoreGL/CurvesPrimitive.cpp
+++ b/src/IECoreGL/CurvesPrimitive.cpp
@@ -45,16 +45,9 @@
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathVecAlgo.h"
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathVecAlgo.h"
 #include "Imath/ImathFun.h"
-#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreGL/Group.cpp
+++ b/src/IECoreGL/Group.cpp
@@ -37,12 +37,7 @@
 #include "IECoreGL/GL.h"
 #include "IECoreGL/State.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreGL/MeshPrimitive.cpp
+++ b/src/IECoreGL/MeshPrimitive.cpp
@@ -39,12 +39,7 @@
 
 #include "IECore/DespatchTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMath.h"
-#else
 #include "Imath/ImathMath.h"
-#endif
 
 #include <cassert>
 

--- a/src/IECoreGL/PointsPrimitive.cpp
+++ b/src/IECoreGL/PointsPrimitive.cpp
@@ -49,14 +49,8 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathFun.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 using namespace IECoreGL;
 using namespace IECore;

--- a/src/IECoreGL/Renderer.cpp
+++ b/src/IECoreGL/Renderer.cpp
@@ -77,12 +77,7 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/SplineData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include <mutex>
 #include <stack>

--- a/src/IECoreGL/SpherePrimitive.cpp
+++ b/src/IECoreGL/SpherePrimitive.cpp
@@ -41,12 +41,7 @@
 #include "IECore/Math.h"
 #include "IECore/MessageHandler.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 using namespace IECoreGL;
 using namespace Imath;

--- a/src/IECoreHoudini/LiveScene.cpp
+++ b/src/IECoreHoudini/LiveScene.cpp
@@ -42,14 +42,8 @@
 #include "IECore/TransformationMatrixData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "MGR/MGR_Node.h"

--- a/src/IECoreHoudini/SOP_SceneCacheSource.cpp
+++ b/src/IECoreHoudini/SOP_SceneCacheSource.cpp
@@ -50,12 +50,7 @@
 #include "IECore/DespatchTypedData.h"
 #include "IECore/TypeTraits.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
 
 #include "GA/GA_Names.h"
 #include "OP/OP_NodeInfoParms.h"
@@ -412,7 +407,7 @@ void SOP_SceneCacheSource::loadObjects( const IECoreScene::SceneInterface *scene
 				gdp->destroyPrimitives( primRange, true );
 			}
 		}
-		
+
 	}
 
 	if ( UT_String( currentPath ).multiMatch( params.shapeFilter ) && tagged( scene, params.tagFilter ) )

--- a/src/IECoreImageBindings/ImagePrimitiveBinding.cpp
+++ b/src/IECoreImageBindings/ImagePrimitiveBinding.cpp
@@ -34,12 +34,7 @@
 
 #include "boost/python.hpp"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 
 #include "IECoreImage/ImagePrimitive.h"
 

--- a/src/IECoreMaya/FromMayaImageConverter.cpp
+++ b/src/IECoreMaya/FromMayaImageConverter.cpp
@@ -46,12 +46,7 @@
 #include "IECoreMaya/FromMayaImageConverter.h"
 #include "IECoreMaya/MImageAccessor.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#else
 #include "Imath/ImathBox.h"
-#endif
 
 using namespace IECore;
 using namespace IECoreImage;

--- a/src/IECoreMaya/FromMayaLocatorConverter.cpp
+++ b/src/IECoreMaya/FromMayaLocatorConverter.cpp
@@ -35,14 +35,9 @@
 #include "IECoreMaya/FromMayaLocatorConverter.h"
 #include "IECoreMaya/Convert.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathVec.h"
 #include "Imath/ImathMatrix.h"
-#endif
+
 #include "IECoreScene/CoordinateSystem.h"
 #include "IECoreScene/MatrixTransform.h"
 

--- a/src/IECoreMaya/LiveScene.cpp
+++ b/src/IECoreMaya/LiveScene.cpp
@@ -75,12 +75,7 @@
 #include "maya/MFnSet.h"
 #include "maya/MFnInstancer.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/algorithm/string.hpp"
 #include "boost/tokenizer.hpp"

--- a/src/IECoreMaya/SceneShapeInterface.cpp
+++ b/src/IECoreMaya/SceneShapeInterface.cpp
@@ -40,14 +40,8 @@
 #include "boost/python.hpp"
 #include "boost/tokenizer.hpp"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "IECoreGL/Renderer.h"
 #include "IECoreGL/Scene.h"

--- a/src/IECoreMaya/ToMayaLocatorConverter.cpp
+++ b/src/IECoreMaya/ToMayaLocatorConverter.cpp
@@ -39,12 +39,8 @@
 #include "maya/MFnTransform.h"
 #include "maya/MPlug.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrixAlgo.h"
-#else
 #include "Imath/ImathMatrixAlgo.h"
-#endif
+
 #include "IECore/AngleConversion.h"
 #include "IECore/MessageHandler.h"
 #include "IECore/SimpleTypedData.h"

--- a/src/IECoreNuke/LiveScene.cpp
+++ b/src/IECoreNuke/LiveScene.cpp
@@ -46,12 +46,7 @@
 #include "IECore/NullObject.h"
 #include "IECore/TransformationMatrixData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/algorithm/string.hpp"
 #include "boost/format.hpp"
@@ -224,7 +219,7 @@ unsigned LiveScene::objectNum( const double* time) const
 		auto jit = cachedGeometryListMap()[this].find( h );
 		if ( jit != cachedGeometryListMap()[this].end() )
 		{
-			
+
 			auto kit = cachedGeometryListMap()[this][h].find( frame );
 			if ( kit != cachedGeometryListMap()[this][h].end() )
 			{
@@ -265,7 +260,7 @@ DD::Image::GeoInfo* LiveScene::object( const unsigned& index, const double* time
 		auto jit = cachedGeometryListMap()[this].find( h );
 		if ( jit != cachedGeometryListMap()[this].end() )
 		{
-			
+
 			auto kit = cachedGeometryListMap()[this][h].find( frame );
 			if ( kit != cachedGeometryListMap()[this][h].end() )
 			{
@@ -581,7 +576,7 @@ SceneInterfacePtr LiveScene::child( const Name &name, MissingBehaviour missingBe
 {
 	IECoreScene::SceneInterface::NameList names;
 	childNames( names );
-	
+
 	if( find( names.cbegin(), names.cend(), name ) == names.cend() )
 	{
 		switch ( missingBehaviour )

--- a/src/IECorePython/AngleConversionBinding.cpp
+++ b/src/IECorePython/AngleConversionBinding.cpp
@@ -42,12 +42,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/HalfBinding.cpp
+++ b/src/IECorePython/HalfBinding.cpp
@@ -39,12 +39,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/half.h"
-#else
 #include "Imath/half.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/HenyeyGreensteinBinding.cpp
+++ b/src/IECorePython/HenyeyGreensteinBinding.cpp
@@ -42,12 +42,7 @@
 #include "IECore/HenyeyGreenstein.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace boost::python;

--- a/src/IECorePython/IECoreBinding.cpp
+++ b/src/IECorePython/IECoreBinding.cpp
@@ -37,22 +37,12 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathColor.h"
-#include "OpenEXR/ImathEuler.h"
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathPlane.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathColor.h"
 #include "Imath/ImathEuler.h"
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathPlane.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 using namespace std;

--- a/src/IECorePython/VectorTypedDataBinding.cpp
+++ b/src/IECorePython/VectorTypedDataBinding.cpp
@@ -51,16 +51,9 @@
 #include "IECore/VectorTypedData.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathQuat.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathQuat.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include "boost/numeric/conversion/cast.hpp"

--- a/src/IECorePythonModule/IECore.cpp
+++ b/src/IECorePythonModule/IECore.cpp
@@ -41,12 +41,7 @@
 
 #include "TBBBinding.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathEuler.h"
-#else
 #include "Imath/ImathEuler.h"
-#endif
 
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"

--- a/src/IECoreScene/CurveExtrudeOp.cpp
+++ b/src/IECoreScene/CurveExtrudeOp.cpp
@@ -49,12 +49,7 @@
 #include "IECore/TypedObjectParameter.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFrame.h"
-#else
 #include "Imath/ImathFrame.h"
-#endif
 
 #include <algorithm>
 #include <cassert>

--- a/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/CurvesPrimitiveEvaluator.cpp
@@ -42,12 +42,7 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 using namespace IECore;
 using namespace IECoreScene;

--- a/src/IECoreScene/Group.cpp
+++ b/src/IECoreScene/Group.cpp
@@ -40,12 +40,7 @@
 
 #include "IECore/MurmurHash.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/format.hpp"
 #include "boost/lexical_cast.hpp"

--- a/src/IECoreScene/MatrixMotionTransform.cpp
+++ b/src/IECoreScene/MatrixMotionTransform.cpp
@@ -38,12 +38,7 @@
 
 #include "IECore/MurmurHash.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 #include "boost/format.hpp"
 

--- a/src/IECoreScene/MeshPrimitiveEvaluator.cpp
+++ b/src/IECoreScene/MeshPrimitiveEvaluator.cpp
@@ -43,21 +43,11 @@
 #include "IECore/TriangleAlgo.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#else
 #include "Imath/ImathMatrix.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathLineAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathLineAlgo.h"
-#endif
 
 #include <cassert>
 

--- a/src/IECoreScene/NParticleReader.cpp
+++ b/src/IECoreScene/NParticleReader.cpp
@@ -42,12 +42,7 @@
 #include "IECore/Timer.h"
 #include "IECore/VectorTypedData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "boost/algorithm/string/predicate.hpp"
 

--- a/src/IECoreScene/SceneCache.cpp
+++ b/src/IECoreScene/SceneCache.cpp
@@ -50,12 +50,7 @@
 #include "IECore/TransformationMatrixData.h"
 #include "IECore/PathMatcherData.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
-#endif
 
 #include "boost/core/demangle.hpp"
 #include "boost/tuple/tuple.hpp"
@@ -2187,7 +2182,7 @@ class SceneCache::WriterImplementation : public SceneCache::Implementation
 				)
 			);
 		}
-		
+
 		WriterImplementation* m_parent;
 		std::map< SceneCache::Name, WriterImplementationPtr > m_children;
 

--- a/src/IECoreScene/SpherePrimitiveEvaluator.cpp
+++ b/src/IECoreScene/SpherePrimitiveEvaluator.cpp
@@ -41,14 +41,8 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/TriangleAlgo.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBoxAlgo.h"
-#include "OpenEXR/ImathLineAlgo.h"
-#else
 #include "Imath/ImathBoxAlgo.h"
 #include "Imath/ImathLineAlgo.h"
-#endif
 
 #include <cassert>
 

--- a/src/IECoreScene/TransformStack.cpp
+++ b/src/IECoreScene/TransformStack.cpp
@@ -39,12 +39,7 @@
 #include "IECore/Exception.h"
 #include "IECore/Interpolator.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathFun.h"
-#else
 #include "Imath/ImathFun.h"
-#endif
 
 using namespace Imath;
 using namespace IECore;

--- a/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
+++ b/src/IECoreScene/bindings/CurvesPrimitiveEvaluatorBinding.cpp
@@ -42,12 +42,7 @@
 #include "IECorePython/RefCountedBinding.h"
 #include "IECorePython/RunTimeTypedBinding.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "tbb/parallel_for.h"
 

--- a/test/IECore/CompilerTest.h
+++ b/test/IECore/CompilerTest.h
@@ -39,16 +39,9 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathLineAlgo.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathVec.h"
 #include "Imath/ImathLineAlgo.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 IECORE_PUSH_DEFAULT_VISIBILITY

--- a/test/IECore/IECoreTest.cpp
+++ b/test/IECore/IECoreTest.cpp
@@ -35,12 +35,7 @@
 #include "IECore/Export.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathColor.h"
-#else
 #include "Imath/ImathColor.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 #include <iostream>

--- a/test/IECore/InternedStringTest.cpp
+++ b/test/IECore/InternedStringTest.cpp
@@ -36,12 +36,7 @@
 
 #include "IECore/InternedString.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "boost/lexical_cast.hpp"
 

--- a/test/IECore/InterpolatorTest.h
+++ b/test/IECore/InterpolatorTest.h
@@ -39,16 +39,9 @@
 #include "IECore/Interpolator.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathMatrix.h"
-#include "OpenEXR/ImathMatrixAlgo.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathMatrix.h"
 #include "Imath/ImathMatrixAlgo.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 

--- a/test/IECore/KDTreeTest.h
+++ b/test/IECore/KDTreeTest.h
@@ -39,14 +39,8 @@
 #include "IECore/KDTree.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathVec.h"
 #include "Imath/ImathRandom.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 IECORE_PUSH_DEFAULT_VISIBILITY

--- a/test/IECore/LevenbergMarquardtTest.h
+++ b/test/IECore/LevenbergMarquardtTest.h
@@ -39,14 +39,8 @@
 #include "IECore/LevenbergMarquardt.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathRandom.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 IECORE_PUSH_DEFAULT_VISIBILITY

--- a/test/IECore/ParameterThreadingTest.cpp
+++ b/test/IECore/ParameterThreadingTest.cpp
@@ -42,12 +42,7 @@
 #include "IECore/TypedObjectParameter.h"
 #include "IECore/VectorTypedParameter.h"
 
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 #include "tbb/parallel_for.h"
 

--- a/test/IECore/SpaceTransformTest.h
+++ b/test/IECore/SpaceTransformTest.h
@@ -40,14 +40,8 @@
 #include "IECore/SphericalToEuclideanTransform.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathVec.h"
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathVec.h"
 #include "Imath/ImathRandom.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 

--- a/test/IECore/SweepAndPruneTest.h
+++ b/test/IECore/SweepAndPruneTest.h
@@ -43,14 +43,8 @@
 #include "IECore/VectorTraits.h"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
-#include "OpenEXR/OpenEXRConfig.h"
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathBox.h"
-#include "OpenEXR/ImathVec.h"
-#else
 #include "Imath/ImathBox.h"
 #include "Imath/ImathVec.h"
-#endif
 IECORE_POP_DEFAULT_VISIBILITY
 
 IECORE_PUSH_DEFAULT_VISIBILITY

--- a/test/IECore/TypedDataTest.h
+++ b/test/IECore/TypedDataTest.h
@@ -39,11 +39,7 @@
 #include "IECore/SimpleTypedData.h"
 #include "IECore/VectorTypedData.h"
 
-#if OPENEXR_VERSION_MAJOR < 3
-#include "OpenEXR/ImathRandom.h"
-#else
 #include "Imath/ImathRandom.h"
-#endif
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "boost/test/unit_test.hpp"


### PR DESCRIPTION
See https://github.com/GafferHQ/gaffer/pull/5800. The last official Gaffer builds we made with Imath 2 were for 1.2.x, which is no longer supported, and Image Engine will be building with Imath 3 exclusively for Gaffer 1.4.