### PR TITLE
Update DisplayDriverServer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 10.5.x.x (relative to 10.5.11.0)
 ========
 
+Features
+--------
+
+- IECoreImage::DisplayDriverServer: Adds option to display server to client driver to write to the same display driver.
 
 
 10.5.11.0 (relative to 10.5.10.0)

--- a/include/IECoreImage/DisplayDriverServer.h
+++ b/include/IECoreImage/DisplayDriverServer.h
@@ -92,7 +92,6 @@ class IECOREIMAGE_API DisplayDriverServer : public IECore::RunTimeTyped
 		static const PortRange &registeredPortRange( const std::string &name );
 
 	private:
-
 		// Session class
 		// Takes care of one client connection.
 		class Session;


### PR DESCRIPTION
Adds option to server and client driver to allow a 'merge' driver that shares a display driver to write to.

Create a map that is shared between server sessions that links a session id to a display driver. This allows multiple client drivers to write to the same display driver and thus the same catalogue in Gaffer.

I haven't added tests yet, but does the code look good so far?

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
