### PR TITLE
IECoreUSD : Load prototype paths inside a PointInstancer as relative

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.5.x.x (relative to 10.5.12.0)
 ========
 
+Features
+--------
+
+- PointInstancerAlgo : Added support for the env var IECOREUSD_POINTINSTANCER_RELATIVEPROTOTYPES. If this is set to "1", then when USD PointInstancers are loaded as point clouds, if they contain prototype paths beneath themselves in the hierarchy, those prototype paths will be loaded as relative paths, starting with "./". This aligns with how Gaffer will now handle prototype paths, and allows point instancers to be relocated in the hierarchy.
+
 Fixes
 -----
 

--- a/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
@@ -53,6 +53,19 @@ using namespace IECoreUSD;
 namespace
 {
 
+bool checkEnvFlag( const char *envVar, bool def )
+{
+	const char *value = getenv( envVar );
+	if( value )
+	{
+		return std::string( value ) != "0";
+	}
+	else
+	{
+		return def;
+	}
+}
+
 IECore::ObjectPtr readPointInstancer( pxr::UsdGeomPointInstancer &pointInstancer, pxr::UsdTimeCode time, const Canceller *canceller )
 {
 	pxr::VtVec3fArray pointsData;
@@ -108,16 +121,31 @@ IECore::ObjectPtr readPointInstancer( pxr::UsdGeomPointInstancer &pointInstancer
 
 	// Prototype paths
 
+	const static bool g_relativePrototypes = checkEnvFlag( "IECOREUSD_POINTINSTANCER_RELATIVE_PROTOTYPES", false );
+
 	pxr::SdfPathVector targets;
 	Canceller::check( canceller );
 	pointInstancer.GetPrototypesRel().GetForwardedTargets( &targets );
+
+	const pxr::SdfPath &primPath = pointInstancer.GetPath();
 
 	IECore::StringVectorDataPtr prototypeRootsData = new IECore::StringVectorData();
 	auto &prototypeRoots = prototypeRootsData->writable();
 	prototypeRoots.reserve( targets.size() );
 	for( const auto &t : targets )
 	{
-		prototypeRoots.push_back( t.GetString() );
+		if( !g_relativePrototypes || !t.HasPrefix( primPath ) )
+		{
+			prototypeRoots.push_back( t.GetString() );
+		}
+		else
+		{
+			// The ./ prefix shouldn't be necessary - we want to just use the absence of a leading
+			// slash to indicate relative paths. We can remove the prefix here once we deprecate the
+			// GAFFERSCENE_INSTANCER_EXPLICIT_ABSOLUTE_PATHS env var and have Gaffer always require a leading
+			// slash for absolute paths.
+			prototypeRoots.push_back( "./" + t.MakeRelativePath( primPath ).GetString() );
+		}
 	}
 
 	newPoints->variables["prototypeRoots"] = IECoreScene::PrimitiveVariable( IECoreScene::PrimitiveVariable::Constant, prototypeRootsData );

--- a/contrib/IECoreUSD/test/IECoreUSD/data/pointInstancerWeirdPrototypes.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/pointInstancerWeirdPrototypes.usda
@@ -1,0 +1,26 @@
+#usda 1.0
+(
+)
+
+def PointInstancer "inst" (
+	kind = "group"
+)
+{
+	point3f[] positions = [(0, 0, -20), (0, 0, -16), (0, 0, -12), (0, 0, -8), (0, 0, -4), (0, 0, 0), (0, 0, 4), (0, 0, 8), (0, 0, 12), (0, 0, 16)]
+	int[] protoIndices = [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+	rel prototypes = [ </inst/Prototypes/sphere>, </cube> ]
+
+	def Scope "Prototypes" (
+		kind = "group"
+	)
+	{
+		def Sphere "sphere"
+		{
+			double radius = 1
+		}
+	}
+}
+
+def Cube "cube"
+{
+}


### PR DESCRIPTION
This implements the approach to relative PointInstancer prototype paths we've discussed.

Known issues:
I've made this check whether GAFFERSCENE_INSTANCER_EXPLICITABSOLUTEPATHS, and use future-style relative paths if Gaffer supports them. It's probably weird to make this depend on a Gaffer env var ... should I just hardcode to prefix the paths with "./", and then we'll have to do another cleanup pass to fix this at some indeterminate point in the future?

I've currently made the env var to enable this "GAFFERUSD_POINTINSTANCER_RELATIVEPROTOTYPES". Since this ends up being implemented in Cortex, I guess it should be "IECOREUSD_POINTINSTANCER_RELATIVEPROTOTYPES"? Not that this is a distinction that users are likely to care about.
