### PR TITLE
ShaderNetworkAlgo::removedUnusedShaders : Optimize, fix crash in case of cycle

### DIFF
--- a/src/IECoreScene/ShaderNetworkAlgo.cpp
+++ b/src/IECoreScene/ShaderNetworkAlgo.cpp
@@ -96,10 +96,12 @@ namespace
 
 void visitInputs( const ShaderNetwork *network, InternedString handle, std::unordered_set<InternedString> &visited )
 {
-	visited.insert( handle );
-	for( const auto &c : network->inputConnections( handle ) )
+	if( visited.insert( handle ).second )
 	{
-		visitInputs( network, c.source.shader, visited );
+		for( const auto &c : network->inputConnections( handle ) )
+		{
+			visitInputs( network, c.source.shader, visited );
+		}
 	}
 }
 

--- a/test/IECoreScene/ShaderNetworkAlgoTest.py
+++ b/test/IECoreScene/ShaderNetworkAlgoTest.py
@@ -85,7 +85,7 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 
 	def testRemoveUnusedShaders( self ) :
 
-		n = IECoreScene.ShaderNetwork(
+		source = IECoreScene.ShaderNetwork(
 			shaders = {
 				"used1" : IECoreScene.Shader(),
 				"used2" : IECoreScene.Shader(),
@@ -103,6 +103,13 @@ class ShaderNetworkAlgoTest( unittest.TestCase ) :
 			output = ( "used3", "" ),
 		)
 
+		n = source.copy()
+		IECoreScene.ShaderNetworkAlgo.removeUnusedShaders( n )
+		self.assertEqual( set( n.shaders().keys() ), { "used1", "used2", "used3" } )
+
+		# Test a network with a cycle - this is invalid, but we don't want it to crash
+		n = source.copy()
+		n.addConnection( ( ( "used3", "out" ), ( "used2", "in2" ) ) )
 		IECoreScene.ShaderNetworkAlgo.removeUnusedShaders( n )
 		self.assertEqual( set( n.shaders().keys() ), { "used1", "used2", "used3" } )
 


### PR DESCRIPTION
This was causing a crash in my testing of ShaderTweakProxy - we will quite possibly need to add an explicit cycle check to that code, because I'm guessing we don't want to depend on renderers behaving reasonably when handed shader networks containing cycles. But it probably still makes sense to merge this, because it's currently easy to cause a crash in this function by building a shader network with the Python API, and also in extreme cases this could be dramatically faster ( because it avoids revisiting subgraphs that have already been checked ).