### PR TITLE
Remove `IECORE_RTLD_GLOBAL` environment variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,6 @@ jobs:
       run: |
         scons ${{ matrix.tests }} BUILD_TYPE=${{ matrix.buildType }} OPTIONS=${{ matrix.options }} BUILD_CACHEDIR=sconsCache
       env:
-        IECORE_RTLD_GLOBAL: 0
         OCIO: ${{ env.CORTEX_BUILD_NAME }}/openColorIO/config.ocio
 
     - name: Build Package

--- a/.github/workflows/main/options.posix
+++ b/.github/workflows/main/options.posix
@@ -59,7 +59,7 @@ USD_LIB_PREFIX = "usd_"
 # Environment
 # ===========
 
-ENV_VARS_TO_IMPORT = "PATH CI IECORE_RTLD_GLOBAL"
+ENV_VARS_TO_IMPORT = "PATH CI"
 
 if platform.system() == "Darwin" :
 	os.environ["DYLD_FRAMEWORK_PATH"] = libs

--- a/Changes
+++ b/Changes
@@ -15,6 +15,7 @@ Breaking Changes
 - IECoreHoudini : Removed.
 - IECoreMaya : Removed.
 - IECoreNuke : Removed.
+- Removed support for `IECORE_RTLD_GLOBAL` environment variable.
 
 10.5.x.x (relative to 10.5.15.0)
 ========

--- a/config/ie/options
+++ b/config/ie/options
@@ -626,7 +626,6 @@ envVarsToImport = [
     "OCIO",
     "IECORE_DEBUG_WAIT",
     "CORTEX_PERFORMANCE_TEST",
-    "IECORE_RTLD_GLOBAL",
 ]
 
 ENV_VARS_TO_IMPORT = " ".join(envVarsToImport)

--- a/python/IECore/__init__.py
+++ b/python/IECore/__init__.py
@@ -38,23 +38,7 @@
 #
 # Some parts of the IECore library are defined purely in Python. These are shown below.
 
-import os, sys, ctypes, pathlib
-if os.name == "posix" and os.environ.get( "IECORE_RTLD_GLOBAL", "1" ) == "1" :
-	# Historically, we had problems with cross-module RTTI on Linux, whereby
-	# different Python modules and/or libraries could end up with their own
-	# copies of symbols, which would break things like dynamic casts. We worked
-	# around this by using RTLD_GLOBAL so that everything was loaded into the
-	# global symbol table and shared, but this can cause hard-to-diagnose
-	# knock-on effects from unwanted sharing.
-	#
-	# We now manage symbol visibility properly so that RTTI symbols should not
-	# be duplicated between modules, and we intend to remove RTLD_GLOBAL. To aid
-	# the transition, this behaviour can be controlled by the
-	# `IECORE_RTLD_GLOBAL` environment variable, which currently defaults on.
-	## \todo Get everything tested, default to off, and then remove.
-	sys.setdlopenflags(
-		sys.getdlopenflags() | ctypes.RTLD_GLOBAL
-	)
+import os, pathlib
 
 if hasattr( os, "add_dll_directory" ) and "IECORE_DLL_DIRECTORIES" in os.environ :
 	for directory in os.environ.get( "IECORE_DLL_DIRECTORIES" ).split( os.pathsep ) :
@@ -64,7 +48,7 @@ if hasattr( os, "add_dll_directory" ) and "IECORE_DLL_DIRECTORIES" in os.environ
 	del directory
 
 # Remove pollution of IECore namespace
-del os, sys, ctypes, pathlib
+del os, pathlib
 
 __import__( "imath" )
 


### PR DESCRIPTION
Historically this was used to work around cross-module RTTI problems on Linux, but hasn't been used in Gaffer since 1.3.0.0, and I believe ceased to be used at Image Engine before that even.
