### PR TITLE
VDBObject : Don't bake in automatic metadata when querying metadata

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 10.5.x.x (relative to 10.5.9.0)
 ========
 
+Fixes
+-----
+
+VDBObject : metadata() now just returns existing metadata, without modifying it.
 
 
 10.5.9.x (relative to 10.5.8.0)

--- a/include/IECoreVDB/VDBObject.h
+++ b/include/IECoreVDB/VDBObject.h
@@ -88,7 +88,7 @@ class IECOREVDB_API VDBObject : public IECoreScene::VisibleRenderable
 		Imath::Box3f bound() const override;
 		void render( IECoreScene::Renderer *renderer ) const override;
 
-		IECore::CompoundObjectPtr metadata( const std::string &name );
+		IECore::CompoundObjectPtr metadata( const std::string &name ) const;
 
 		//! Are the grids in this VDBObject unmodified from the vdb file in filename?
 		//! Useful for passing VDB objects to renders by filename instead of memory buffer

--- a/src/IECoreVDB/VDBObject.cpp
+++ b/src/IECoreVDB/VDBObject.cpp
@@ -199,7 +199,7 @@ void VDBObject::render( IECoreScene::Renderer *renderer ) const
 {
 }
 
-IECore::CompoundObjectPtr VDBObject::metadata( const std::string &name )
+IECore::CompoundObjectPtr VDBObject::metadata( const std::string &name ) const
 {
 	CompoundObjectPtr metadata = new CompoundObject();
 
@@ -216,12 +216,7 @@ IECore::CompoundObjectPtr VDBObject::metadata( const std::string &name )
 	}
 	else
 	{
-		openvdb::GridBase::Ptr tmpGrid  = findGrid ( name );
-		if ( tmpGrid )
-		{
-			tmpGrid->addStatsMetadata();
-		}
-		grid = tmpGrid;
+		grid = findGrid ( name );
 	}
 
 	if( !grid )


### PR DESCRIPTION
This addresses proposal 2) from John's comment here:
https://github.com/GafferHQ/gaffer/pull/5923#issuecomment-2191354486

I think a PR is probably the most direct way to discuss it, though I'm not entirely convinced that just merging this is necessarily correct.

I think the argument is completely sound that the previous behaviour was wrong - we were calling this function assuming it was const, and this was resulting in things getting written in the cache in a completely non-threadsafe way. This definitely seems more correct.

But just doing this results in a worse experience for users. Seeing the voxel counts and bounding box sizes in the Gaffer Scene Inspector seems quite useful.

Perhaps the Gaffer inspector should compute the bounding box and voxel counts explicitly, in addition to showing the metadata? That is pretty independent from this, but maybe we should have a plan for it before we merge this.