### PR TITLE
USDScene : Fix crash trying to write to an open stage

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ Fixes
 -----
 
 - USDScene :
+  - Fixed crash attempting to write to a file that is already open for reading. An exception is now thrown instead.
   - Fixed loading of skinned facevarying normals.
   - `lightLink` and `shadowLink` collections on UsdLuxLightAPI are no longer treated as sets.
 

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -793,11 +793,11 @@ class USDScene::IO : public RefCounted
 
 		static pxr::UsdStageRefPtr makeStage( const std::string &fileName, IndexedIO::OpenMode openMode )
 		{
+			pxr::UsdStageRefPtr stage;
 			switch( openMode )
 			{
 				case IndexedIO::Read : {
 					static const std::string g_stageCachePrefix( "stageCache:" );
-					pxr::UsdStageRefPtr stage;
 					if( boost::starts_with( fileName, g_stageCachePrefix ) )
 					{
 						// Get Id from filename of form "stageCache:{id}.usd"
@@ -811,17 +811,20 @@ class USDScene::IO : public RefCounted
 					{
 						stage = pxr::UsdStage::Open( fileName );
 					}
-					if( !stage )
-					{
-						throw IECore::Exception( boost::str( boost::format( "USDScene : Failed to open USD stage : '%1%'" ) % fileName ) );
-					}
-					return stage;
+					break;
 				}
 				case IndexedIO::Write :
-					return pxr::UsdStage::CreateNew( fileName );
+					stage = pxr::UsdStage::CreateNew( fileName );
+					break;
 				default:
 					throw Exception( "Unsupported OpenMode" );
 			}
+
+			if( !stage )
+			{
+				throw IECore::Exception( boost::str( boost::format( "USDScene : Failed to open USD stage : '%1%'" ) % fileName ) );
+			}
+			return stage;
 		}
 
 		std::string m_fileName;

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4359,5 +4359,17 @@ class USDSceneTest( unittest.TestCase ) :
 			with self.subTest( setName = setName ) :
 				self.assertEqual( root.readSet( setName ), IECore.PathMatcher( [ f"/set{setIndex}Member" ] ) )
 
+	def testWriteToOpenScene( self ) :
+
+		# Using posix-format filename, because Windows backslashes don't play nicely
+		# with `assertRaisesRegex()`.
+		fileName = ( pathlib.Path( self.temporaryDirectory() ) / "test.usda" ).as_posix()
+		IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		reader = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+		with self.assertRaisesRegex( RuntimeError, f"USDScene : Failed to open USD stage : '{fileName}'" ) :
+			IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
In this case, `UsdStage::CreateNew()` returns a null result, which we were dereferencing, leading to a crash. We now just throw an exception describing the problem instead.
