### PR TITLE
SConstruct : Install "private" headers

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.5.x.x (relative to 10.5.15.1)
 ========
 
+API
+---
 
+- SConstruct : Install "private" headers.
 
 10.5.15.1 (relative to 10.5.15.0)
 =========

--- a/SConstruct
+++ b/SConstruct
@@ -1907,6 +1907,7 @@ if doConfigure :
 		# source list
 		imageSources = sorted( glob.glob( "src/IECoreImage/*.cpp" ) )
 		imageHeaders = sorted( glob.glob( "include/IECoreImage/*.h" ) + glob.glob( "include/IECoreImage/*.inl" ) )
+		imagePrivateHeaders =  glob.glob( "include/IECoreImage/Private/*.h" )
 		imagePythonHeaders = sorted( glob.glob( "include/IECoreImageBindings/*.h" ) + glob.glob( "include/IECoreImageBindings/*.inl" ) )
 		imagePythonSources = sorted( glob.glob( "src/IECoreImageBindings/*.cpp" ) )
 		imagePythonModuleSources = sorted( glob.glob( "src/IECoreImageModule/*.cpp" ) )
@@ -1930,10 +1931,12 @@ if doConfigure :
 
 		# headers
 		imageHeaderInstall = imageEnv.Install( "$INSTALL_HEADER_DIR/IECoreImage", imageHeaders )
+		imagePrivateHeaderInstall = imageEnv.Install( "$INSTALL_HEADER_DIR/IECoreImage/Private", imagePrivateHeaders )
+
 		if env[ "INSTALL_CREATE_SYMLINKS" ] :
 			imageEnv.AddPostAction( "$INSTALL_HEADER_DIR/IECoreImage", lambda target, source, env : makeSymLinks( imageEnv, imageEnv["INSTALL_HEADER_DIR"] ) )
-		imageEnv.Alias( "install", imageHeaderInstall )
-		imageEnv.Alias( "installImage", imageHeaderInstall )
+		imageEnv.Alias( "install", [ imageHeaderInstall, imagePrivateHeaderInstall ] )
+		imageEnv.Alias( "installImage", [ imageHeaderInstall, imagePrivateHeaderInstall ] )
 
 		# python headers
 		imagePythonHeaderInstall = imageEnv.Install( "$INSTALL_HEADER_DIR/IECoreImageBindings", imagePythonHeaders )
@@ -1990,6 +1993,7 @@ scenePythonModuleEnv = corePythonModuleEnv.Clone( IECORE_NAME="IECoreScene" )
 
 sceneSources = sorted( glob.glob( "src/IECoreScene/*.cpp" ) )
 sceneHeaders = glob.glob( "include/IECoreScene/*.h" ) + glob.glob( "include/IECoreScene/*.inl" )
+scenePrivateHeaders =  glob.glob( "include/IECoreScene/private/*.h" )
 scenePythonModuleSources = sorted( glob.glob( "src/IECoreScene/bindings/*.cpp" ) )
 scenePythonScripts = glob.glob( "python/IECoreScene/*.py" )
 
@@ -2018,10 +2022,11 @@ if doConfigure :
 
 	# headers
 	sceneHeaderInstall = sceneEnv.Install( "$INSTALL_HEADER_DIR/IECoreScene", sceneHeaders )
+	scenePrivateHeaderInstall = sceneEnv.Install( "$INSTALL_HEADER_DIR/IECoreScene/private", scenePrivateHeaders )
 	if env[ "INSTALL_CREATE_SYMLINKS" ] :
 		sceneEnv.AddPostAction( "$INSTALL_HEADER_DIR/IECoreScene", lambda target, source, env : makeSymLinks( sceneEnv, sceneEnv["INSTALL_HEADER_DIR"] ) )
-	sceneEnv.Alias( "install", sceneHeaderInstall )
-	sceneEnv.Alias( "installScene", sceneHeaderInstall )
+	sceneEnv.Alias( "install", [ sceneHeaderInstall, scenePrivateHeaderInstall ] )
+	sceneEnv.Alias( "installScene", [ sceneHeaderInstall, scenePrivateHeaderInstall ] )
 
 	# python module
 	scenePythonModuleEnv.Append( LIBS = os.path.basename( sceneEnv.subst( "$INSTALL_LIB_NAME" ) ) )
@@ -2256,11 +2261,13 @@ if env["WITH_GL"] and doConfigure :
 		glEnv.Alias( "installLib", [ glLibraryInstall ] )
 
 		glHeaders = glob.glob( "include/IECoreGL/*.h" ) + glob.glob( "include/IECoreGL/*.inl" )
+		glPrivateHeaders = glob.glob( "include/IECoreGL/private/*.h" )
 		glHeaderInstall = glEnv.Install( "$INSTALL_HEADER_DIR/IECoreGL", glHeaders )
+		glPrivateHeaderInstall = glEnv.Install( "$INSTALL_HEADER_DIR/IECoreGL/private", glPrivateHeaders )
 		if env[ "INSTALL_CREATE_SYMLINKS" ] :
 			glEnv.AddPostAction( "$INSTALL_HEADER_DIR/IECoreGL", lambda target, source, env : makeSymLinks( glEnv, glEnv["INSTALL_HEADER_DIR"] ) )
-		glEnv.Alias( "install", glHeaderInstall )
-		glEnv.Alias( "installGL", glHeaderInstall )
+		glEnv.Alias( "install", [ glHeaderInstall, glPrivateHeaderInstall ] )
+		glEnv.Alias( "installGL", [ glHeaderInstall, glPrivateHeaderInstall ] )
 
 		glslHeaders = glob.glob( "glsl/IECoreGL/*.h" )
 		glslHeaderInstall = glEnv.Install( "$INSTALL_GLSL_HEADER_DIR/IECoreGL", glslHeaders )


### PR DESCRIPTION
As suggested by John, I've changed the `SConstruct` so that the "private" headers do get installed.

The specific use-case for accessing them is the effort to move the dcc-specific modules out of the public cortex repository. And since some of those private headers are needed by them, the simplest solution is to have them accessible from the installed locations.

Even though the requirement to have those repositories outside of cortex is only for 10.6, targeting this PR to 10.5 makes our transition easier.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
