### PR TITLE
LiveScene: Support point-based geometry in readObject

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -47,6 +47,7 @@ import os
 import re
 import subprocess
 import platform
+import distutils
 
 EnsureSConsVersion( 3, 0, 2 )  # Substfile is a default builder as of 3.0.2
 SConsignFile()

--- a/src/IECoreNuke/LiveScene.cpp
+++ b/src/IECoreNuke/LiveScene.cpp
@@ -498,11 +498,15 @@ ConstObjectPtr LiveScene::readObject( double time, const IECore::Canceller *canc
 		if ( result == IECore::PathMatcher::ExactMatch )
 		{
 			auto geoInfo = object( i, &time );
-			if ( !geoInfo )
+			if ( !geoInfo || geoInfo->primitives() == 0 )
 			{
 				return IECore::NullObject::defaultNullObject();
 			}
-			if ( geoInfo->primitives() == 1 && ( geoInfo->primitive( 0 )->getPrimitiveType() == DD::Image::PrimitiveType::eParticlesSprite ) )
+
+			auto primitiveType = geoInfo->primitive( 0 )->getPrimitiveType();
+			if ( primitiveType == DD::Image::PrimitiveType::eParticlesSprite
+				|| primitiveType == DD::Image::PrimitiveType::eParticles
+				|| primitiveType == DD::Image::PrimitiveType::ePoint )
 			{
 				auto converter = new IECoreNuke::FromNukePointsConverter( geoInfo, m_op->input0() );
 				return converter->convert();

--- a/test/IECoreNuke/LiveSceneKnobTest.py
+++ b/test/IECoreNuke/LiveSceneKnobTest.py
@@ -377,6 +377,73 @@ class LiveSceneKnobTest( IECoreNuke.TestCase ) :
 		self.assertEqual( objectA.topologyHash(), expectedObjectA.topologyHash() )
 		self.assertEqual( objectA.keys(), [ "P", "uv" ] )
 
+	def testReadObjectParticles(self):
+		import IECoreScene
+		import tempfile, os
+
+		noise = nuke.createNode("Noise")
+		card = nuke.createNode("Card2")
+		card.setInput(0, noise)
+		particle = nuke.createNode("ParticleEmitter")
+		particle.setInput(1, card)
+
+		# Read through ieLiveScene at frame 5 (after simulation)
+		nuke.frame(5)
+		n = nuke.createNode("ieLiveScene")
+		n.setInput(0, particle)
+		n.forceValidate()
+
+		liveScene = n.knob("scene").getValue()
+		self.assertGreater(len(liveScene.childNames()), 0)
+
+		child = liveScene.scene(["object0"])
+		self.assertTrue(child.hasObject())
+
+		obj = child.readObject(1.0)
+		self.assertIsInstance(obj, IECoreScene.PointsPrimitive)
+
+	def testReadObjectDeepToPoints(self):
+		import IECoreScene
+
+		checker = nuke.createNode("CheckerBoard2")
+		deepFromImage = nuke.createNode("DeepFromImage")
+		deepFromImage["z"].setValue(1000)
+		deepFromImage["set_z"].setValue(True)
+		deepFromImage.setInput(0, checker)
+
+		camera = nuke.createNode("Camera")
+
+		deepToPoints = nuke.createNode("DeepToPoints")
+		deepToPoints.setInput(0, deepFromImage)
+		deepToPoints.setInput(1, camera)
+
+		n = nuke.createNode("ieLiveScene")
+		n.setInput(0, deepToPoints)
+		n.forceValidate()
+
+		liveScene = n.knob("scene").getValue()
+		self.assertGreater(len(liveScene.childNames()), 0)
+
+		child = liveScene.scene(["object0"])
+		self.assertTrue(child.hasObject())
+
+		obj = child.readObject(0)
+		self.assertIsInstance(obj, IECoreScene.PointsPrimitive)
+
+	def testReadObjectMesh(self):
+		import IECoreScene
+
+		sphere = nuke.createNode("Sphere")
+
+		n = nuke.createNode("ieLiveScene")
+		n.setInput(0, sphere)
+
+		liveScene = n.knob("scene").getValue()
+		child = liveScene.scene(["object0"])
+		self.assertTrue(child.hasObject())
+
+		obj = child.readObject(0)
+		self.assertIsInstance(obj, IECoreScene.MeshPrimitive)
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Generally describe what this PR will do, and why it is needed.

- Nuke's `DeepToPoints` node outputs `eParticles` type primitives, which `LiveScene::readObject()` did not recognize as point geometry. The previous check only matched `eParticlesSprite`, causing DeepToPoints output to fall through to `MeshFromNuke`. `eParticlesSprite` represent a collection of particles in one primitive, but output of `DeepToPoints` could be N primitives, now checking if primitives > 0.

### Related Issues ###

-

### Dependencies ###

-

### Breaking Changes ###

- IECoreNuke LiveScene: Fixed point clouds from DeepToPoints to be supported. The geometry was incorrectly treated as a mesh instead of points.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
