### PR TITLE
CI : Update to macos-15 runner image with Xcode 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
             jobs: 4
 
           - name: macos-arm64-platform25
-            os: macos-14
+            os: macos-15
             buildType: RELEASE
             options: .github/workflows/main/options.posix
             dependenciesURL: https://github.com/GafferHQ/dependencies/releases/download/11.0.0a8/gafferDependencies-11.0.0a8-macos-platform25.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           linux-debug-platform25,
           windows-platform25,
           windows-debug-platform25,
-          macos-arm64-platform25
+          macos-platform25
         ]
 
         include:
@@ -88,7 +88,7 @@ jobs:
             publish: false
             jobs: 4
 
-          - name: macos-arm64-platform25
+          - name: macos-platform25
             os: macos-15
             buildType: RELEASE
             options: .github/workflows/main/options.posix

--- a/SConstruct
+++ b/SConstruct
@@ -872,6 +872,13 @@ if env["PLATFORM"] != "win32" :
 		# Work around Boost issues with Xcode 15 where `std::unary_function` has been removed.
 		if clangVersion >= [ 15, 0, 0 ] :
 			env.Append( CXXFLAGS = [ "-DBOOST_NO_CXX98_FUNCTION_BASE", "-D_HAS_AUTO_PTR_ETC=0" ] )
+		if clangVersion >= [ 16, 0, 0 ] :
+			# XCode 16 warns about deprecations in fmtlib. Overriding `FMT_DEPRECATED`
+			# allows us to remove the [[deprecated]] attributes and still build with
+			# `-Werror,-Wdeprecated-declarations`.
+			env.Append( CPPDEFINES = [ ( "FMT_DEPRECATED", "" ), ] )
+			# Disable new warnings about ObjectInterpolator::InterpolatorDescription's reinterpret_cast.
+			env.Append( CXXFLAGS = [ "-Wno-cast-function-type-mismatch" ] )
 		# Disable FMA on arm64 builds to limit floating point discrepancies with x86_64 builds.
 		if platform.machine() == "arm64" :
 			env.Append( CXXFLAGS = [ "-ffp-contract=off" ] )


### PR DESCRIPTION
The `macos-14` runner image is now deprecated and is expected to be removed within the maintenance lifespan of Cortex 10.7 (brownouts begin in October, and it will be fully unsupported by November 2nd).