### PR TITLE
IECoreGL : Restore CurvesPrimitive OpenGL 2.1 compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,7 @@ Fixes
 - PointsAlgo :
   - Fixed loss of blind data in `deletePoints()`.
   - Fixed loss of primitive type in `deletePoints()` (if processing a derived class of PointsPrimitive).
+- IECoreGL::Shader : Restored compatibility with OpenGL 2.1 in order to preserve macOS support [^1].
 
 Breaking Changes
 ----------------
@@ -37,6 +38,8 @@ Build
 -----
 
 - CI : Updated to GafferHQ/dependencies 11.0.0a8.
+
+[^1]: To be omitted from the notes for the final 10.7.0.0 release.
 
 10.7.0.0a10 (relative to 10.7.0.0a9)
 ===========

--- a/glsl/IECoreGL/CurvesPrimitive.h
+++ b/glsl/IECoreGL/CurvesPrimitive.h
@@ -47,7 +47,7 @@
 	layout( lines_adjacency ) in;\
 	layout( line_strip, max_vertices = 10 ) out;\
 	\
-	in int geometryIsCurveEndPoint[];\
+	in float geometryIsCurveEndPoint[];\
 	\
 	uniform mat4x4 basis;\
 	uniform mat4x4 phantomBasis0;\
@@ -70,7 +70,7 @@
 	layout( lines_adjacency ) in;\
 	layout( triangle_strip, max_vertices = 20 ) out;\
 	\
-	in int geometryIsCurveEndPoint[];\
+	in float geometryIsCurveEndPoint[];\
 	\
 	uniform mat4x4 basis;\
 	uniform mat4x4 phantomBasis0;\

--- a/src/IECoreGL/CurvesPrimitive.cpp
+++ b/src/IECoreGL/CurvesPrimitive.cpp
@@ -338,15 +338,18 @@ const Shader::Setup *CurvesPrimitive::shaderSetup( const Shader *shader, State *
 		// To handle "phantom vertices" in the geometry shader, we need to know which
 		// vertices correspond to the original endpoints of the curve. We do that using
 		// the `vertexIsCurveEndPoint` attribute.
-		IECore::IntVectorDataPtr isEndPointData = new IECore::IntVectorData();
-		vector<int> &isEndPoint = isEndPointData->writable();
+		/// \todo `vertexIsCurveEndPoint` is a float attribute only to maintain compatibility
+		/// with OpenGL 2.1. Use an int attribute once we we're able to move IECoreGL to
+		/// OpenGL 3.3 Core Profile.
+		IECore::FloatVectorDataPtr isEndPointData = new IECore::FloatVectorData();
+		vector<float> &isEndPoint = isEndPointData->writable();
 		isEndPoint.resize( m_memberData->points->readable().size(), 0 );
 
 		int i = 0;
 		for( auto c : m_memberData->vertsPerCurve->readable() )
 		{
-			isEndPoint[i] = 1;
-			isEndPoint[i+c-1] = 1;
+			isEndPoint[i] = 1.0f;
+			isEndPoint[i+c-1] = 1.0f;
 			i += c;
 		}
 		geometryShaderSetup->addVertexAttribute( "vertexIsCurveEndPoint", isEndPointData );

--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -1063,7 +1063,7 @@ const std::string &Shader::defaultFragmentSource()
 			vec3 Nf = faceforward( fragmentN, -fragmentI, fragmentN );
 			float f = dot( normalize( fragmentI ), normalize(Nf) );
 			gl_FragColor = vec4( f * fragmentCs, 1 );
-		};
+		}
 
 	)";
 
@@ -1083,7 +1083,7 @@ const std::string &Shader::constantFragmentSource()
 		void main()
 		{
 			gl_FragColor = vec4( fragmentCs, 1 );
-		};
+		}
 
 	)";
 
@@ -1118,7 +1118,7 @@ const std::string &Shader::lambertFragmentSource()
 			vec3 Cdiffuse = ieDiffuse( fragmentP, n, Cl, L, gl_MaxLights );
 
 			gl_FragColor = vec4( Cdiffuse, 1.0 );
-		};
+		}
 
 	)";
 

--- a/src/IECoreGL/Shader.cpp
+++ b/src/IECoreGL/Shader.cpp
@@ -970,7 +970,7 @@ const std::string &Shader::defaultVertexSource()
 {
 	static const string g_s = R"(
 
-		#version 150 compatibility
+		#version 120
 
 		#if __VERSION__ <= 120
 		#define in attribute
@@ -985,14 +985,14 @@ const std::string &Shader::defaultVertexSource()
 		in vec3 vertexN;
 		in vec2 vertexuv;
 		in vec3 vertexCs;
-		in int vertexIsCurveEndPoint;
+		in float vertexIsCurveEndPoint;
 
 		out vec3 geometryI;
 		out vec3 geometryP;
 		out vec3 geometryN;
 		out vec2 geometryuv;
 		out vec3 geometryCs;
-		out int geometryIsCurveEndPoint;
+		out float geometryIsCurveEndPoint;
 
 		out vec3 fragmentI;
 		out vec3 fragmentP;


### PR DESCRIPTION
The GL shader adjustments in #1526 bumped `Shader::defaultVertexSource()` to requiring OpenGL 3.2 Compatibility Profile, which is not supported on macOS. This PR adds a workaround to maintain support with GL 2.1 with a todo to revert it once we can target a more modern OpenGL version supported by all platforms...