### PR TITLE
MeshAlgo::MeshSplitter : Preserve vertex order

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,6 +8,11 @@ Improvements
 - IECoreHoudini : Updated to support Houdini 20.0 and 20.5.
 - IECoreMaya : Avoid compilation warnings with new gcc.
 
+Fixes
+-----
+
+- MeshAlgo::MeshSplitter/segment : Fixed so that we now preserve vertex order while splitting. This matches the old behvaviour before 1.4.6.0 when segment was optimized. This doesn't affect the correctness of the result, but is a better convention to match user expectations - when combining meshes followed by splitting, it's better if you get back the same vertex ids you started with.
+
 Build
 -----
 

--- a/test/IECoreScene/MeshAlgoSegmentTest.py
+++ b/test/IECoreScene/MeshAlgoSegmentTest.py
@@ -66,8 +66,8 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 		p12 = imath.V3f( 1, 2, 0 )
 		p22 = imath.V3f( 2, 2, 0 )
 
-		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p00, p10, p11, p01, p20, p21], IECore.GeometricData.Interpretation.Point ) )
-		self.assertEqual( segments[1]["P"].data, IECore.V3fVectorData( [p01, p11, p12, p02, p21, p22], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p00, p10, p20, p01, p11, p21], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( segments[1]["P"].data, IECore.V3fVectorData( [p01, p11, p21, p02, p12, p22], IECore.GeometricData.Interpretation.Point ) )
 
 	def testCanSegmentUsingStringPrimvar( self ) :
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 2 ) )
@@ -95,8 +95,8 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 		p12 = imath.V3f( 1, 2, 0 )
 		p22 = imath.V3f( 2, 2, 0 )
 
-		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p00, p10, p11, p01, p21, p22, p12], IECore.GeometricData.Interpretation.Point ) )
-		self.assertEqual( segments[1]["P"].data, IECore.V3fVectorData( [p10, p20, p21, p11, p01, p12, p02], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p00, p10, p01, p11, p21, p12, p22], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( segments[1]["P"].data, IECore.V3fVectorData( [p10, p20, p01, p11, p21, p02, p12], IECore.GeometricData.Interpretation.Point ) )
 
 	def testSegmentsFullyIfNoSegmentValuesGiven( self ) :
 		mesh = IECoreScene.MeshPrimitive.createPlane( imath.Box2f( imath.V2f( 0 ), imath.V2f( 2 ) ), imath.V2i( 2 ) )
@@ -130,8 +130,8 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 			s0 = segments[1]
 			s1 = segments[0]
 
-		self.assertEqual( s0["P"].data, IECore.V3fVectorData( [p00, p10, p11, p01, p21, p22, p12], IECore.GeometricData.Interpretation.Point ) )
-		self.assertEqual( s1["P"].data, IECore.V3fVectorData( [p10, p20, p21, p11, p01, p12, p02], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( s0["P"].data, IECore.V3fVectorData( [p00, p10, p01, p11, p21, p12, p22], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( s1["P"].data, IECore.V3fVectorData( [p10, p20, p01, p11, p21, p02, p12], IECore.GeometricData.Interpretation.Point ) )
 
 
 	def testRaisesExceptionIfSegmentKeysNotSameTypeAsPrimvar( self ) :
@@ -184,7 +184,7 @@ class MeshAlgoSegmentTest( unittest.TestCase ) :
 		p22 = imath.V3f( 2, 2, 0 )
 
 		self.assertEqual( len( segments ), 1 )
-		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p11, p21, p22, p12], IECore.GeometricData.Interpretation.Point ) )
+		self.assertEqual( segments[0]["P"].data, IECore.V3fVectorData( [p11, p21, p12, p22], IECore.GeometricData.Interpretation.Point ) )
 		self.assertEqual( segments[0]["s"].data, IECore.StringVectorData( ["b"] ) )
 
 


### PR DESCRIPTION
I feel like maybe I should have explained a bit more about the now-somewhat-odd interface to Reindexer, but maybe it doesn't matter since it's fully internal.

Maybe take a look and see if this makes sense to you?