### PR TITLE
ToMayaMeshConverter: Revert "ToMayaMeshConverter : No longer set normals"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@
 *.lib
 *.ilk
 *.exp
-.sconsign.dblite
+.sconsign*.dblite
 .sconf_temp
 .cproject
 .project

--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Fixes
 - USDScene :
   - Fixed round-tripping of colons in set names.
   - Fixed `hash()` to consider animation on ModelAPI extents when hashing the bound.
+- ToMayaMeshConverter : Reverted #1386 that no longer locked normals set on the Mesh from the scc to fix issues with Maya incorrectly recomputing normals as Vertex normals when they were originally computed as Face normals
 
 10.5.9.1 (relative to 10.5.9.0)
 ========

--- a/test/IECoreMaya/ParameterisedHolder.py
+++ b/test/IECoreMaya/ParameterisedHolder.py
@@ -286,6 +286,7 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		op = fnOP.getOp()
 
 		mesh = IECoreScene.MeshPrimitive.createBox( imath.Box3f( imath.V3f( -2, -2, -2 ), imath.V3f( 2, 3, 4 ) ) )
+		mesh[ "N" ] = IECoreScene.PrimitiveVariable( mesh[ "N" ].interpolation, mesh[ "N" ].expandedData() )
 		op.parameters()[ "input" ].setValue( mesh )
 		fnOP.setNodeValues()
 
@@ -300,13 +301,7 @@ class TestParameterisedHolder( IECoreMaya.TestCase ) :
 		op = fnOP.getOp()
 
 		mesh2 = op.parameters()["input"].getValue()
-
 		self.assertTrue( mesh2.arePrimitiveVariablesValid() )
-		# The ToMayaMeshConverter relies on Maya to calculate the normals
-		# whereas createBox uses indexed normals so we cannot include them
-		# in the comparison otherwise they will never be the same
-		del mesh[ "N" ]
-		del mesh2[ "N" ]
 		self.assertEqual( mesh2, mesh )
 
 	def testOpHolder( self ) :

--- a/test/IECoreMaya/ToMayaMeshConverterTest.py
+++ b/test/IECoreMaya/ToMayaMeshConverterTest.py
@@ -308,9 +308,6 @@ class ToMayaMeshConverterTest( IECoreMaya.TestCase ) :
 				self.assertAlmostEqual( origNormal[j], normal3f[j], 6 )
 				self.assertAlmostEqual( origNormal[j], normal3d[j], 6 )
 
-		# normals should always be unlocked when reading from scc
-		self.assertFalse( any( maya.cmds.polyNormalPerVertex( newSphere+".vtx[*]", query=True, allLocked=True ) ) )
-
 	def testSetMeshInterpolation( self ) :
 
 		sphere = maya.cmds.polySphere( subdivisionsX=10, subdivisionsY=5, constructionHistory=False )


### PR DESCRIPTION
This reverts #1386 since not setting the normals is causing more problems than it solves. I have also added a small change to the gitignore to ignore all `sconsdblite` files.

### Related Issues ###

- This solves an issue introduced by #1386 where by not setting the normals explicitly, Maya may recompute the normals incorrectly for hard surface models as a result of computing normals as Vertex normals instead of Face normals

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.