### PR TITLE
TypeIds.h : Added range for AtomsGaffer

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.6.x.x (relative to 10.6.0.1)
 ========
 
+API
+---
 
+- TypeIds : Claimed range for AtomsGaffer.
 
 10.6.0.1 (relative to 10.6.0.0)
 ========

--- a/include/IECore/TypeIds.h
+++ b/include/IECore/TypeIds.h
@@ -312,6 +312,9 @@ enum TypeId
 	FirstGafferTypeId = 118000, // Used by Gaffer 1.6 and later
 	LastGafferTypeId = 127999,
 
+	FirstAtomsGafferTypeId = 128000,  // Used by AtomsGaffer
+	LastAtomsGafferTypeId = 128999,
+
 	// TypeIds dynamically allocated by registerRunTimeTyped (IECore Python)
 	FirstDynamicTypeId = 300000,
 	LastDynamicTypeId = 399999,


### PR DESCRIPTION
[AtomsGaffer ](https://github.com/Toolchefs/atomsGaffer) is currently claiming a range that has now been taken over by Gaffer 1.6.

https://github.com/Toolchefs/atomsGaffer/blob/master/include/AtomsGaffer/TypeIds.h

In the file you can see a note about updating cortex to claim the range in question, but that was never done.

I believe the solution is to change `AtomsGaffer`'s range, and claim that new range here, so we don't run the risk of the same happening again in the future.

I'll update `AtomsGaffer` once the Cortex PR is approved.

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
