### PR TITLE
ShaderStateComponent : Handle ToGLTextureConverter exceptions

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - ShaderNetworkAlgo : Fixed crash caused by cyclic connections in `removeUnusedShaders()`.
+- ShaderStateComponent : Fixed GL rendering failures caused by unsupported values for texture parameters.
 
 10.5.7.1 (relative to 10.5.7.0)
 ========

--- a/src/IECoreGL/ShaderStateComponent.cpp
+++ b/src/IECoreGL/ShaderStateComponent.cpp
@@ -139,7 +139,14 @@ class ShaderStateComponent::Implementation : public IECore::RefCounted
 						it->second->typeId() == IECore::SplinefColor3fData::staticTypeId()
 					)
 					{
-						texture = IECore::runTimeCast<const Texture>( CachedConverter::defaultCachedConverter()->convert( it->second.get() ) );
+						try
+						{
+							texture = IECore::runTimeCast<const Texture>( CachedConverter::defaultCachedConverter()->convert( it->second.get() ) );
+						}
+						catch( const std::exception &e )
+						{
+							IECore::msg( IECore::Msg::Error, "ShaderStateComponent", e.what() );
+						}
 					}
 					else if( it->second->typeId() == IECore::StringData::staticTypeId() )
 					{


### PR DESCRIPTION
These were thrown if a GLSL shader had bad values for a texture parameter - the case that motivated this was a custom setup in production that would pass a CompoundData with no channels and an empty data window.

We can't let the exception propagate because `addParametersToShaderSetup()` is called during drawing and the exception would prevent the rest of the scene drawing and/or lead to a corrupted GL state.
