### PR TITLE
USD MeshLight I/O

### DIFF
--- a/Changes
+++ b/Changes
@@ -10,7 +10,9 @@ Improvements
 ------------
 
 - PrimitiveVariable : Added Python bindings for `IndexedView` class.
-- USDScene : Added support for writing `IECoreScene::PointInstancer` as `UsdGeomPointInstancer`.
+- USDScene :
+  - Added support for writing `IECoreScene::PointInstancer` as `UsdGeomPointInstancer`.
+  - Added support for reading and writing mesh lights.
 
 Fixes
 -----

--- a/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
@@ -44,6 +44,7 @@
 #include "pxr/usd/usdLux/cylinderLight.h"
 #include "pxr/usd/usdLux/nonboundableLightBase.h"
 #include "pxr/usd/usdLux/sphereLight.h"
+#include "pxr/usd/usdLux/meshLightAPI.h"
 
 #include "pxr/usd/usd/schemaRegistry.h"
 
@@ -645,7 +646,8 @@ void IECoreUSD::ShaderAlgo::writeLight( const IECoreScene::ShaderNetwork *shader
 	pxr::TfType type = pxr::UsdSchemaRegistry::GetInstance().GetTypeFromName( pxr::TfToken( outputShader->getName() ) );
 	if(
 		!type.IsA<pxr::UsdLuxBoundableLightBase>() &&
-		!type.IsA<pxr::UsdLuxNonboundableLightBase>()
+		!type.IsA<pxr::UsdLuxNonboundableLightBase>() &&
+		outputShader->getName() != "MeshLight"
 	)
 	{
 		IECore::msg( IECore::Msg::Warning, "ShaderAlgo::writeLight", "Shader `{}` is not a valid UsdLux light type", outputShader->getName() );
@@ -655,7 +657,14 @@ void IECoreUSD::ShaderAlgo::writeLight( const IECoreScene::ShaderNetwork *shader
 	// Write the light itself onto the prim we've been given.
 
 	ShaderMap usdShaders;
-	prim.SetTypeName( pxr::TfToken( outputShader->getName() ) );
+	if( outputShader->getName() == "MeshLight" )
+	{
+		pxr::UsdLuxMeshLightAPI::Apply( prim );
+	}
+	else
+	{
+		prim.SetTypeName( pxr::TfToken( outputShader->getName() ) );
+	}
 	writeShaderParameterValues( outputShader, pxr::UsdShadeConnectableAPI( prim ) );
 	usdShaders[shaderNetwork->getOutput().shader] = pxr::UsdShadeConnectableAPI( prim );
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -53,6 +53,7 @@ import IECoreUSD
 
 import pxr.Usd
 import pxr.UsdGeom
+import pxr.UsdLux
 
 if pxr.Usd.GetVersion() < ( 0, 19, 3 ) :
 	pxr.Usd.Attribute.HasAuthoredValue = pxr.Usd.Attribute.HasAuthoredValueOpinion
@@ -3899,6 +3900,53 @@ class USDSceneTest( unittest.TestCase ) :
 		light = pxr.UsdLux.DomeLight( stage.GetPrimAtPath( "/light" ) )
 		self.assertEqual( light.GetTextureFileAttr().Get(), "test.exr" )
 		self.assertEqual( light.GetTextureFormatAttr().Get(), "latlong" )
+
+	@unittest.skipIf( pxr.Usd.GetVersion() < ( 0, 21, 11 ), "UsdLuxLightAPI not available" )
+	def testWriteMeshLight( self ) :
+
+		# Write to USD
+
+		fileName = os.path.join( self.temporaryDirectory(), "meshLight.usda" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		lightNetwork = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader(
+					"MeshLight",
+					"light",
+					{
+						"intensity" : IECore.FloatData( 2.0 ),
+						"color" : IECore.Color3fData( imath.Color3f( 1, 2, 3 ) ),
+						"enableColorTemperature" : IECore.BoolData( True )
+					}
+				),
+			},
+			output = "output",
+		)
+
+		meshLightObject = IECoreScene.MeshPrimitive.createPlane(
+			imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 1, 1 ) ),
+			imath.V2i( 16, 16 )
+		)
+
+		meshLight = root.createChild( "meshLight" )
+		meshLight.writeObject( meshLightObject, 0 )
+		meshLight.writeAttribute( "light", lightNetwork, 0 )
+
+		del meshLight, root
+
+		# Verify via USD API.
+
+		stage = pxr.Usd.Stage.Open( fileName )
+		prim = stage.GetPrimAtPath( "/meshLight" )
+
+		self.assertTrue( prim.IsValid() )
+		self.assertTrue( prim.IsA( pxr.UsdGeom.Mesh ) )
+		self.assertTrue( prim.HasAPI( pxr.UsdLux.MeshLightAPI ) )
+		self.assertEqual( prim.GetAttribute( "inputs:intensity" ).Get( 0 ), 2.0 )
+		self.assertEqual( prim.GetAttribute( "inputs:color" ).Get( 0 ), pxr.Gf.Vec3f( 1, 2, 3 ) )
+		self.assertEqual( prim.GetAttribute( "inputs:enableColorTemperature" ).Get( 0 ), True )
+		self.assertFalse( pxr.UsdShade.MaterialBindingAPI.ComputeBoundMaterials( [ prim ] )[0][0] )
 
 	def testPointInstancerPrimvars( self ) :
 

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4008,6 +4008,59 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertIn( "__lights", root.setNames() )
 		self.assertEqual( root.readSet( "__lights" ), IECore.PathMatcher( [ "/meshLight/meshLightMesh" ] ) )
 
+	@unittest.skipIf( pxr.Usd.GetVersion() < ( 0, 21, 11 ), "UsdLuxLightAPI not available" )
+	def testRoundTripMeshLight( self ) :
+
+		# Write to USD
+
+		fileName = os.path.join( self.temporaryDirectory(), "meshLight.usda" )
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+
+		lightNetwork = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader( "MeshLight", "light", {} ),
+			},
+			output = "output",
+		)
+		surfaceNetwork = IECoreScene.ShaderNetwork(
+			shaders = {
+				"output" : IECoreScene.Shader( "UsdPreviewSurface", "surface", {} ),
+				"texture" : IECoreScene.Shader( "UsdUVTexture", "surface", {} ),
+			},
+			output = "output",
+			connections = [ ( ( "texture", "rgb" ), ( "output", "glowColor" ) ) ],
+		)
+
+		meshLightObject = IECoreScene.MeshPrimitive.createPlane(
+			imath.Box2f( imath.V2f( 0, 0 ), imath.V2f( 1, 1 ) ),
+			imath.V2i( 16, 16 )
+		)
+
+		meshLight = root.createChild( "meshLight" )
+		meshLight.writeObject( meshLightObject, 0 )
+		meshLight.writeAttribute( "light", lightNetwork, 0 )
+		meshLight.writeAttribute( "surface", surfaceNetwork, 0 )
+
+		root.writeSet( "__lights", IECore.PathMatcher( [ "/meshLight" ] ) )
+
+		del meshLight, root
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+		meshLight = root.child( "meshLight" )
+		self.assertIn( "light", meshLight.attributeNames() )
+
+		# The Cortex shader handle is lost when converting to USD because we are only attaching
+		# the `MeshLightAPI` to the prim. Therefore the shader networks will not be equal, but we
+		# can check that the output shaders are equal.
+		self.assertEqual( meshLight.readAttribute( "light", 0 ).outputShader(), lightNetwork.outputShader() )
+
+		# The surface shader networks should be equivalent
+		self.assertEqual( meshLight.readAttribute( "surface", 0 ), surfaceNetwork )
+
+		self.assertIn( "__lights", root.setNames() )
+		self.assertEqual( root.readSet( "__lights" ), IECore.PathMatcher( [ "/meshLight" ] ) )
+
 	def testPointInstancerPrimvars( self ) :
 
 		# Use the USD API to author a point instancer with primvars on it.

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -3948,6 +3948,66 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertEqual( prim.GetAttribute( "inputs:enableColorTemperature" ).Get( 0 ), True )
 		self.assertFalse( pxr.UsdShade.MaterialBindingAPI.ComputeBoundMaterials( [ prim ] )[0][0] )
 
+	@unittest.skipIf( pxr.Usd.GetVersion() < ( 0, 21, 11 ), "UsdLuxLightAPI not available" )
+	def testReadMeshLight( self ) :
+
+		fileName = os.path.dirname( __file__ ) + "/data/meshLight.usda"
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		meshLightXForm = root.child( "meshLight" )
+
+		self.assertEqual( meshLightXForm.attributeNames(), [] )
+		self.assertEqual( meshLightXForm.childNames(), ["meshLightMesh"] )
+
+		meshLight = meshLightXForm.child( "meshLightMesh" )
+
+		meshLightObject = meshLight.readObject( 0 )
+		self.assertIsInstance( meshLightObject, IECoreScene.MeshPrimitive )
+		self.assertTrue( meshLightObject.arePrimitiveVariablesValid() )
+		self.assertEqual( len( meshLightObject["P"].data ), 8 )
+
+		self.assertTrue( meshLight.hasAttribute( "light" ) )
+		network = meshLight.readAttribute( "light", 0 )
+
+		self.assertEqual(
+			network,
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"meshLightMesh" : IECoreScene.Shader(
+						"MeshLight",
+						"light",
+						{
+							"color" : IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ),
+							"intensity" : IECore.FloatData( 2.0 ),
+						}
+					),
+				},
+				output = "meshLightMesh"
+			)
+		)
+
+		self.assertTrue( meshLight.hasAttribute( "surface" ) )
+		network = meshLight.readAttribute( "surface", 0 )
+
+		self.assertEqual(
+			network,
+			IECoreScene.ShaderNetwork(
+				shaders = {
+					"previewSurface" : IECoreScene.Shader(
+						"UsdPreviewSurface",
+						"surface",
+						{
+							"diffuseColor" : IECore.Color3fData( imath.Color3f( 0, 1, 0 ) ),
+							"roughness" : IECore.FloatData( 0.5 ),
+						}
+					),
+				},
+				output = ( "previewSurface", "surface" ),
+			)
+		)
+
+		self.assertIn( "__lights", root.setNames() )
+		self.assertEqual( root.readSet( "__lights" ), IECore.PathMatcher( [ "/meshLight/meshLightMesh" ] ) )
+
 	def testPointInstancerPrimvars( self ) :
 
 		# Use the USD API to author a point instancer with primvars on it.

--- a/contrib/IECoreUSD/test/IECoreUSD/data/meshLight.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/meshLight.usda
@@ -1,0 +1,35 @@
+#usda 1.0
+
+def Xform "meshLight" (
+)
+{
+    def Material "previewMaterial"
+    {
+        token outputs:surface.connect = </meshLight/previewMaterial/previewSurface.outputs:surface>
+
+        def Shader "previewSurface"
+        {
+            uniform token info:id = "UsdPreviewSurface"
+            color3f inputs:diffuseColor = (0, 1, 0)
+            float inputs:roughness = 0.5
+            token outputs:surface
+        }
+    }
+
+    def Mesh "meshLightMesh" (
+        prepend apiSchemas = ["MeshLightAPI", "MaterialBindingAPI"]
+    )
+    {
+        rel material:binding = </meshLight/previewMaterial>
+
+        color3f inputs:color = (0, 1, 0)
+        float inputs:intensity = 2.0
+
+        # Cube
+        float3[] extent = [(-0.5, -0.5, -0.5), (0.5, 0.5, 0.5)]
+        int[] faceVertexCounts = [4, 4, 4, 4, 4, 4]
+        int[] faceVertexIndices = [0, 1, 3, 2, 2, 3, 5, 4, 4, 5, 7, 6, 6, 7, 1, 0, 1, 7, 5, 3, 6, 0, 2, 4]
+        point3f[] points = [(-0.5, -0.5, 0.5), (0.5, -0.5, 0.5), (-0.5, 0.5, 0.5), (0.5, 0.5, 0.5), (-0.5, 0.5, -0.5), (0.5, 0.5, -0.5), (-0.5, -0.5, -0.5), (0.5, -0.5, -0.5)]
+
+    }
+}


### PR DESCRIPTION
This adds reading and writing of USD mesh lights. A mesh becomes a mesh light in USD by attaching the `MeshLightAPI` to it. USD itself makes reading mesh lights easy by taking on the addition of the relevant attributes when a mesh has a `MeshLightAPI` attached to it.
Writing mesh lights is also pretty straightforward - we need to intercept a light with a `MeshLight` shader, attach the `MeshLightAPI` to the prim and continue on with writing the parameters.

### Checklist ###

- [X] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [X] I have updated the documentation, if applicable.
- [X] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [X] My code follows the Cortex project's prevailing coding style and conventions.
