### PR TITLE
VDBObject bindings : Adapt for OpenVDB 12

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,11 @@ Features
 
 - NanobindConverter : Added new class providing interoperability between Boost Python bindings and Nanobind bindings.
 
+Fixes
+-----
+
+- VDBObject : Fixed Python bindings for OpenVDB 12.
+
 10.7.0.0a9 (relative to 10.7.0.0a8)
 ==========
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.7.x.x (relative to 10.7.0.0a9)
 ========
 
+Features
+--------
 
+- NanobindConverter : Added new class providing interoperability between Boost Python bindings and Nanobind bindings.
 
 10.7.0.0a9 (relative to 10.7.0.0a8)
 ==========

--- a/Changes
+++ b/Changes
@@ -11,6 +11,11 @@ Fixes
 
 - VDBObject : Fixed Python bindings for OpenVDB 12.
 
+Breaking Changes
+----------------
+
+- VDBObject : Removed support for OpenVDB 10.0 and earlier.
+
 10.7.0.0a9 (relative to 10.7.0.0a8)
 ==========
 

--- a/SConstruct
+++ b/SConstruct
@@ -470,6 +470,18 @@ o.Add(
 	"",
 )
 
+o.Add(
+	"NANOBIND_INCLUDE_PATH",
+	"The path to the nanobind include directory.",
+	"",
+)
+
+o.Add(
+	"NANOBIND_LIB_PATH",
+	"The path to the nanobind lib directory.",
+	"",
+)
+
 # Build options
 
 o.Add(
@@ -1841,6 +1853,21 @@ if doConfigure :
 	c.Finish()
 
 	if haveVDB :
+
+		vdbVersion = None
+		vdbVersionHeader = env.FindFile( "openvdb/version.h", dependencyIncludes )
+		for line in open( str( vdbVersionHeader ) ) :
+			m = re.compile( r"^#define OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER\s*([0-9]+)" ).match( line )
+			if m :
+				vdbVersion = m.group( 1 )
+				break
+
+		if vdbVersion and int( vdbVersion ) >= 12 :
+			vdbPythonModuleEnv.Append(
+				LIBPATH = [ "$NANOBIND_LIB_PATH" ],
+				LIBS = [ "nanobind-static" ],
+				CXXFLAGS = [ "-fPIC", systemIncludeArgument, "$NANOBIND_INCLUDE_PATH" ]
+			)
 
 		vdbEnv.Append(
 			LIBS = [

--- a/include/IECorePython/NanobindConverter.h
+++ b/include/IECorePython/NanobindConverter.h
@@ -1,0 +1,112 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#ifndef IECOREPYTHON_NANOBINDCONVERTER_H
+#define IECOREPYTHON_NANOBINDCONVERTER_H
+
+#include "boost/python.hpp"
+
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/shared_ptr.h"
+
+namespace IECorePython
+{
+
+// Registers `boost::python` converters for types
+// wrapped using Nanobind.
+template<typename T>
+struct NanobindConverter
+{
+
+	static void registerConverters()
+	{
+		if( !nanobind::is_alive() )
+		{
+			// Initialise Nanobind so that types registered by Nanobind-bound
+			// modules (e.g. `openvdb`) can be looked up via its shared type
+			// registry. `NB_MODULE` would normally do this for Nanobind-native
+			// modules, but our Boost::Python modules need to perform this step
+			// manually before any Nanobind cast can run.
+			nanobind::detail::nb_module_exec( NB_DOMAIN_STR, nullptr );
+		}
+
+		boost::python::to_python_converter<T, ToNanobind>();
+		boost::python::converter::registry::push_back(
+			&FromNanobind::convertible,
+			&FromNanobind::construct,
+			boost::python::type_id<T>()
+		);
+	}
+
+	private :
+
+		struct ToNanobind
+		{
+			static PyObject *convert( const T &t )
+			{
+				nanobind::object o = nanobind::cast( t );
+				Py_INCREF( o.ptr() );
+				return o.ptr();
+			}
+		};
+
+		struct FromNanobind
+		{
+
+			static void *convertible( PyObject *object )
+			{
+				nanobind::handle handle( object );
+				T value;
+				return nanobind::try_cast<T>( handle, value ) ? object : nullptr;
+			}
+
+			static void construct( PyObject *object, boost::python::converter::rvalue_from_python_stage1_data *data )
+			{
+				void *storage = ( ( boost::python::converter::rvalue_from_python_storage<T> * ) data )->storage.bytes;
+				T *t = new( storage ) T;
+				data->convertible = storage;
+
+				nanobind::handle handle( object );
+				*t = nanobind::cast<T>( handle );
+			}
+
+		};
+
+};
+
+} // namespace IECorePython
+
+#endif // IECOREPYTHON_NANOBINDCONVERTER_H

--- a/python/IECoreVDB/__init__.py
+++ b/python/IECoreVDB/__init__.py
@@ -41,7 +41,10 @@ import warnings
 # we use the warnings module to suppress these during the import
 with warnings.catch_warnings():
 	warnings.simplefilter("ignore")
-	import pyopenvdb
+	try :
+		import openvdb
+	except ImportError :
+		import pyopenvdb
 
 from ._IECoreVDB import *
 

--- a/python/IECoreVDB/__init__.py
+++ b/python/IECoreVDB/__init__.py
@@ -35,16 +35,10 @@
 __import__( "IECore" )
 __import__( "IECoreScene" )
 
-import warnings
-# the first import of pyopenvdb results in a duplicate c++ -> python
-# boost python type conversions warnings.
-# we use the warnings module to suppress these during the import
-with warnings.catch_warnings():
-	warnings.simplefilter("ignore")
-	try :
-		import openvdb
-	except ImportError :
-		import pyopenvdb
+try :
+	import openvdb
+except ImportError :
+	import pyopenvdb
 
 from ._IECoreVDB import *
 

--- a/src/IECoreVDB/bindings/IECoreVDBModule.cpp
+++ b/src/IECoreVDB/bindings/IECoreVDBModule.cpp
@@ -41,18 +41,24 @@
 
 #include "IECoreVDB/VDBObject.h"
 
-// OpenVDB 10.0 and earlier used `boost::python` for its Python bindings, but
-// this was switched to PyBind11 in OpenVDB 10.1. We need to take a different
-// approach to binding VDBObject's grid accessors in each case.
-#if OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER > 10 || OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER == 10 && OPENVDB_LIBRARY_MINOR_VERSION_NUMBER >= 1
+// OpenVDB 10.0 and earlier used `boost::python` for its Python bindings,
+// OpenVDB 10.1 to 11.x used PyBind11, and OpenVDB 12 onwards uses Nanobind.
+// We need to take a different approach to binding VDBObject's grid accessors
+// in each case.
+#if OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER >= 12
+#include "IECorePython/NanobindConverter.h"
+#define IECOREVDB_USE_NANOBIND
+#define IECOREVDB_CONVERT_GRID_BINDING
+#elif OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER == 11 || OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER == 10 && OPENVDB_LIBRARY_MINOR_VERSION_NUMBER >= 1
 #include "IECorePython/PyBindConverter.h"
 #define IECOREVDB_USE_PYBIND
+#define IECOREVDB_CONVERT_GRID_BINDING
 #endif
 
 using namespace boost::python;
 using namespace IECoreVDB;
 
-#ifndef IECOREVDB_USE_PYBIND
+#ifndef IECOREVDB_CONVERT_GRID_BINDING
 
 namespace
 {
@@ -148,7 +154,7 @@ void insertGrid( VDBObject::Ptr vdbObject, boost::python::object pyObject )
 
 } // namespace
 
-#endif // #ifndef IECOREVDB_USE_PYBIND
+#endif // #ifndef IECOREVDB_CONVERT_GRID_BINDING
 
 namespace
 {
@@ -169,7 +175,9 @@ boost::python::list gridNames( VDBObject::Ptr vdbObject )
 BOOST_PYTHON_MODULE( _IECoreVDB )
 {
 
-#ifdef IECOREVDB_USE_PYBIND
+#if defined( IECOREVDB_USE_NANOBIND )
+	IECorePython::NanobindConverter<openvdb::GridBase::Ptr>::registerConverters();
+#elif defined( IECOREVDB_USE_PYBIND )
 	IECorePython::PyBindConverter<openvdb::GridBase::Ptr>::registerConverters();
 #endif
 
@@ -179,7 +187,7 @@ BOOST_PYTHON_MODULE( _IECoreVDB )
 		.def("gridNames", &::gridNames)
 		.def("metadata", &VDBObject::metadata)
 		.def("removeGrid", &VDBObject::removeGrid)
-#ifdef IECOREVDB_USE_PYBIND
+#ifdef IECOREVDB_CONVERT_GRID_BINDING
 		.def( "findGrid", (openvdb::GridBase::Ptr (VDBObject::*)( const std::string &name ))&VDBObject::findGrid )
 		.def( "insertGrid", &VDBObject::insertGrid )
 #else

--- a/src/IECoreVDB/bindings/IECoreVDBModule.cpp
+++ b/src/IECoreVDB/bindings/IECoreVDBModule.cpp
@@ -41,120 +41,19 @@
 
 #include "IECoreVDB/VDBObject.h"
 
-// OpenVDB 10.0 and earlier used `boost::python` for its Python bindings,
 // OpenVDB 10.1 to 11.x used PyBind11, and OpenVDB 12 onwards uses Nanobind.
 // We need to take a different approach to binding VDBObject's grid accessors
 // in each case.
 #if OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER >= 12
 #include "IECorePython/NanobindConverter.h"
 #define IECOREVDB_USE_NANOBIND
-#define IECOREVDB_CONVERT_GRID_BINDING
 #elif OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER == 11 || OPENVDB_LIBRARY_MAJOR_VERSION_NUMBER == 10 && OPENVDB_LIBRARY_MINOR_VERSION_NUMBER >= 1
 #include "IECorePython/PyBindConverter.h"
 #define IECOREVDB_USE_PYBIND
-#define IECOREVDB_CONVERT_GRID_BINDING
 #endif
 
 using namespace boost::python;
 using namespace IECoreVDB;
-
-#ifndef IECOREVDB_CONVERT_GRID_BINDING
-
-namespace
-{
-
-// all functions in iepyopenvdb namespace are from the pyopenvdb bindings
-namespace iepyopenvdb
-{
-
-// openvdb/python/pyutil.h
-std::string className( boost::python::object obj )
-{
-	std::string s = boost::python::extract<std::string>( obj.attr( "__class__" ).attr( "__name__" ) );
-	return s;
-}
-
-// openvdb/python/pyGrid.h
-boost::python::object getPyObjectFromGrid( const openvdb::GridBase::Ptr &grid )
-{
-	if( !grid )
-	{
-		return boost::python::object();
-	}
-
-#define CONVERT_BASE_TO_GRID( GridType, grid ) \
-        if (grid->isType<GridType>()) { \
-            return boost::python::object(openvdb::gridPtrCast<GridType>(grid)); \
-        }
-
-	CONVERT_BASE_TO_GRID( openvdb::FloatGrid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::Vec3SGrid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::BoolGrid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::DoubleGrid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::Int32Grid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::Int64Grid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::Vec3IGrid, grid );
-	CONVERT_BASE_TO_GRID( openvdb::Vec3DGrid, grid );
-
-#undef CONVERT_BASE_TO_GRID
-
-	throw openvdb::TypeError( grid->type() + " is not a supported OpenVDB grid type" );
-}
-
-// openvdb/python/pyGrid.h
-openvdb::GridBase::Ptr getGridFromPyObject( const boost::python::object &gridObj )
-{
-	if( !gridObj )
-	{
-		return openvdb::GridBase::Ptr();
-	}
-
-#define CONVERT_GRID_TO_BASE( GridPtrType ) \
-        { \
-            boost::python::extract<GridPtrType> x(gridObj); \
-            if (x.check()) return x(); \
-        }
-
-	// Extract a grid pointer of one of the supported types
-	// from the input object, then cast it to a base pointer.
-	CONVERT_GRID_TO_BASE( openvdb::FloatGrid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::Vec3SGrid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::BoolGrid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::DoubleGrid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::Int32Grid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::Int64Grid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::Vec3IGrid::Ptr );
-	CONVERT_GRID_TO_BASE( openvdb::Vec3DGrid::Ptr );
-
-#undef CONVERT_GRID_TO_BASE
-
-	throw openvdb::TypeError( className( gridObj ) + " is not a supported OpenVDB grid type" );
-}
-
-} // namespace iepyopenvdb
-
-boost::python::object findGrid( VDBObject::Ptr vdbObject, const std::string &gridName )
-{
-	openvdb::GridBase::Ptr grid = vdbObject->findGrid( gridName );
-	if( grid )
-	{
-		return iepyopenvdb::getPyObjectFromGrid( grid );
-	}
-	else
-	{
-		return boost::python::object();
-	}
-}
-
-void insertGrid( VDBObject::Ptr vdbObject, boost::python::object pyObject )
-{
-	openvdb::GridBase::Ptr gridPtr = iepyopenvdb::getGridFromPyObject( pyObject );
-	vdbObject->insertGrid( gridPtr );
-}
-
-} // namespace
-
-#endif // #ifndef IECOREVDB_CONVERT_GRID_BINDING
 
 namespace
 {
@@ -187,13 +86,8 @@ BOOST_PYTHON_MODULE( _IECoreVDB )
 		.def("gridNames", &::gridNames)
 		.def("metadata", &VDBObject::metadata)
 		.def("removeGrid", &VDBObject::removeGrid)
-#ifdef IECOREVDB_CONVERT_GRID_BINDING
 		.def( "findGrid", (openvdb::GridBase::Ptr (VDBObject::*)( const std::string &name ))&VDBObject::findGrid )
 		.def( "insertGrid", &VDBObject::insertGrid )
-#else
-		.def("findGrid", &::findGrid)
-		.def("insertGrid", &::insertGrid)
-#endif
 		.def("unmodifiedFromFile", &VDBObject::unmodifiedFromFile)
 		.def("fileName", &VDBObject::fileName)
 		;


### PR DESCRIPTION
OpenVDB 12 switched from PyBind11 to Nanobind for its bindings, so VDBObject needs another update to support the change. Rather than maintain three sets of bindings, I've gone ahead and removed the Boost bindings required for OpenVDB <= 10.0 in the last commit, but this could be dropped if there's a compelling argument for keeping it...

This should unlock the final part of the VFX Platform 2025 update.