### PR TITLE
USD PrimitiveAlgo : Fix crash loading skinned facevarying normals

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.9.4)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed crash loading skinned facevarying normals (bug introduced in 10.5.9.3).
 
 10.5.9.4 (relative to 10.5.9.3)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PrimitiveAlgo.cpp
@@ -351,7 +351,7 @@ bool computeFaceVaryingSkinnedNormals( pxr::UsdSkelSkinningQuery &skinningQuery,
 
 	Canceller::check( canceller );
 	pxr::VtArray<pxr::GfMatrix3d> invTransposeXforms( orderedXforms.size() );
-	for( size_t i = 0; i < xforms.size(); ++i )
+	for( size_t i = 0; i < orderedXforms.size(); ++i )
 	{
 		invTransposeXforms[i] = orderedXforms[i].ExtractRotationMatrix().GetInverse().GetTranspose();
 	}

--- a/contrib/IECoreUSD/test/IECoreUSD/data/skinnedFaceVaryingNormals.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/skinnedFaceVaryingNormals.usda
@@ -2,6 +2,8 @@
 (
     defaultPrim = "main"
     metersPerUnit = 0.01
+    startTimeCode = 1
+    endTimeCode = 24
     upAxis = "Y"
 )
 
@@ -33,11 +35,11 @@ def SkelRoot "main" (
             interpolation = "vertex"
         )
         uniform token[] skel:joints = ["joint1"]
-        rel skel:skeleton = </main/joint1>
+        rel skel:skeleton = </main/skel>
         uniform token subdivisionScheme = "none"
     }
 
-    def Skeleton "joint1" (
+    def Skeleton "skel" (
         prepend apiSchemas = ["SkelBindingAPI"]
         customData = {
             dictionary Maya = {
@@ -49,7 +51,7 @@ def SkelRoot "main" (
         uniform matrix4d[] bindTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
         uniform token[] joints = ["joint1"]
         uniform matrix4d[] restTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
-        rel skel:animationSource = </main/joint1/anim>
+        rel skel:animationSource = </main/skel/anim>
 
         def SkelAnimation "anim"
         {

--- a/contrib/IECoreUSD/test/IECoreUSD/data/skinnedFaceVaryingNormals.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/skinnedFaceVaryingNormals.usda
@@ -48,9 +48,9 @@ def SkelRoot "main" (
         }
     )
     {
-        uniform matrix4d[] bindTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
-        uniform token[] joints = ["joint1"]
-        uniform matrix4d[] restTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
+        uniform matrix4d[] bindTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) ), ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
+        uniform token[] joints = ["joint1", "joint2"]
+        uniform matrix4d[] restTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) ), ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
         rel skel:animationSource = </main/skel/anim>
 
         def SkelAnimation "anim"


### PR DESCRIPTION
The call to `skinningQuery.GetJointMapper()` can not only reorder transforms but can also omit them. This occurs when SkelBindingAPI uses a `skel:joints` attribute to bind a mesh to a subset of joints, allowing the weights for other joints to be omitted. We were assuming that the mapped transform array had the same length as the input array, and were running off the end of the array.