### PR TITLE
USD VolumeAlgo : Fix crash loading empty field

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.9.3)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed crash loading a Volume with an empty field.
 
 10.5.9.3 (relative to 10.5.9.2)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/VolumeAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/VolumeAlgo.cpp
@@ -98,8 +98,11 @@ IECore::ObjectPtr readVolume( pxr::UsdVolVolume &volume, pxr::UsdTimeCode time, 
 			continue;
 		}
 
-		ConstDataPtr fieldFileNameData = DataAlgo::fromUSD( fieldAsset.GetFilePathAttr(), time );
-		const std::string fieldFileName = static_cast<const StringData *>( fieldFileNameData.get() )->readable();
+		std::string fieldFileName;
+		if( auto fieldFileNameData = runTimeCast<const StringData>( DataAlgo::fromUSD( fieldAsset.GetFilePathAttr(), time ) ) )
+		{
+			fieldFileName = fieldFileNameData->readable();
+		}
 
 		if( fileName.empty() )
 		{

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4398,5 +4398,12 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertNotIn( "\\", vdbObject.fileName() )
 		self.assertTrue( pathlib.Path( vdbObject.fileName() ).is_file() )
 
+	@unittest.skipIf( not haveVDB, "No IECoreVDB" )
+	def testUsdVolVolumeWithEmptyField( self ) :
+
+		fileName = os.path.dirname( __file__ ) + "/data/volumeWithEmptyField.usda"
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		self.assertIsNone( root.child( "volume" ).readObject( 0 ) )
+
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/data/volumeWithEmptyField.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/volumeWithEmptyField.usda
@@ -1,0 +1,11 @@
+#usda 1.0
+
+def Volume "volume"
+{
+    custom rel field:density = </volume/density>
+
+    def OpenVDBAsset "density"
+    {
+    }
+}
+


### PR DESCRIPTION
If an attribute has no value, `DataAlgo::fromUSD()` returns `nullptr`, and we were dereferencing it. We could probably still use a `static_cast` here as long as we checked for null, since we don't expect anything but StringData when non-null. But since I failed to predict this outcome, I've gone belt-and-braces and used a `runTimeCast()`.
