### PR TITLE
Alembic MeshReader : Don't load invalid UVs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.13.1)
 ========
 
+Fixes
+-----
 
+- Alembic : Fixed crashes caused by invalid UVs.
 
 10.5.13.1 (relative to 10.5.13.0)
 =========

--- a/contrib/IECoreAlembic/src/IECoreAlembic/MeshReader.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/MeshReader.cpp
@@ -150,8 +150,23 @@ class MeshReader : public PrimitiveReader
 				}
 			}
 
-			PrimitiveVariable::Interpolation interpolation = PrimitiveReader::interpolation( uvs.getScope() );
-			primitive->variables["uv"] = PrimitiveVariable( interpolation, uvData, indexData );
+			const PrimitiveVariable primitiveVariable( PrimitiveReader::interpolation( uvs.getScope() ), uvData, indexData );
+			if( primitive->isPrimitiveVariableValid( primitiveVariable ) )
+			{
+				primitive->variables["uv"] = primitiveVariable;
+			}
+			else
+			{
+				IECore::msg(
+					IECore::Msg::Warning, "PrimitiveReader::readGeomParam",
+					boost::format(
+						"Ignoring invalid \"uv\" property on object \"%1%\" (size %2%, expected %3%)"
+					)
+						% uvs.getParent().getObject().getFullName()
+						% ( indexData ? indexData->readable().size() : uvData->readable().size() )
+						% primitive->variableSize( primitiveVariable.interpolation )
+				);
+			}
 		}
 
 };


### PR DESCRIPTION
If the UVs in the Alembic archive were malformed, we were creating invalid primitive variables, with incorrect data lengths. These then caused corruption when `reverseWinding()` ran off the end of the array.

