### PR TITLE
USDScene : Use `extentsHint` to load bounds when `prim.IsModel()`

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.15.0)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed reading of bounds from prims with `extentsHint` and model `kind` but without UsdGeomModelAPI applied.
 
 10.5.15.0 (relative to 10.5.14.1)
 =========

--- a/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/USDScene.cpp
@@ -627,7 +627,8 @@ pxr::UsdAttribute boundAttribute( const pxr::UsdPrim &prim )
 
 	if( g_useModelAPIBounds )
 	{
-		if( auto modelAPI = pxr::UsdGeomModelAPI( prim ) )
+		pxr::UsdGeomModelAPI modelAPI( prim );
+		if( modelAPI || prim.IsModel() )
 		{
 			return modelAPI.GetExtentsHintAttr();
 		}

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4413,9 +4413,16 @@ class USDSceneTest( unittest.TestCase ) :
 		pxr.UsdGeom.Xform.Define( stage, "/withoutModelAPI" )
 		pxr.UsdGeom.Xform.Define( stage, "/withModelAPI" )
 		pxr.UsdGeom.Xform.Define( stage, "/withModelAPIAndExtent" )
+		pxr.UsdGeom.Xform.Define( stage, "/withKind" )
+		pxr.UsdGeom.Xform.Define( stage, "/withKindAndExtent" )
 
 		pxr.UsdGeom.ModelAPI.Apply( stage.GetPrimAtPath( "/withModelAPI" ) )
 		modelAPI = pxr.UsdGeom.ModelAPI.Apply( stage.GetPrimAtPath( "/withModelAPIAndExtent" ) )
+		modelAPI.SetExtentsHint( [ ( 1, 2, 3 ), ( 4, 5, 6 ) ] )
+
+		stage.GetPrimAtPath( "/withKind" ).SetKind( "group" )
+		stage.GetPrimAtPath( "/withKindAndExtent" ).SetKind( "group" )
+		modelAPI = pxr.UsdGeom.ModelAPI( stage.GetPrimAtPath( "/withKindAndExtent" ) )
 		modelAPI.SetExtentsHint( [ ( 1, 2, 3 ), ( 4, 5, 6 ) ] )
 
 		stage.GetRootLayer().Save()
@@ -4428,6 +4435,9 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertFalse( root.child( "withModelAPI" ).hasBound() )
 		self.assertTrue( root.child( "withModelAPIAndExtent" ).hasBound() )
 		self.assertEqual( root.child( "withModelAPIAndExtent" ).readBound( 0 ), imath.Box3d( imath.V3d( 1, 2, 3 ), imath.V3d( 4, 5, 6 ) ) )
+		self.assertFalse( root.child( "withKind" ).hasBound() )
+		self.assertTrue( root.child( "withKindAndExtent" ).hasBound() )
+		self.assertEqual( root.child( "withKindAndExtent" ).readBound( 0 ), imath.Box3d( imath.V3d( 1, 2, 3 ), imath.V3d( 4, 5, 6 ) ) )
 
 	def testAnimatedModelBound( self ) :
 


### PR DESCRIPTION
Even if the UsdGeomModelAPI that provides that attribute has not been applied. This allows us to load the bounds from certain assets exported from certain DCCs. It also follows the behaviour of UsdGeomBBoxCache, where `_UseExtentsHintForPrim()` checks `prim.IsModel()` but doesn't check the for the application of the API.
