### PR TITLE
Root tag support ie core usd

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,15 @@
 10.5.x.x (relative to 10.5.15.3)
 ========
 
+Improvements
+-----
 
+- IECoreUSD: Added support for root level tags (reading/writing) to our IECoreUSD::SceneCacheData plugin.
+
+Fixes
+-----
+
+- IECoreUSD: Fixed crash when using invalid file path with IECoreUSD::SceneCacheFileFormat.
 
 10.5.15.3 (relative to 10.5.15.2)
 =========

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheData.h
@@ -179,7 +179,7 @@ private:
 	void addCollections( SpecData& spec, TfTokenVector& properties, const SdfPath& primPath );
 	void addReference( IECoreScene::ConstSceneInterfacePtr scene, SpecData& spec, TfTokenVector& children );
 	void addValueClip( SpecData& spec, const VtVec2dArray times, const VtVec2dArray actives, const std::string& assetPath, const std::string& primPath);
-	void addInternalRoot( TfTokenVector children );
+	void addInternalRoot( TfTokenVector children, IECoreScene::ConstSceneInterfacePtr scene );
 
 	VtValue getTimeSampleMap( const SdfPath& path, const TfToken& field, const VtValue& value ) const;
 

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -375,6 +375,18 @@ void UsdSceneCacheFileFormat::writeLocation(
 			}
 		}
 	}
+	// internal root is mapped to the SceneInterface root '/'
+	else
+	{
+		SceneInterface::NameList tags;
+		inChild->readTags( tags );
+		// round trip internal tag name
+		for ( auto& tag : tags )
+		{
+			tag = SceneCacheDataAlgo::fromInternalName( tag );
+		}
+		outChild->writeTags( tags );
+	}
 
 	// recursion
 	SceneInterface::NameList grandChildNames;

--- a/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SceneCacheFileFormat.cpp
@@ -175,6 +175,11 @@ bool UsdSceneCacheFileFormat::WriteToFile( const SdfLayer& layer, const std::str
 	SceneInterfacePtr outScene;
 
 	outScene = SdfFileFormatSharedSceneWriters::get( filePath );
+	if ( !outScene )
+	{
+		IECore::msg( IECore::Msg::Error, "UsdSceneCacheFileFormat::WriteToFile", boost::format( "Invalid file path \"%s\" for layer \"%s\"." ) % filePath % layer.GetIdentifier() );
+		return false;
+	}
 
 	SceneInterface::NameList childNames;
 	usdScene->childNames( childNames );

--- a/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/SdfFileFormatSharedSceneWriters.cpp
@@ -35,6 +35,7 @@
 #include "SdfFileFormatSharedSceneWriters.h"
 
 #include "IECore/LRUCache.h"
+#include "IECore/MessageHandler.h"
 
 using namespace IECore;
 using namespace IECoreScene;
@@ -61,7 +62,15 @@ class Cache : public SceneLRUCache
 
 		static SceneInterfacePtr fileCacheGetter( const std::string &fileName, size_t &cost )
 		{
-			SceneInterfacePtr result = SceneInterface::create( fileName, IECore::IndexedIO::Write );
+			SceneInterfacePtr result = nullptr;
+			try
+			{
+				result = SceneInterface::create( fileName, IECore::IndexedIO::Write );
+			}
+			catch ( ... )
+			{
+				IECore::msg( IECore::Msg::Error, "SdfFileFormatSharedSceneWriters::SceneLRUCache", boost::format( "Unable to open file path \"%s\" for writing IndexedIo data." ) % fileName );
+			}
 			cost = 1;
 			return result;
 		}

--- a/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
@@ -320,6 +320,7 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		# includes
 		fileName = os.path.join( self.temporaryDirectory(), "testUSDTags.scc" )
 		m = IECoreScene.SceneCache( fileName, IECore.IndexedIO.OpenMode.Write )
+		m.writeTags( ["geoId:chessy"] )
 		t = m.createChild( "t" )
 		s = t.createChild( "s" )
 		t.writeTags( ["t1", "all", "asset-(12)"] )
@@ -329,6 +330,16 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		# root
 		stage = pxr.Usd.Stage.Open( fileName )
 		root = stage.GetPseudoRoot()
+
+		tagInternalRootPrim = root.GetPrimAtPath( f"/{IECoreUSD.SceneCacheDataAlgo.internalRootName()}" )
+		self.assertEqual(
+			tagInternalRootPrim.GetRelationship(
+				"collection:{}:includes".format(
+					IECoreUSD.SceneCacheDataAlgo.toInternalName( "geoId:chessy" )
+				)
+			).GetTargets(),
+			[ pxr.Sdf.Path( f"/{IECoreUSD.SceneCacheDataAlgo.internalRootName()}" ) ]
+		)
 
 		tagPrim = root.GetPrimAtPath( "/{}/t".format( IECoreUSD.SceneCacheDataAlgo.internalRootName() ) )
 		self.assertTrue( tagPrim )
@@ -346,6 +357,10 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		stage.Export( exportPath )
 
 		scene = IECoreScene.SharedSceneInterfaces.get( exportPath )
+		# check root tags
+		self.assertTrue( "geoId:chessy" in scene.readTags() )
+
+		# check children tags
 		for tag, paths in tags.items():
 			for path in paths:
 				child = scene.scene( IECoreScene.SceneInterface.stringToPath( path ) )

--- a/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/SceneCacheFileFormatTest.py
@@ -939,6 +939,17 @@ class SceneCacheFileFormatTest( unittest.TestCase ) :
 		stage.Export( exportPath )
 		self.assertTrue( os.path.exists( exportPath ) )
 
+        # invalid path
+		invalidExportPath = os.path.join( self.temporaryDirectory(), "invalid", "invalid.scc" )
+		with IECore.CapturingMessageHandler() as mh :
+			stage.Export( invalidExportPath )
+
+		self.assertEqual( len( mh.messages ), 2 )
+		self.assertEqual( mh.messages[0].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[0].context, "SdfFileFormatSharedSceneWriters::SceneLRUCache" )
+		self.assertEqual( mh.messages[1].level, IECore.Msg.Level.Error )
+		self.assertEqual( mh.messages[1].context, "UsdSceneCacheFileFormat::WriteToFile" )
+
 		# root
 		layer = pxr.Sdf.Layer.FindOrOpen( linkFileName )
 


### PR DESCRIPTION
Improvements
-----

- IECoreUSD: Added support for root level tags (reading/writing) to our IECoreUSD::SceneCacheData plugin.

Fixes
-----

- IECoreUSD: Fixed crash when using invalid file path with IECoreUSD::SceneCacheFileFormat.


### Checklist ###

- [ ] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation, if applicable.
- [ ] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [ ] My code follows the Cortex project's prevailing coding style and conventions.
