### PR TITLE
USDScene : Fix loading of instanced skinning with unique animation

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,11 @@ Improvements
 
 - USDScene : Added loading of ArnoldAlembic, ArnoldUsd and ArnoldProceduralCustom prims as Cortex ExternalProcedural objects.
 
+Fixes
+-----
+
+- USDScene : Fixed loading of instanced UsdSkel geometry with unique animation applied.
+
 10.5.14.1 (relative to 10.5.14.0)
 =========
 

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -71,6 +71,7 @@ IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usdShade/material.h"
 #include "pxr/usd/usdShade/materialBindingAPI.h"
 #include "pxr/usd/usdShade/connectableAPI.h"
+#include "pxr/usd/usdSkel/bindingAPI.h"
 #include "pxr/usd/usdUtils/stageCache.h"
 #ifdef IECOREUSD_WITH_OPENVDB
 #include "pxr/usd/usdVol/fieldBase.h"
@@ -1763,6 +1764,17 @@ void USDScene::objectHash( double time, IECore::MurmurHash &h ) const
 		if( ObjectAlgo::objectMightBeTimeVarying( m_location->prim ) )
 		{
 			h.append( time );
+		}
+		// Account for the skinning applied by PrimitiveAlgo. Ideally this
+		// responsibility would be taken on by PrimitiveAlgo itself, but that
+		// would require modifying the ObjectAlgo API, which we don't want to
+		// do right now.
+		if( auto skelBindingAPI = pxr::UsdSkelBindingAPI( m_location->prim ) )
+		{
+			if( auto animationSource = skelBindingAPI.GetInheritedAnimationSource() )
+			{
+				appendPrimOrMasterPath( animationSource, h );
+			}
 		}
 	}
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/data/instancedSkinning.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/instancedSkinning.usda
@@ -1,0 +1,129 @@
+#usda 1.0
+
+# A prototype containing a skeleton and a couple of cubes, one of them skinned.
+
+def Scope "Prototypes"
+{
+
+    uniform token visibility = "invisible"
+
+    def SkelRoot "SkeletonRoot" (
+        prepend apiSchemas = ["SkelBindingAPI"]
+    )
+    {
+        def Skeleton "Skeleton" (
+            prepend apiSchemas = ["SkelBindingAPI"]
+        )
+        {
+            uniform matrix4d[] bindTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
+            uniform token[] joints = ["Joint1"]
+            uniform matrix4d[] restTransforms = [( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )]
+        }
+
+        def Mesh "SkinnedCube" (
+            prepend apiSchemas = ["SkelBindingAPI"]
+        )
+        {
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            uniform token subdivisionScheme = "none"
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+            matrix4d primvars:skel:geomBindTransform = ( (1, 0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1) )
+            int[] primvars:skel:jointIndices = [0, 0, 0, 0, 0, 0, 0, 0] (
+                elementSize = 1
+                interpolation = "vertex"
+            )
+            float[] primvars:skel:jointWeights = [1, 1, 1, 1, 1, 1, 1, 1] (
+                elementSize = 1
+                interpolation = "vertex"
+            )
+            rel skel:skeleton = </Prototypes/SkeletonRoot/Skeleton>
+        }
+
+        # Just regular geometry. Even though it's inside a SkelRoot, it
+        # shouldn't be affected by SkelAnimation at all.
+        def Mesh "UnskinnedCube"
+        {
+            int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+            int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+            uniform token subdivisionScheme = "none"
+            point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+        }
+    }
+
+}
+
+# Instance of the prototype, with an animation inherited onto it.
+
+def Xform "Instance1" (
+    prepend apiSchemas = ["SkelBindingAPI"]
+)
+{
+	append rel skel:animationSource = </Instance1/InlineAnim>
+
+    def SkelAnimation "InlineAnim"
+    {
+        uniform token[] joints = ["Joint1"]
+        quatf[] rotations = [(1, 0, 0, 0)]
+        half3[] scales = [(1, 1, 1)]
+        float3[] translations = [(0, 0, 1)]
+    }
+
+	over "SkeletonRoot" (
+		instanceable = true
+		prepend references = </Prototypes/SkeletonRoot>
+	)
+	{
+	}
+}
+
+# Another instance of the prototype, with a different animation inherited onto it.
+
+def SkelAnimation "SeparateAnim"
+{
+	uniform token[] joints = ["Joint1"]
+    quatf[] rotations = [(1, 0, 0, 0)]
+    half3[] scales = [(1, 1, 1)]
+	float3[] translations = [(0, 0, -1)]
+}
+
+def Xform "Group" (
+    prepend apiSchemas = ["SkelBindingAPI"]
+)
+{
+	append rel skel:animationSource = </SeparateAnim>
+
+    def Xform "Instance2"
+    {
+        over "SkeletonRoot" (
+            instanceable = true
+            prepend references = </Prototypes/SkeletonRoot>
+        )
+        {
+        }
+    }
+}
+
+# A third instance, this time sharing the animation with the second instance.
+
+def Xform "Instance3" (
+    prepend apiSchemas = ["SkelBindingAPI"]
+)
+{
+    append rel skel:animationSource = </SeparateAnim>
+    over "SkeletonRoot" (
+        instanceable = true
+        prepend references = </Prototypes/SkeletonRoot>
+    )
+    {
+    }
+}
+
+# And now an instanceable reference to the third instance.
+
+def Xform "Instance4" (
+    instanceable = true
+    prepend references = </Instance3>
+)
+{
+}


### PR DESCRIPTION
The `skel:animationSource` can be inherited from ancestor prims, allowing instanced skeletons to receive unique animation. We need to account for that when generating the object hash, otherwise objects with distinct animation will falsely share a hash.

In the comment I've mentioned that ideally ObjectAlgo would be in charge of this hashing, but I'm not 100% sure that is the case. I have a prototype which does more accurate hashing using SdfPrimSpecs, and in that USDScene tracks an inherited hash to account for value clips. It may be that it would be better to track an inherited animation hash as well, which would be hard to delegate out to ObjectAlgo.
