### PR TITLE
IECoreUSD::PointInstancerAlgo : Support inactive / invisible ids

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,9 @@
 10.5.x.x (relative to 10.5.9.5)
 ========
 
-
+Improvements
+------------
+- USDScene : PointInstancers are now loaded with invisibleIds and inactiveIds as primitive variables.
 
 10.5.9.5 (relative to 10.5.9.4)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
@@ -86,8 +86,6 @@ IECore::ObjectPtr readPointInstancer( pxr::UsdGeomPointInstancer &pointInstancer
 	Canceller::check( canceller );
 	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetAngularVelocitiesAttr(), time, newPoints.get(), "angularVelocity" );
 
-	std::vector<double> times;
-	pointInstancer.GetInvisibleIdsAttr().GetTimeSamples( &times );
 	if( pointInstancer.GetInvisibleIdsAttr().HasAuthoredValue() )
 	{
 		DataPtr cortexInvisIds = DataAlgo::fromUSD( pointInstancer.GetInvisibleIdsAttr(), time, true );


### PR DESCRIPTION
This is a pretty naive implementation of loading inactiveIds and invisibleIds as prim vars, but everything seems to work.

Haven't yet used this to recreate the correct behaviour in Gaffer, but all the relevant data seems to be coming through.