### PR TITLE
CI : Continue using Node16 for actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,12 @@ jobs:
 
     container: ${{ matrix.containerImage }}
 
+    env:
+      # GitHub have moved to running actions on Node20, which prevents them from
+      # running on CentOS 7. The below allows actions to continue running on Node16
+      # until October.
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,9 +94,9 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: ilammy/msvc-dev-cmd@v1.10.0
+    - uses: ilammy/msvc-dev-cmd@v1.12.1
       with:
         sdk: 10.0.17763.0
 
@@ -188,7 +188,7 @@ jobs:
        ${{ env.PACKAGE_COMMAND }} ${{ env.CORTEX_BUILD_NAME }}.${{env.PACKAGE_EXTENSION}} ${{ env.CORTEX_BUILD_NAME }}
       if: matrix.publish
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CORTEX_BUILD_NAME }}
         path: ${{ env.CORTEX_BUILD_NAME }}.${{ env.PACKAGE_EXTENSION }}


### PR DESCRIPTION
GitHub actions are now run on Node20 by default, but this requires glibc >=2.28 so actions no longer run in our CentOS 7 build container.

Setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true` allows us to continue using Node16 for the near future, but support for this may be removed in October...

https://github.blog/changelog/2024-05-17-updated-dates-for-actions-runner-using-node20-instead-of-node16-by-default/

This also updates the existing Node12 actions to the Node16 native versions used on Gaffer CI to silence a few additional warnings reported during the CI run.