### PR TITLE
DisplayDriverServer : Support IPv4-only environments

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.6.x.x (relative to 10.6.0.1)
 ========
 
+Fixes
+-----
+
+- DisplayDriverServer : Fixed to support IPv4-only environments.
+
 API
 ---
 


### PR DESCRIPTION
In c357ea106daea2ee5aad6bb4f871ddb87e80991e, we switched from making an IPv4 connection, to an IPv6 one. This fixed some nasty lag on Windows, but it turns out that it also broke IPv4-only environments completely. So now we fall back to opening a v4 connection if the v6 connection fails.

@ericmehl, if you could check that the lag is still banished on Windows, that would be great. I think it should be fine because we open the v6 connection first still, but I'm a bit out of my comfort zone with this, so the more testing the better.