### PR TITLE
CI : Update to GafferHQ/dependencies 8.0.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,45 +30,55 @@ jobs:
         # and then use `include` to define their settings.
 
         name: [
-          linux-python3,
-          linux-python3-debug,
-          windows-python3,
-          windows-python3-debug
+          linux-gcc9,
+          linux-debug-gcc9,
+          linux-gcc11,
+          windows,
+          windows-debug
         ]
 
         include:
 
-          - name: linux-python3
+          - name: linux-gcc9
             os: ubuntu-20.04
             buildType: RELEASE
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
+            containerImage: ghcr.io/gafferhq/build/build:2.1.2
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/7.0.0/gafferDependencies-7.0.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.1/gafferDependencies-8.0.1-linux-gcc9.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: true
 
-          - name: linux-python3-debug
+          - name: linux-debug-gcc9
             os: ubuntu-20.04
             buildType: DEBUG
-            containerImage: ghcr.io/gafferhq/build/build:2.0.0
+            containerImage: ghcr.io/gafferhq/build/build:2.1.2
             options: .github/workflows/main/options.posix
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/7.0.0/gafferDependencies-7.0.0-linux.tar.gz
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.1/gafferDependencies-8.0.1-linux-gcc9.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: false
 
-          - name: windows-python3
-            os: windows-2019
+          - name: linux-gcc11
+            os: ubuntu-20.04
             buildType: RELEASE
-            options: .github/workflows/main/options.windows
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/7.0.0/gafferDependencies-7.0.0-windows.zip
+            containerImage: ghcr.io/gafferhq/build/build:3.0.0
+            options: .github/workflows/main/options.posix
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.1/gafferDependencies-8.0.1-linux-gcc11.tar.gz
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: true
 
-          - name: windows-python3-debug
+          - name: windows
+            os: windows-2019
+            buildType: RELEASE
+            options: .github/workflows/main/options.windows
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.1/gafferDependencies-8.0.1-windows.zip
+            tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
+            publish: true
+
+          - name: windows-debug
             os: windows-2019
             buildType: RELWITHDEBINFO
             options: .github/workflows/main/options.windows
-            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/7.0.0/gafferDependencies-7.0.0-windows.zip
+            dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/8.0.1/gafferDependencies-8.0.1-windows.zip
             tests: testCore testCorePython testScene testImage testAlembic testUSD testVDB
             publish: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
 
     - name: Build
       run: |
-       scons -j 2 install BUILD_TYPE=${{ matrix.buildType }} OPTIONS=${{ matrix.options }} BUILD_CACHEDIR=sconsCache
+       scons -j 2 BUILD_TYPE=${{ matrix.buildType }} OPTIONS=${{ matrix.options }} BUILD_CACHEDIR=sconsCache
        # Copy the config log for use in the "Debug Failures" step, because it
        # gets clobbered by the `scons test*` call below.
        cp config.log buildConfig.log
@@ -178,6 +178,7 @@ jobs:
 
     - name: Build Package
       run: |
+       scons install BUILD_TYPE=${{ matrix.buildType }} OPTIONS=${{ matrix.options }} BUILD_CACHEDIR=sconsCache
        ${{ env.PACKAGE_COMMAND }} ${{ env.CORTEX_BUILD_NAME }}.${{env.PACKAGE_EXTENSION}} ${{ env.CORTEX_BUILD_NAME }}
       if: matrix.publish
 

--- a/.github/workflows/main/options.posix
+++ b/.github/workflows/main/options.posix
@@ -19,10 +19,7 @@ LIBPATH = libs
 
 PYTHON = deps + "/bin/python"
 
-if os.path.exists( deps + "/bin/python3" ) :
-	pythonABIVersion = "3.7m"
-else :
-	pythonABIVersion = "2.7"
+pythonABIVersion = "3.10"
 
 PYTHON_LINK_FLAGS = "-lpython" + pythonABIVersion
 

--- a/Changes
+++ b/Changes
@@ -7,6 +7,11 @@ Fixes
 - ShaderNetworkAlgo : Fixed crash caused by cyclic connections in `removeUnusedShaders()`.
 - ShaderStateComponent : Fixed GL rendering failures caused by unsupported values for texture parameters.
 
+Build
+-----
+
+- CI : Updated to GafferHQ/dependencies 8.0.1.
+
 10.5.7.1 (relative to 10.5.7.0)
 ========
 

--- a/SConstruct
+++ b/SConstruct
@@ -1496,6 +1496,7 @@ if testEnv["PLATFORM"] == "darwin" :
 testEnv["ENV"][testEnv["TEST_LIBRARY_PATH_ENV_VAR"]] = os.pathsep.join( [ testEnv["ENV"].get(testEnv["TEST_LIBRARY_PATH_ENV_VAR"], ""), testEnvLibPath ] )
 if testEnv["TEST_LIBRARY_PATH_ENV_VAR"] != libraryPathEnvVar :
 	testEnv["ENV"][libraryPathEnvVar] = os.pathsep.join( [ testEnv["ENV"].get(libraryPathEnvVar, ""), testEnvLibPath ] )
+testEnv["ENV"]["IECORE_DLL_DIRECTORIES"] = testEnv["ENV"][libraryPathEnvVar]
 testEnv["ENV"]["IECORE_OP_PATHS"] = os.path.join( "test", "IECore", "ops" )
 
 c = configureSharedLibrary( testEnv )

--- a/python/IECore/__init__.py
+++ b/python/IECore/__init__.py
@@ -38,7 +38,7 @@
 #
 # Some parts of the IECore library are defined purely in Python. These are shown below.
 
-import os, sys, ctypes
+import os, sys, ctypes, pathlib
 if os.name == "posix" and os.environ.get( "IECORE_RTLD_GLOBAL", "1" ) == "1" :
 	# Historically, we had problems with cross-module RTTI on Linux, whereby
 	# different Python modules and/or libraries could end up with their own
@@ -56,8 +56,15 @@ if os.name == "posix" and os.environ.get( "IECORE_RTLD_GLOBAL", "1" ) == "1" :
 		sys.getdlopenflags() | ctypes.RTLD_GLOBAL
 	)
 
+if hasattr( os, "add_dll_directory" ) and "IECORE_DLL_DIRECTORIES" in os.environ :
+	for directory in os.environ.get( "IECORE_DLL_DIRECTORIES" ).split( os.pathsep ) :
+		directory = pathlib.Path( directory ).resolve()
+		if directory.is_dir() :
+			os.add_dll_directory( directory )
+	del directory
+
 # Remove pollution of IECore namespace
-del os, sys, ctypes
+del os, sys, ctypes, pathlib
 
 __import__( "imath" )
 

--- a/test/IECoreImage/ImageReaderTest.py
+++ b/test/IECoreImage/ImageReaderTest.py
@@ -212,7 +212,7 @@ class ImageReaderTest( unittest.TestCase ) :
 	def testIncompleteImage( self ) :
 
 		r = IECoreImage.ImageReader( os.path.join( "test", "IECoreImage", "data", "exr", "incomplete.exr" ) )
-		self.assertRaisesRegex( Exception, "Error reading pixel data from image file", r.read )
+		self.assertRaisesRegex( Exception, "Error reading pixel data from image file|.*Some scanline chunks were missing or corrupted", r.read )
 
 	def testHeaderToBlindData( self ) :
 

--- a/test/IECoreImage/ImageThinnerTest.py
+++ b/test/IECoreImage/ImageThinnerTest.py
@@ -58,7 +58,7 @@ class ImageThinnerTest( unittest.TestCase ) :
 			iic = ii[c]
 			for j in range( 0, i.channelSize() ) :
 				# the values may not match exactly due to color space conversions reading the tif on disk
-				self.assertAlmostEqual( ic[j], iic[j], 6 )
+				self.assertAlmostEqual( ic[j], iic[j], delta = 0.0001 )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This updates to the latest dependencies and build environment used for Gaffer 1.4, meaning that we'll be able to use the builds from Cortex releases for Gaffer 1.4 builds.