### PR TITLE
`repr` Infinity

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 10.5.x.x (relative to 10.5.11.0)
 ========
 
+Fixes
+-----
+
+- IECore : Fixed bug that was causing imath vectors and colors with values of `inf` / `std::numeric_limits<float>::infinity()` to be serialised in a way that could not be evaluated with `eval()`.
 
 
 10.5.11.0 (relative to 10.5.10.0)

--- a/src/IECorePython/IECoreBinding.cpp
+++ b/src/IECorePython/IECoreBinding.cpp
@@ -58,6 +58,14 @@ IECORE_POP_DEFAULT_VISIBILITY
 using namespace std;
 using namespace Imath;
 
+namespace
+{
+
+static std::string g_positiveInfString = "float( 'inf' )";
+static std::string g_negativeInfString = "-float( 'inf' )";
+
+}
+
 namespace IECorePython
 {
 
@@ -70,7 +78,18 @@ std::string repr<VEC>( VEC &x )\
 	s << "imath." << #VEC << "( ";\
 	for( unsigned i=0; i<VEC::dimensions(); i++ )\
 	{\
-		s << boost::lexical_cast<string>( x[i] );\
+		if constexpr( std::numeric_limits<VEC::BaseType>::has_infinity )\
+		{\
+			s << (\
+				x[i] == std::numeric_limits<VEC::BaseType>::infinity() ? g_positiveInfString :\
+				( x[i] == -std::numeric_limits<VEC::BaseType>::infinity() ? g_negativeInfString :\
+				boost::lexical_cast<std::string>( x[i] ) ) \
+			);\
+		}\
+		else\
+		{\
+			s << boost::lexical_cast<string>( x[i] );\
+		}\
 		if( i!=VEC::dimensions()-1 )\
 		{\
 			s << ", ";\
@@ -142,7 +161,18 @@ std::string repr<COL>( COL &x )\
 	s << "imath." << #COL << "( ";\
 	for( unsigned i=0; i<COL::dimensions(); i++ )\
 	{\
-		s << boost::lexical_cast<std::string>( x[i] );\
+		if constexpr( std::numeric_limits<COL::BaseType>::has_infinity )\
+		{\
+			s << (\
+				x[i] == std::numeric_limits<COL::BaseType>::infinity() ? g_positiveInfString :\
+				( x[i] == -std::numeric_limits<COL::BaseType>::infinity() ? g_negativeInfString :\
+				boost::lexical_cast<std::string>( x[i] ) ) \
+			);\
+		}\
+		else\
+		{\
+			s << boost::lexical_cast<string>( x[i] );\
+		}\
 		if( i!=COL::dimensions()-1 )\
 		{\
 			s << ", ";\

--- a/test/IECore/ReprTest.py
+++ b/test/IECore/ReprTest.py
@@ -60,6 +60,28 @@ class ReprTest( unittest.TestCase ) :
 		] :
 			self.assertTrue( type( v ) is type( eval( IECore.repr( v ) ) ) )
 			self.assertEqual( v, eval( IECore.repr( v ) ) )
+	
+	def testInfinity( self ) :
+
+		for v in [
+			# Python raises "OverflowError : bad numeric conversion : positive overflow"
+			# when passing `float( "inf" )` to `V2f``
+			imath.V2d( float( "inf" ), float( "inf" ) ),
+			imath.V3f( float( "inf" ), float( "inf" ), float( "inf" ) ),
+			imath.V3d( float( "inf" ), float( "inf" ), float( "inf" ) ),
+			imath.Color3f( float( "inf" ), float( "inf" ), float( "inf" ) ),
+			imath.Color4f( float( "inf" ), float( "inf" ), float( "inf" ), float( "inf" ) ),
+		] :
+			with self.subTest( v = v ) :
+				self.assertTrue( type( v ) is type( eval( IECore.repr( v ) ) ) )
+				self.assertEqual( v, eval( IECore.repr( v ) ) )
+
+				self.assertTrue( type( -v ) is type( eval( IECore.repr( -v ) ) ) )
+				self.assertEqual( -v, eval( IECore.repr( -v ) ) )
+
+				self.assertEqual( str( v ), "{}({})".format( type( v ).__name__, ", ".join( ["inf"] * v.dimensions() ) ) )
+				self.assertEqual( str( -v ), "{}({})".format( type( v ).__name__, ", ".join( ["-inf"] * v.dimensions() ) ) )
+
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
This fixes a bug where `imath` vectors and colors with values set to infinity were not `repr`-ing in a form that could then be `eval`-ed.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
