### PR TITLE
OpenImageIOAlgo::DataView : Support 64 bit integer data variants

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.10.0)
 ========
 
+Improvements
+------------
 
+- OpenImageIOAlgo::DataView : Added support for Int64Data, UInt64Data, Int64VectorData and UInt64VectorData.
 
 10.5.10.0 (relative to 10.5.9.5)
 =========

--- a/src/IECoreImage/OpenImageIOAlgo.cpp
+++ b/src/IECoreImage/OpenImageIOAlgo.cpp
@@ -347,6 +347,14 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 			type = TypeDesc::TypeInt;
 			data = static_cast<const IntData *>( d )->baseReadable();
 			break;
+		case UInt64DataTypeId :
+			type = TypeDesc::UINT64;
+			data = static_cast<const UInt64Data *>( d )->baseReadable();
+			break;
+		case Int64DataTypeId :
+			type = TypeDesc::INT64;
+			data = static_cast<const Int64Data *>( d )->baseReadable();
+			break;
 		case FloatDataTypeId :
 			type = TypeDesc::TypeFloat;
 			data = static_cast<const FloatData *>( d )->baseReadable();
@@ -470,6 +478,24 @@ DataView::DataView( const IECore::Data *d, bool createUStrings )
 				static_cast<const UIntVectorData *>( d )->readable().size()
 			);
 			data = static_cast<const UIntVectorData *>( d )->baseReadable();
+			break;
+		case UInt64VectorDataTypeId :
+			type = TypeDesc(
+				TypeDesc::UINT64,
+				TypeDesc::SCALAR,
+				TypeDesc::NOSEMANTICS,
+				static_cast<const UInt64VectorData *>( d )->readable().size()
+			);
+			data = static_cast<const UInt64VectorData *>( d )->baseReadable();
+			break;
+		case Int64VectorDataTypeId :
+			type = TypeDesc(
+				TypeDesc::INT64,
+				TypeDesc::SCALAR,
+				TypeDesc::NOSEMANTICS,
+				static_cast<const Int64VectorData *>( d )->readable().size()
+			);
+			data = static_cast<const Int64VectorData *>( d )->baseReadable();
 			break;
 		case CharVectorDataTypeId :
 			type = TypeDesc(


### PR DESCRIPTION
Needed to allow OSLObject in Gaffer to read Int64VectorData, as in `instanceId`.