### PR TITLE
USDScene : Load bounds from UsdGeomModelAPI extents hints

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.8.0)
 ========
 
+Improvements
+------------
 
+- USDScene : `hasBound()` and `readBound()` now use `UsdGeomModelAPI` extents hints if they are available. This behaviour can be disabled by setting the `IECOREUSD_USE_MODELAPI_BOUNDS` environment variable to a value of `0`.
 
 10.5.8.0 (relative to 10.5.7.1)
 ========


### PR DESCRIPTION
This can provide significant performance improvements where the ModelAPI has been used to provide cached extents. This knocks around 30% off the time taken to open the file and compute the root bound of the ALab in Gaffer. If USD composition time is omitted so only the bound computation is measured in isolation, a full 95% is knocked off the time. In the case of the ALab, the new root bound is also far more reasonable for some reason - I suspect the model extents are masking a bad authored extent on a leaf object elsewhere in the scene.

This has the potential to be surprising for any folks who have authored inaccurate model extents in the past, so I've made it possible to turn off the behaviour using an environment variable. I'd like to default things on in Cortex itself, but we can debate the appropriate default for Gaffer when we next update the Cortex version.
