### PR TITLE
IECoreVDB : Python bindings renamed from pyopenvdb to openvdb in later versions

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,21 @@
 10.5.x.x (relative to 10.5.13.0)
 ========
 
+Features
+--------
 
+- NanoBindConverter : Added new class providing interoperability between Boost Python bindings and NanoBind bindings.
+
+Improvements
+------------
+
+- IEcoreVDB : Support for the renamed python module `openvdb` in more recent versions of OpenVDB.
+
+Build
+-----
+
+- SConstruct :
+  - Added `NANOBIND_INCLUDE_PATH` option.
 
 10.5.13.0 (relative to 10.5.12.0)
 =========

--- a/SConstruct
+++ b/SConstruct
@@ -570,6 +570,18 @@ o.Add(
 	"",
 )
 
+o.Add(
+	"NANOBIND_INCLUDE_PATH",
+	"The path to the nanobind include directory.",
+	"",
+)
+
+o.Add(
+	"NANOBIND_LIB_PATH",
+	"The path to the nanobind lib directory.",
+	"",
+)
+
 # Build options
 
 o.Add(
@@ -2069,11 +2081,22 @@ vdbEnvPrepends = {
 	"LIBS" : ["openvdb$VDB_LIB_SUFFIX"],
 	"CXXFLAGS" : [
 		systemIncludeArgument, "$VDB_INCLUDE_PATH",
-		systemIncludeArgument, "$PYBIND11_INCLUDE_PATH",
 	]
 }
 
-vdbEnv.Prepend( **vdbEnvPrepends)
+if env[ "PYBIND11_INCLUDE_PATH" ] != "" :
+	vdbEnvPrepends["CXXFLAGS"].append( [ systemIncludeArgument, "$PYBIND11_INCLUDE_PATH" ] )
+
+if env[ "NANOBIND_INCLUDE_PATH" ] != "" :
+	vdbEnvPrepends["CXXFLAGS"].append( [ systemIncludeArgument, "$NANOBIND_INCLUDE_PATH" ] )
+
+vdbEnv.Prepend( **vdbEnvPrepends )
+
+if env[ "NANOBIND_LIB_PATH" ] != "" :
+	vdbEnvPrepends["LIBPATH"].append( "$NANOBIND_LIB_PATH" )
+
+if env[ "NANOBIND_INCLUDE_PATH" ] != "" :
+	vdbEnvPrepends["LIBS"].append( "nanobind-static" )
 
 vdbPythonModuleEnv = corePythonModuleEnv.Clone( **vdbEnvSets )
 vdbPythonModuleEnv.Prepend( **vdbEnvPrepends )

--- a/include/IECorePython/NanoBindConverter.h
+++ b/include/IECorePython/NanoBindConverter.h
@@ -1,0 +1,103 @@
+
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2025, Alex Fuller. All rights reserved.
+//  Copyright (c) 2024, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_NANOBINDCONVERTER_H
+#define IECOREPYTHON_NANOBINDCONVERTER_H
+
+#include "boost/python.hpp"
+
+#include "nanobind/nanobind.h"
+
+namespace IECorePython
+{
+
+// Registers `boost::python` converters for types
+// wrapped using nanobind.
+template<typename T>
+struct NanoBindConverter
+{
+
+	static void registerConverters()
+	{
+		boost::python::to_python_converter<T, ToNanoBind>();
+		boost::python::converter::registry::push_back(
+			&FromNanoBind::convertible,
+			&FromNanoBind::construct,
+			boost::python::type_id<T>()
+		);
+	}
+
+	private :
+
+		struct ToNanoBind
+		{
+			static PyObject *convert( const T &t )
+			{
+				nanobind::object o = nanobind::cast( t );
+				Py_INCREF( o.ptr() );
+				return o.ptr();
+			}
+		};
+
+		struct FromNanoBind
+		{
+
+			static void *convertible( PyObject *object )
+			{
+				nanobind::handle handle( object );
+				return nanobind::cast<T>( handle ) ? object : nullptr;
+			}
+
+			static void construct( PyObject *object, boost::python::converter::rvalue_from_python_stage1_data *data )
+			{
+				void *storage = ( ( boost::python::converter::rvalue_from_python_storage<T> * ) data )->storage.bytes;
+				T *t = new( storage ) T;
+				data->convertible = storage;
+
+				nanobind::handle handle( object );
+				*t = nanobind::cast<T>( handle );
+			}
+
+		};
+
+};
+
+} // namespace IECorePython
+
+#endif // IECOREPYTHON_NANOBINDCONVERTER_H
+

--- a/python/IECoreVDB/__init__.py
+++ b/python/IECoreVDB/__init__.py
@@ -41,7 +41,10 @@ import warnings
 # we use the warnings module to suppress these during the import
 with warnings.catch_warnings():
 	warnings.simplefilter("ignore")
-	import pyopenvdb
+	try:
+		import pyopenvdb
+	except:
+		import openvdb
 
 from ._IECoreVDB import *
 


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

- If `pyopenvdb` fails, try the renamed `openvdb` in later versions in a try/except.

### Related Issues ###

- NA

### Dependencies ###

- OpenVDB 12 (maybe 11?) but this change just adds support for the module rename, the old one will work.

### Breaking Changes ###

- NA

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
