### PR TITLE
Fix IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES bugs

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,7 +4,10 @@
 Fixes
 -----
 
-- USDScene : Fixed bug writing shader assignments with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1`.
+- USDScene :
+  - Fixed bug writing shader assignments with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1`.
+  - Fixed bug reading shader assignments with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1`.
+  - Fixed bug reading legacy attributes with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1`.
 
 10.6.7.0 (relative to 10.6.6.0)
 ========

--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.6.x.x (relative to 10.6.7.0)
 ========
 
+Fixes
+-----
 
+- USDScene : Fixed bug writing shader assignments with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1`.
 
 10.6.7.0 (relative to 10.6.6.0)
 ========

--- a/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
@@ -36,6 +36,7 @@
 #include "boost/algorithm/string/erase.hpp"
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/algorithm/string/predicate.hpp"
+#include "boost/container/flat_set.hpp"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usdGeom/primvar.h"
@@ -58,6 +59,7 @@ const std::string g_renderPrefix = "render:";
 const std::string g_riPrefix = "ri:";
 const std::string g_riAttributesPrefix = "ri:attributes:";
 const std::string g_userPrefix = "user:";
+const boost::container::flat_set<std::string> g_shaderTypes = { "surface", "displacement", "light", "volume" };
 
 bool writeConformantRenderManAttributes()
 {
@@ -135,6 +137,11 @@ IECoreUSD::AttributeAlgo::Name IECoreUSD::AttributeAlgo::nameToUSD( std::string 
 {
 	if( boost::starts_with( name, g_riPrefix ) && writeConformantRenderManAttributes() )
 	{
+		const std::string potentialShaderType = name.substr( g_riPrefix.size() );
+		if( g_shaderTypes.count( potentialShaderType ) )
+		{
+			return { pxr::TfToken( name ), true };
+		}
 		return { pxr::TfToken( g_riAttributesPrefix + name.substr( g_riPrefix.size() ) ), true };
 	}
 

--- a/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
@@ -37,6 +37,7 @@
 #include "boost/algorithm/string/replace.hpp"
 #include "boost/algorithm/string/predicate.hpp"
 #include "boost/container/flat_set.hpp"
+#include "boost/container/small_vector.hpp"
 
 IECORE_PUSH_DEFAULT_VISIBILITY
 #include "pxr/usd/usdGeom/primvar.h"
@@ -68,6 +69,91 @@ bool writeConformantRenderManAttributes()
 		return strcmp( e, "0" );
 	}
 	return false;
+}
+
+using Names = boost::container::small_vector<AttributeAlgo::Name, 2>;
+
+// Given a Cortex attribute name, return the ways it might be represented in
+// USD. This is a one-to-many mapping, to account for legacy representations
+// in old files. The first name returned should be used for writing new files,
+// and the other names are used as fallbacks when reading.
+Names usdNames( std::string name )
+{
+	if( boost::starts_with( name, g_riPrefix ) )
+	{
+		const std::string potentialShaderType = name.substr( g_riPrefix.size() );
+		if( g_shaderTypes.count( potentialShaderType ) )
+		{
+			return { { pxr::TfToken( name ), true } };
+		}
+		const AttributeAlgo::Name conformantName = { pxr::TfToken( g_riAttributesPrefix + name.substr( g_riPrefix.size() ) ), true };
+		const AttributeAlgo::Name legacyName = { pxr::TfToken( name ), false };
+		if( writeConformantRenderManAttributes() )
+		{
+			return { conformantName, legacyName };
+		}
+		else
+		{
+			return { legacyName, conformantName };
+		}
+	}
+
+	bool isPrimvar = false;
+
+	// The long term plan is to convert only "render:" prefixed attributes to primvars, and it will
+	// be the client's responsibility to ensure everything important gets prefixed with "render:".
+	// But for the moment, Gaffer doesn't do this yet, so we support the two most important prefixes
+	// for Gaffer currently:  "user:" and "ai:".
+	/// \todo I don't think the `render:` plan is working out - it may well be better to just map
+	/// all Cortex attributes to primvars.
+	if( boost::starts_with( name, "render:" ) || boost::starts_with( name, "user:" ) || boost::starts_with( name, "ai:" ) )
+	{
+		isPrimvar = true;
+
+		// Strip the "render:" prefix from when writing attributes as primitive variables
+		if( boost::starts_with( name, g_renderPrefix ) )
+		{
+			name = name.substr( 7 );
+		}
+	}
+
+	if( name == "ai:disp_map" )
+	{
+		// Special case where the whole name is different, not just prefix
+		name = "arnold:displacement";
+	}
+	else
+	{
+		size_t colonPos = name.find( ":" );
+		if( colonPos != std::string::npos )
+		{
+			std::string prefix = name.substr( 0, colonPos );
+			std::string newPrefix;
+			// Translate prefixes.  Currently ai -> arnold is the only mapping supported
+			if( prefix == "ai" )
+			{
+				newPrefix = "arnold";
+			}
+
+			if( newPrefix.size() )
+			{
+				name = newPrefix + name.substr( colonPos );
+			}
+		}
+	}
+
+	Names result;
+	if( isPrimvar )
+	{
+		result.push_back( { TfToken( name ), true } );
+	}
+	if( name.find( ':' ) != std::string::npos )
+	{
+		// We add this one even when the primary version is a primvar, as a
+		// fallback to legacy files from a time when we wrote attributes.
+		result.push_back( { TfToken( name ), false } );
+	}
+	return result;
 }
 
 } // namespace
@@ -135,61 +221,16 @@ pxr::TfToken IECoreUSD::AttributeAlgo::cortexPrimitiveVariableMetadataTokenDepre
 
 IECoreUSD::AttributeAlgo::Name IECoreUSD::AttributeAlgo::nameToUSD( std::string name )
 {
-	if( boost::starts_with( name, g_riPrefix ) && writeConformantRenderManAttributes() )
+	const Names names = usdNames( name );
+	if( names.size() )
 	{
-		const std::string potentialShaderType = name.substr( g_riPrefix.size() );
-		if( g_shaderTypes.count( potentialShaderType ) )
-		{
-			return { pxr::TfToken( name ), true };
-		}
-		return { pxr::TfToken( g_riAttributesPrefix + name.substr( g_riPrefix.size() ) ), true };
+		return names.front();
 	}
-
-	bool isPrimvar = false;
-
-	// The long term plan is to convert only "render:" prefixed attributes to primvars, and it will
-	// be the client's responsibility to ensure everything important gets prefixed with "render:".
-	// But for the moment, Gaffer doesn't do this yet, so we support the two most important prefixes
-	// for Gaffer currently:  "user:" and "ai:".
-	/// \todo I don't think the `render:` plan is working out - it may well be better to just map
-	/// all Cortex attributes to primvars.
-	if( boost::starts_with( name, "render:" ) || boost::starts_with( name, "user:" ) || boost::starts_with( name, "ai:" ) )
-	{
-		isPrimvar = true;
-
-		// Strip the "render:" prefix from when writing attributes as primitive variables
-		if( boost::starts_with( name, g_renderPrefix ) )
-		{
-			name = name.substr( 7 );
-		}
-	}
-
-	if( name == "ai:disp_map" )
-	{
-		// Special case where the whole name is different, not just prefix
-		name = "arnold:displacement";
-	}
-	else
-	{
-		size_t colonPos = name.find( ":" );
-		if( colonPos != std::string::npos )
-		{
-			std::string prefix = name.substr( 0, colonPos );
-			std::string newPrefix;
-			// Translate prefixes.  Currently ai -> arnold is the only mapping supported
-			if( prefix == "ai" )
-			{
-				newPrefix = "arnold";
-			}
-
-			if( newPrefix.size() )
-			{
-				name = newPrefix + name.substr( colonPos );
-			}
-		}
-	}
-
-	return { TfToken( name ), isPrimvar };
+	// This is necessary because `USDScene` calls `nameToUSD()` when writing
+	// materials, and `surface` etc aren't handled by the above.
+	/// \todo It would likely be better if the material-writing code wasn't
+	/// mixed up with this.
+	return { pxr::TfToken( name ), false };
 }
 
 IECore::InternedString IECoreUSD::AttributeAlgo::nameFromUSD( IECoreUSD::AttributeAlgo::Name name )
@@ -241,27 +282,27 @@ IECore::InternedString IECoreUSD::AttributeAlgo::nameFromUSD( IECoreUSD::Attribu
 
 UsdAttribute IECoreUSD::AttributeAlgo::findUSDAttribute( const pxr::UsdPrim &prim, std::string cortexName )
 {
-	AttributeAlgo::Name n = AttributeAlgo::nameToUSD( cortexName );
-	if( n.isPrimvar )
+	for( const auto &n : usdNames( cortexName ) )
 	{
-		if( pxr::UsdGeomPrimvar primvar = pxr::UsdGeomPrimvarsAPI( prim ).GetPrimvar( n.name ) )
+		if( n.isPrimvar )
 		{
-			if( isCortexAttribute( primvar ) )
+			if( pxr::UsdGeomPrimvar primvar = pxr::UsdGeomPrimvarsAPI( prim ).GetPrimvar( n.name ) )
 			{
-				return primvar.GetAttr();
+				if( isCortexAttribute( primvar ) )
+				{
+					return primvar.GetAttr();
+				}
 			}
 		}
-	}
-
-	// In theory, this should be able to be an else.  But for the moment, for attributes that should be written
-	// to a primvar, we try reading them from an attribute if we can't find them in a primvar.  This provides
-	// some backwards compatibility with files from before we started writing to primvars, and might provide
-	// compatibility with other USD authors, maybe?
-	if( pxr::UsdAttribute attribute = prim.GetAttribute( n.name ) )
-	{
-		if ( attribute.GetName().GetString().find( ":" ) != std::string::npos && attribute.IsCustom() )
+		else
 		{
-			return attribute;
+			if( pxr::UsdAttribute attribute = prim.GetAttribute( n.name ) )
+			{
+				if( attribute.IsCustom() )
+				{
+					return attribute;
+				}
+			}
 		}
 	}
 

--- a/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/AttributeAlgo.cpp
@@ -50,14 +50,14 @@ using namespace pxr;
 namespace
 {
 
-static const pxr::TfToken g_cortexPrimitiveVariableMetadataToken( "cortex_isConstantPrimitiveVariable" );
-static const pxr::TfToken g_cortexPrimitiveVariableMetadataTokenDeprecated( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" );
-static const std::string g_primVarPrefix = "primvars:";
-static const std::string g_primVarUserPrefix = "primvars:user:";
-static const std::string g_renderPrefix = "render:";
-static const std::string g_riPrefix = "ri:";
-static const std::string g_riAttributesPrefix = "ri:attributes:";
-static const std::string g_userPrefix = "user:";
+const pxr::TfToken g_cortexPrimitiveVariableMetadataToken( "cortex_isConstantPrimitiveVariable" );
+const pxr::TfToken g_cortexPrimitiveVariableMetadataTokenDeprecated( "IECOREUSD_CONSTANT_PRIMITIVE_VARIABLE" );
+const std::string g_primVarPrefix = "primvars:";
+const std::string g_primVarUserPrefix = "primvars:user:";
+const std::string g_renderPrefix = "render:";
+const std::string g_riPrefix = "ri:";
+const std::string g_riAttributesPrefix = "ri:attributes:";
+const std::string g_userPrefix = "user:";
 
 bool writeConformantRenderManAttributes()
 {
@@ -68,7 +68,7 @@ bool writeConformantRenderManAttributes()
 	return false;
 }
 
-}
+} // namespace
 
 bool IECoreUSD::AttributeAlgo::isCortexAttribute( const pxr::UsdGeomPrimvar &primVar )
 {

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4868,20 +4868,19 @@ class USDSceneTest( unittest.TestCase ) :
 					self.assertEqual( loadedShaderNetwork.getShader( "scale" ).name, "floatAttribute" )
 					self.assertEqual( loadedShaderNetwork.getShader( "scale" ).type, "osl:shader" )
 
-	def testRenderManAttributeRoundTrip( self ) :
+	def testWriteConformantRenderManAttributes( self ) :
 
 		self.addCleanup( os.environ.__delitem__, "IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES" )
 
-		for conformant in True, False :
+		for writeConformant in ( True, False ) :
 
-			with self.subTest( conformant = conformant ) :
-
-				os.environ["IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES"] = str( int( conformant ) )
-
-				fileName = os.path.join( self.temporaryDirectory(), f"renderManAttributes{conformant}.usda" )
+			with self.subTest( writeConformant = writeConformant ) :
 
 				# Test writing to USD.
 
+				os.environ["IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES"] = str( int( writeConformant ) )
+
+				fileName = os.path.join( self.temporaryDirectory(), f"renderManAttributes{writeConformant}.usda" )
 				scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
 				child = scene.createChild( "test" )
 				child.writeAttribute( "ri:trace:maxdiffusedepth", IECore.IntData( 2 ), 0 )
@@ -4904,7 +4903,7 @@ class USDSceneTest( unittest.TestCase ) :
 
 				# The attribute is written differently depending on IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES.
 
-				if conformant :
+				if writeConformant :
 					primVars = pxr.UsdGeom.PrimvarsAPI( stage.GetPrimAtPath( "/test" ) )
 					diffuseDepth = primVars.GetPrimvar( "ri:attributes:trace:maxdiffusedepth" )
 					self.assertTrue( diffuseDepth.IsDefined() )
@@ -4916,6 +4915,7 @@ class USDSceneTest( unittest.TestCase ) :
 					self.assertEqual( diffuseDepth.Get( 0 ), 2 )
 
 				# But the materials should be the same either way, with an `ri:surface` terminal.
+
 				for purpose in [ "", "full" ] :
 					material = pxr.UsdShade.MaterialBindingAPI( stage.GetPrimAtPath( "/test" ) ).ComputeBoundMaterial( purpose )[0]
 					output = material.GetOutput( "ri:surface" )
@@ -4924,12 +4924,20 @@ class USDSceneTest( unittest.TestCase ) :
 
 				# Test loading back to Cortex.
 
-				scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
-				child = scene.child( "test" )
-				self.assertEqual( set( child.attributeNames() ), { "ri:trace:maxdiffusedepth", "ri:surface", "ri:surface:full" } )
-				self.assertEqual( child.readAttribute( "ri:trace:maxdiffusedepth", 0 ), IECore.IntData( 2 ) )
-				self.assertEqual( child.readAttribute( "ri:surface", 0 ), surface )
-				self.assertEqual( child.readAttribute( "ri:surface:full", 0 ), surfaceFull )
+				for readConformant in ( True, False ) :
+
+					with self.subTest( readConformant = readConformant ) :
+
+						os.environ["IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES"] = str( int( readConformant ) )
+
+						fileName = os.path.join( self.temporaryDirectory(), f"renderManAttributes{writeConformant}.usda" )
+
+						scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+						child = scene.child( "test" )
+						self.assertEqual( set( child.attributeNames() ), { "ri:trace:maxdiffusedepth", "ri:surface", "ri:surface:full" } )
+						self.assertEqual( child.readAttribute( "ri:trace:maxdiffusedepth", 0 ), IECore.IntData( 2 ) )
+						self.assertEqual( child.readAttribute( "ri:surface", 0 ), surface )
+						self.assertEqual( child.readAttribute( "ri:surface:full", 0 ), surfaceFull )
 
 if __name__ == "__main__":
 	unittest.main()

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4885,9 +4885,24 @@ class USDSceneTest( unittest.TestCase ) :
 				scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
 				child = scene.createChild( "test" )
 				child.writeAttribute( "ri:trace:maxdiffusedepth", IECore.IntData( 2 ), 0 )
+
+				surface = IECoreScene.ShaderNetwork(
+					shaders = { "constant" : IECoreScene.Shader( "PxrDiffuse" ) },
+					output = ( "constant", "out_bxdf" )
+				)
+				child.writeAttribute( "ri:surface", surface, 0.0 )
+
+				surfaceFull = IECoreScene.ShaderNetwork(
+					shaders = { "constant" : IECoreScene.Shader( "PxrSurface" ) },
+					output = ( "constant", "out_bxdf" )
+				)
+				child.writeAttribute( "ri:surface:full", surfaceFull, 0.0 )
+
 				del scene, child
 
 				stage = pxr.Usd.Stage.Open( fileName )
+
+				# The attribute is written differently depending on IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES.
 
 				if conformant :
 					primVars = pxr.UsdGeom.PrimvarsAPI( stage.GetPrimAtPath( "/test" ) )
@@ -4900,12 +4915,21 @@ class USDSceneTest( unittest.TestCase ) :
 					diffuseDepth = stage.GetPrimAtPath( "/test" ).GetAttribute( "ri:trace:maxdiffusedepth" )
 					self.assertEqual( diffuseDepth.Get( 0 ), 2 )
 
+				# But the materials should be the same either way, with an `ri:surface` terminal.
+				for purpose in [ "", "full" ] :
+					material = pxr.UsdShade.MaterialBindingAPI( stage.GetPrimAtPath( "/test" ) ).ComputeBoundMaterial( purpose )[0]
+					output = material.GetOutput( "ri:surface" )
+					self.assertTrue( output )
+					self.assertEqual( output.GetConnectedSource()[1], "out_bxdf" )
+
 				# Test loading back to Cortex.
 
 				scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
 				child = scene.child( "test" )
-				self.assertEqual( child.attributeNames(), [ "ri:trace:maxdiffusedepth" ] )
+				self.assertEqual( set( child.attributeNames() ), { "ri:trace:maxdiffusedepth", "ri:surface", "ri:surface:full" } )
 				self.assertEqual( child.readAttribute( "ri:trace:maxdiffusedepth", 0 ), IECore.IntData( 2 ) )
+				self.assertEqual( child.readAttribute( "ri:surface", 0 ), surface )
+				self.assertEqual( child.readAttribute( "ri:surface:full", 0 ), surfaceFull )
 
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
I messed up in 5e2f322b19d4d5cc9882b5380337e46b5b1c8985, because I didn't realise the full effects of changing `AttributeAlgo::nameToUSD()`. Despite the function name, this was used when _reading_ attributes too, and was also used when determining the names to use for UsdShadeShader outputs. This lead to several bugs :

- Failure to read shaders written with IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=0.
- Bad output names when writing shaders with IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES=1.
- Failure to read renderman attributes written with a different value of IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES.

All this stuff is well overdue for a complete simplification where we only write attributes as primvars, but since we need this for 1.6.
x, I've made the most minimal change I can that I think is logical and fixes the problems. The fundamental issue is that because we want to support legacy attributes too, and `nameToUSD()` is used for reading, there is not a 1-to-1 mapping of Cortex names to USD names. This is reflected in the new internal `usdNames()` function which lists the relevant attribute names in the order we'd prefer to use them.