### PR TITLE
IECoreScene Camera : Add depthOfField accessors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.x.x.x (relative to 10.5.x.x)
 ========
 
+Improvements
+------------
+
+- IECoreScene::Camera : Added "depthOfField" parameter accessors.
+
 Fixes
 -----
 

--- a/include/IECoreScene/Camera.h
+++ b/include/IECoreScene/Camera.h
@@ -210,6 +210,13 @@ class IECORESCENE_API Camera : public PreWorldRenderable
 		void setShutter( const Imath::V2f &shutter );
 		void removeShutter();
 
+		/// Override whether the camera should render with depth of field blur. The amount of blur
+		/// can be controlled from the fStop parameter.
+		bool hasDepthOfField() const;
+		bool getDepthOfField() const;
+		void setDepthOfField( const bool &depthOfField );
+		void removeDepthOfField();
+
 		/// Given window with an arbitrary aspect, compute a box that fits it with a particular fit mode,
 		/// to achieve a desired target aspect ratio.
 		static Imath::Box2f fitWindow( const Imath::Box2f &window, Camera::FilmFit fitMode, float targetAspect );

--- a/src/IECoreScene/Camera.cpp
+++ b/src/IECoreScene/Camera.cpp
@@ -263,6 +263,7 @@ DECLARE_ACCESSORS_FOR_OPTIONAL( OverscanTop, "overscanTop", FloatData, 0.0f );
 DECLARE_ACCESSORS_FOR_OPTIONAL( OverscanBottom, "overscanBottom", FloatData, 0.0f );
 DECLARE_ACCESSORS_FOR_OPTIONAL( CropWindow, "cropWindow", Box2fData, Box2f() );
 DECLARE_ACCESSORS_FOR_OPTIONAL( Shutter, "shutter", V2fData, V2f( -0.5f, 0.5f ) );
+DECLARE_ACCESSORS_FOR_OPTIONAL( DepthOfField, "depthOfField", BoolData, false );
 
 namespace {
 

--- a/src/IECoreScene/bindings/CameraBinding.cpp
+++ b/src/IECoreScene/bindings/CameraBinding.cpp
@@ -150,6 +150,11 @@ void bindCamera()
 		.def( "getShutter", &Camera::getShutter )
 		.def( "removeShutter", &Camera::removeShutter )
 
+		.def( "hasDepthOfField", &Camera::hasDepthOfField )
+		.def( "setDepthOfField", &Camera::setDepthOfField )
+		.def( "getDepthOfField", &Camera::getDepthOfField )
+		.def( "removeDepthOfField", &Camera::removeDepthOfField )
+
 		.def( "fitWindow", &Camera::fitWindow ).staticmethod( "fitWindow" )
 		.def<Imath::Box2f (Camera::*)() const>( "frustum", &Camera::frustum )
 		.def<Imath::Box2f (Camera::*)(Camera::FilmFit) const>( "frustum", &Camera::frustum )

--- a/test/IECoreScene/Camera.py
+++ b/test/IECoreScene/Camera.py
@@ -163,6 +163,7 @@ class TestCamera( unittest.TestCase ) :
 		self.assertEqual( c.hasOverscanBottom(), False )
 		self.assertEqual( c.hasCropWindow(), False )
 		self.assertEqual( c.hasShutter(), False )
+		self.assertEqual( c.hasDepthOfField(), False )
 
 		c.setFilmFit( IECoreScene.Camera.FilmFit.Vertical )
 		c.setResolution( imath.V2i( 1280, 720 ) )
@@ -175,6 +176,7 @@ class TestCamera( unittest.TestCase ) :
 		c.setOverscanBottom( 0.4 )
 		c.setCropWindow( imath.Box2f( imath.V2f( 0.1, 0.2 ), imath.V2f( 0.8, 0.9 ) ) )
 		c.setShutter( imath.V2f( -0.7, 0.3 ) )
+		c.setDepthOfField( True )
 
 		self.assertEqual( c.hasFilmFit(), True )
 		self.assertEqual( c.hasResolution(), True )
@@ -187,6 +189,7 @@ class TestCamera( unittest.TestCase ) :
 		self.assertEqual( c.hasOverscanBottom(), True )
 		self.assertEqual( c.hasCropWindow(), True )
 		self.assertEqual( c.hasShutter(), True )
+		self.assertEqual( c.hasDepthOfField(), True )
 
 		self.assertEqual( c.getFilmFit(), IECoreScene.Camera.FilmFit.Vertical )
 		self.assertEqual( c.getResolution(), imath.V2i( 1280, 720 ) )
@@ -199,6 +202,7 @@ class TestCamera( unittest.TestCase ) :
 		self.assertAlmostEqual( c.getOverscanBottom(), 0.4 )
 		self.assertBox2fEqual( c.getCropWindow(), 0.1, 0.2, 0.8, 0.9 )
 		self.assertAlmostEqual( c.getShutter(), imath.V2f( -0.7, 0.3 ) )
+		self.assertEqual( c.getDepthOfField(), True )
 
 		c.removeFilmFit()
 		c.removeResolution()
@@ -211,6 +215,7 @@ class TestCamera( unittest.TestCase ) :
 		c.removeOverscanBottom()
 		c.removeCropWindow()
 		c.removeShutter()
+		c.removeDepthOfField()
 
 		self.assertEqual( c.hasFilmFit(), False )
 		self.assertEqual( c.hasResolution(), False )
@@ -223,6 +228,7 @@ class TestCamera( unittest.TestCase ) :
 		self.assertEqual( c.hasOverscanBottom(), False )
 		self.assertEqual( c.hasCropWindow(), False )
 		self.assertEqual( c.hasShutter(), False )
+		self.assertEqual( c.hasDepthOfField(), False )
 
 	def testHash( self ) :
 		c = IECoreScene.Camera()


### PR DESCRIPTION
Adding these allow us to address a longstanding todo in Gaffer that will simplify handling of applying depth of field from the globals to a camera.