### PR TITLE
PointInstancer : Add `instanceAttributes()` method

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,12 @@
 10.7.x.x (relative to 10.7.0.0a14)
 ========
 
+Improvements
+------------
 
+- PointInstancer : Added `instanceAttributes()` method [^1].
+
+[^1]: To be omitted from the notes for the final 10.7.0.0 release.
 
 10.7.0.0a14 (relative to 10.7.0.0a13)
 ===========

--- a/include/IECoreScene/PointInstancer.h
+++ b/include/IECoreScene/PointInstancer.h
@@ -38,6 +38,9 @@
 
 #include "IECoreScene/PointsPrimitive.h"
 
+#include "boost/range/adaptor/filtered.hpp"
+#include "boost/range/iterator_range.hpp"
+
 #include <unordered_set>
 
 namespace IECoreScene
@@ -112,6 +115,20 @@ class IECORESCENE_API PointInstancer : public IECoreScene::PointsPrimitive
 		void setInvisibleIDs( const IECore::Int64VectorDataPtr &invisibleIds );
 		PrimitiveVariable::IndexedView<int64_t> getInvisibleIDs() const;
 
+		/// Instance Attributes
+		/// ===================
+
+		struct InstanceAttributePredicate;
+		/// \todo Use `std::ranges` when we have access to C++20.
+		using ConstPrimitiveVariableRange = boost::iterator_range<PrimitiveVariableMap::const_iterator>;
+		using InstanceAttributeRange = boost::filtered_range<InstanceAttributePredicate, ConstPrimitiveVariableRange>;
+
+		/// Returns the range of PrimitiveVariables that should be converted
+		/// to per-instance attributes for rendering. All vertex or varying
+		/// primitive variables not included in the accessors above are
+		/// interpreted as shading attributes.
+		InstanceAttributeRange instanceAttributes() const;
+
 		/// Queries
 		/// =======
 		///
@@ -163,3 +180,5 @@ class IECORESCENE_API PointInstancer : public IECoreScene::PointsPrimitive
 IE_CORE_DECLAREPTR( PointInstancer )
 
 } // namespace IECoreScene
+
+#include "IECoreScene/PointInstancer.inl"

--- a/include/IECoreScene/PointInstancer.inl
+++ b/include/IECoreScene/PointInstancer.inl
@@ -1,0 +1,67 @@
+//////////////////////////////////////////////////////////////////////////
+//
+//  Copyright (c) 2026, Cinesite VFX Ltd. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are
+//  met:
+//
+//      * Redistributions of source code must retain the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer.
+//
+//      * Redistributions in binary form must reproduce the above
+//        copyright notice, this list of conditions and the following
+//        disclaimer in the documentation and/or other materials provided with
+//        the distribution.
+//
+//      * Neither the name of John Haddon nor the names of
+//        any other contributors to this software may be used to endorse or
+//        promote products derived from this software without specific prior
+//        written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+//  IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+//  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+//  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+//  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+//  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+//  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+//  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+//////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+namespace IECoreScene
+{
+
+struct PointInstancer::InstanceAttributePredicate
+{
+	bool operator() ( const PrimitiveVariableMap::value_type &value )
+	{
+		/// \todo There's a cleaner distinction between the core properties
+		/// and instance attributes in USD's representation because the
+		/// latter are authored separately via UsdGeomPrimvarsAPI. We
+		/// might want to consider namespacing of some sort in our
+		/// representation, but for now we need to stick to the current set
+		/// of names for backwards compatibility.
+		return
+			(
+				value.second.interpolation == PrimitiveVariable::Vertex ||
+				value.second.interpolation == PrimitiveVariable::Varying
+			) &&
+			value.first != "prototypeRoots" &&
+			value.first != "prototypeIndex" &&
+			value.first != "P" &&
+			value.first != "scale" &&
+			value.first != "orientation" &&
+			value.first != "instanceId"
+		;
+	}
+};
+
+} // namespace IECoreScene

--- a/src/IECoreScene/PointInstancer.cpp
+++ b/src/IECoreScene/PointInstancer.cpp
@@ -210,6 +210,12 @@ PrimitiveVariable::IndexedView<int64_t> PointInstancer::getInvisibleIDs() const
 	return optionalView ? *optionalView : PrimitiveVariable::IndexedView<int64_t>();
 }
 
+PointInstancer::InstanceAttributeRange PointInstancer::instanceAttributes() const
+{
+	ConstPrimitiveVariableRange range( variables );
+	return boost::adaptors::filter( range, InstanceAttributePredicate() );
+}
+
 // Query
 // =====
 

--- a/src/IECoreScene/bindings/PointInstancerBinding.cpp
+++ b/src/IECoreScene/bindings/PointInstancerBinding.cpp
@@ -48,6 +48,16 @@ using namespace IECoreScene;
 namespace
 {
 
+dict instanceAttributesWrapper( const PointInstancer &instancer )
+{
+	dict result;
+	for( const auto &[name, primitiveVariable] : instancer.instanceAttributes() )
+	{
+		result[name] = primitiveVariable;
+	}
+	return result;
+}
+
 } // namespace
 
 void IECoreSceneModule::bindPointInstancer()
@@ -68,6 +78,7 @@ void IECoreSceneModule::bindPointInstancer()
 		.def( "getID", &PointInstancer::getID )
 		.def( "setInvisibleIDs", &PointInstancer::setInvisibleIDs )
 		.def( "getInvisibleIDs", &PointInstancer::getInvisibleIDs )
+		.def( "instanceAttributes", &instanceAttributesWrapper )
 	;
 
 	class_<PointInstancer::VisibilityQuery>( "VisibilityQuery", no_init )

--- a/test/IECoreScene/PointInstancerTest.py
+++ b/test/IECoreScene/PointInstancerTest.py
@@ -98,5 +98,24 @@ class PointInstancerTest( unittest.TestCase ) :
 		for i in range( 4 ) :
 			self.assertEqual( query.transform( i ), imath.M44f().translate( imath.V3f( i, 0, 0 ) ) )
 
+	def testInstanceAttributes( self ) :
+
+		instancer = IECoreScene.PointInstancer( 1 )
+
+		instancer.setPrototypes( IECore.StringVectorData( [ "prototypes/proto1" ] ) )
+		instancer.setPrototypeIndex( IECore.IntVectorData( [ 0 ] ) )
+		instancer.setPosition( IECore.V3fVectorData( [ imath.V3f( 0 ) ] ) )
+		instancer.setScale( IECore.V3fVectorData( [ imath.V3f( 0 ) ] ) )
+		instancer.setOrientation( IECore.QuatfVectorData( [ imath.Quatf() ] ) )
+		instancer.setID( IECore.Int64VectorData( [ 0 ] ) )
+
+		instancer["constant"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.StringData( "test" ) )
+		instancer["vertex"] = IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Vertex, IECore.StringVectorData( [ "test" ] ) )
+
+		self.assertEqual(
+			instancer.instanceAttributes(),
+			{ "vertex" : instancer["vertex"] }
+		)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This identifies the vertex primitive variables that should be converted to per-instance attributes when rendering. Once this is merged I'll have a PR for using them in Gaffer's renderer backends.