### PR TITLE
USD CameraAlgo : Fix reading and writing of cameras without shutter values

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,7 +4,9 @@
 Fixes
 -----
 
-- USDScene : Fixed writing of shutter values from cameras without a `shutter` parameter. The `shutter:open` and `shutter:close` attributes are now omitted instead of being written with Cortex's default -0.5, 0.5 shutter values.
+- USDScene :
+  - Fixed writing of shutter values from cameras without a `shutter` parameter. The `shutter:open` and `shutter:close` attributes are now omitted instead of being written with Cortex's default -0.5, 0.5 shutter values.
+  - Fixed reading of shutter values from cameras without `shutter:open` and `shutter:close` attributes. The `shutter` parameter is now omitted instead of being created with USD's default 0, 0 shutter values.
 
 10.5.x.x (relative to 10.5.15.0)
 ========

--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.x.x.x (relative to 10.5.x.x)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed writing of shutter values from cameras without a `shutter` parameter. The `shutter:open` and `shutter:close` attributes are now omitted instead of being written with Cortex's default -0.5, 0.5 shutter values.
 
 10.5.x.x (relative to 10.5.15.0)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/CameraAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/CameraAlgo.cpp
@@ -111,9 +111,14 @@ IECore::ObjectPtr readCamera( pxr::UsdGeomCamera &camera, pxr::UsdTimeCode time,
 	result->setFocusDistance( focusDistance );
 
 	Imath::V2d shutter;
-	camera.GetShutterOpenAttr().Get( &shutter[0], time );
-	camera.GetShutterCloseAttr().Get( &shutter[1], time );
-	result->setShutter( shutter );
+	auto shutterOpenAttr = camera.GetShutterOpenAttr();
+	auto shutterCloseAttr = camera.GetShutterCloseAttr();
+	if( shutterOpenAttr.HasAuthoredValue() || shutterCloseAttr.HasAuthoredValue() )
+	{
+		shutterOpenAttr.Get( &shutter[0], time );
+		shutterCloseAttr.Get( &shutter[1], time );
+		result->setShutter( shutter );
+	}
 
 	return result;
 }

--- a/contrib/IECoreUSD/src/IECoreUSD/CameraAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/CameraAlgo.cpp
@@ -188,14 +188,17 @@ bool writeCamera( const IECoreScene::Camera *camera, const pxr::UsdStagePtr &sta
 	usdCamera.GetFStopAttr().Set( camera->getFStop() );
 	usdCamera.GetFocusDistanceAttr().Set( camera->getFocusDistance() );
 
-	/// \todo This is documented as being specified in UsdTimeCode units,
-	/// in which case I think we should be converting from seconds using
-	/// `stage->GetTimeCodesPerSecond()`. Having looked at both the Maya
-	/// and Houdini plugin sources, I've been unable to find evidence for
-	/// anyone else doing this though, so maybe it's one of those things
-	/// everyone is just getting wrong?
-	usdCamera.GetShutterOpenAttr().Set( (double)camera->getShutter()[0] );
-	usdCamera.GetShutterCloseAttr().Set( (double)camera->getShutter()[1] );
+	if( camera->hasShutter() )
+	{
+		/// \todo This is documented as being specified in UsdTimeCode units,
+		/// in which case I think we should be converting from seconds using
+		/// `stage->GetTimeCodesPerSecond()`. Having looked at both the Maya
+		/// and Houdini plugin sources, I've been unable to find evidence for
+		/// anyone else doing this though, so maybe it's one of those things
+		/// everyone is just getting wrong?
+		usdCamera.GetShutterOpenAttr().Set( (double)camera->getShutter()[0] );
+		usdCamera.GetShutterCloseAttr().Set( (double)camera->getShutter()[1] );
+	}
 
 	return true;
 }

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1400,6 +1400,7 @@ class USDSceneTest( unittest.TestCase ) :
 			self.assertEqual( c2.getClippingPlanes(), c.getClippingPlanes() )
 			self.assertEqual( c2.getFStop(), c.getFStop() )
 			self.assertEqual( c2.getFocusDistance(), c.getFocusDistance() )
+			self.assertEqual( c2.hasShutter(), c.hasShutter() )
 			self.assertEqual( c2.getShutter(), c.getShutter() )
 
 			assertVectorsAlmostEqual( c2.frustum().min(), c.frustum().min(), places = 6 )

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -1285,6 +1285,13 @@ class USDSceneTest( unittest.TestCase ) :
 			name = formatCameraName( scale = scale )
 			testCameras[name] = c
 
+		for shutterOpen in [ 0, -0.25, -1.0 ] :
+			for shutterClose in [ 0, 0.25, 1.0 ] :
+				c = IECoreScene.Camera()
+				c.setShutter( imath.V2f( shutterOpen, shutterClose ) )
+				name = formatCameraName( shutterOpen = shutterOpen, shutterClose = shutterClose )
+				testCameras[name] = c
+
 		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
 
 		for name, c in testCameras.items() :
@@ -1321,8 +1328,12 @@ class USDSceneTest( unittest.TestCase ) :
 			self.assertEqual( c.clippingRange.max, cortexCam.getClippingPlanes()[1] )
 			self.assertEqual( c.fStop, cortexCam.getFStop() )
 			self.assertEqual( c.focusDistance, cortexCam.getFocusDistance() )
-			self.assertEqual( cG.GetShutterOpenAttr().Get(), cortexCam.getShutter()[0] )
-			self.assertEqual( cG.GetShutterCloseAttr().Get(), cortexCam.getShutter()[1] )
+			if cortexCam.hasShutter() :
+				self.assertEqual( cG.GetShutterOpenAttr().Get(), cortexCam.getShutter()[0] )
+				self.assertEqual( cG.GetShutterCloseAttr().Get(), cortexCam.getShutter()[1] )
+			else :
+				self.assertFalse( cG.GetShutterOpenAttr().HasAuthoredValue() )
+				self.assertFalse( cG.GetShutterCloseAttr().HasAuthoredValue() )
 
 			try :
 				from pxr import CameraUtil


### PR DESCRIPTION
This improves how we deal with the camera shutter when reading and writing cameras to USD. Previously we'd always read/write shutter values even if the shutter wasn't authored, which resulted in baking in either Cortex's default shutter value when writing a camera with no shutter to USD, or USD's default shutter value when reading a camera with no shutter from USD. This would make it hard to USD round-trip cameras without a shutter parameter, as they'd come back in with a baked-in `-0.5, 0.5` shutter, and reading cameras authored in other DCCs with no `shutter:open` and `shutter:close` attributes would result in a shutter parameter of `0, 0` as noted by @masterkeech in [Gaffer #6431](https://github.com/GafferHQ/gaffer/issues/6431).

While this is a fix and I've currently made this PR to `RB-10.5`, this is a change in behaviour and would be better held back for a major Gaffer release though we've yet to make a call on how to handle Cortex across the upcoming Gaffer 1.5/1.6 transition so I've marked this as draft while we figure that out...