### PR TITLE
USDScene : Accommodate non-standard component conections from Arnold/Solaris

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,11 @@ Improvements
 
 - PointInstancer : Added `instanceAttributes()` method [^1].
 
+Fixes
+-----
+
+- USDScene : Fixed loading of non-standard component connections in Arnold materials exported from Solaris.
+
 [^1]: To be omitted from the notes for the final 10.7.0.0 release.
 
 10.7.0.0a14 (relative to 10.7.0.0a13)

--- a/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/ShaderAlgo.cpp
@@ -240,12 +240,24 @@ bool nonStandardLightParametersMightBeTimeVarying( const pxr::UsdPrim &prim )
 
 const std::regex g_arrayIndexFromUSDRegex( ":i([0-9]+)$" );
 const std::string g_arrayIndexFromUSDFormat( "[$1]" );
+const std::regex g_componentFromUSDRegex( ":([rgbaxyz])$" );
+const std::string g_componentFromUSDFormat( ".$1" );
+
 IECore::InternedString fromUSDParameterName( const pxr::TfToken &usdName )
 {
 	// USD doesn't support connections to array indices. So Arnold-USD emulates
 	// them using its own `parameter:i<N>`syntax - see https://github.com/Autodesk/arnold-usd/pull/381.
 	// We convert these to the regular `parameter[N]` syntax during loading.
-	return std::regex_replace( usdName.GetString(), g_arrayIndexFromUSDRegex, g_arrayIndexFromUSDFormat );
+	std::string result = std::regex_replace( usdName.GetString(), g_arrayIndexFromUSDRegex, g_arrayIndexFromUSDFormat );
+	// Likewise, USD doesn't support connections to or from individual components of a vector
+	// or colour. But we've received files out of Solaris where component outputs for Arnold
+	// shaders have been emulated as `<parameter>:[rgbaxyz]`. Convert to our usual
+	// `<parameter>.[rgbaxyz]` syntax.
+	/// \todo Determine just how off-spec these files are. It would certainly be nice if this
+	/// became an official standard - it's much simpler than all the hoops we're jumping through
+	/// to insert and remove split/join adaptors.
+	result = std::regex_replace( result, g_componentFromUSDRegex, g_componentFromUSDFormat );
+	return IECore::InternedString( result );
 }
 
 const std::regex g_arrayIndexFromCortexRegex( "\\[([0-9]+)\\]$" );
@@ -354,7 +366,7 @@ IECoreScene::ShaderNetwork::Parameter readShaderNetworkWalk( const pxr::SdfPath 
 	IECore::InternedString shaderHandle = readShaderNetworkWalk( anchorPath, pxr::UsdShadeConnectableAPI( output.GetPrim() ), timeCode, shaderNetwork );
 	if( output.GetBaseName() != "DEFAULT_OUTPUT" )
 	{
-		return IECoreScene::ShaderNetwork::Parameter( shaderHandle, output.GetBaseName().GetString() );
+		return IECoreScene::ShaderNetwork::Parameter( shaderHandle, fromUSDParameterName( output.GetBaseName() ) );
 	}
 	else
 	{

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -4137,6 +4137,34 @@ class USDSceneTest( unittest.TestCase ) :
 		scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
 		assertExpectedArrayInputs( scene.child( "sphere" ).readAttribute( "ai:surface", 0 ) )
 
+	def testArnoldComponentInputs( self ) :
+
+		def assertExpectedInputs( network ) :
+
+			inputs = network.inputConnections( "standardSurface" )
+			self.assertEqual( len( inputs ), 1 )
+			self.assertEqual( inputs[0], ( ( "state_vector", "out_variable.y" ), ( "standardSurface", "indirect_specular" ) ) )
+
+		# Load original USD.
+
+		scene = IECoreScene.SceneInterface.create(
+			os.path.join( os.path.dirname( __file__ ), "data", "arnoldComponentConnections.usda" ),
+			IECore.IndexedIO.OpenMode.Read
+		)
+		network = scene.child( "sphere" ).readAttribute( "ai:surface", 0 )
+
+		assertExpectedInputs( network )
+
+		# Write our own USD from that data, to check we can round-trip it.
+
+		fileName = os.path.join( self.temporaryDirectory(), "arnoldComponentConnectionsRewritten.usda" )
+		scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Write )
+		scene.createChild( "sphere" ).writeAttribute( "ai:surface", network, 0 )
+
+		del scene
+		scene = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+		assertExpectedInputs( scene.child( "sphere" ).readAttribute( "ai:surface", 0 ) )
+
 	def testInvalidPrimitiveVariables( self ) :
 
 		goodRoot = IECoreScene.SceneInterface.create( os.path.dirname( __file__ ) + "/data/cube.usda", IECore.IndexedIO.OpenMode.Read )

--- a/contrib/IECoreUSD/test/IECoreUSD/data/arnoldComponentConnections.usda
+++ b/contrib/IECoreUSD/test/IECoreUSD/data/arnoldComponentConnections.usda
@@ -1,0 +1,28 @@
+#usda 1.0
+
+def Sphere "sphere" (
+    prepend apiSchemas = ["MaterialBindingAPI"]
+)
+{
+    rel material:binding = </testMaterial>
+}
+
+def Material "testMaterial"
+{
+    token outputs:arnold:surface.connect = </testMaterial/standardSurface.outputs:surface>
+
+    def Shader "standardSurface"
+    {
+        uniform token info:id = "arnold:standard_surface"
+        float inputs:indirect_specular = 0
+        float inputs:indirect_specular.connect = </testMaterial/state_vector.outputs:out_variable:y>
+        token outputs:surface
+    }
+
+    def Shader "state_vector"
+    {
+        uniform token info:id = "arnold:state_vector"
+        vector outputs:out_variable
+        float outputs:out_variable:y
+    }
+}


### PR DESCRIPTION
When using an Arnold Material Builder in Solaris, the Arnold shader nodes have additional outputs for each of the components of vector and color outputs. I do not know why. Such outputs are not present in the Ndr registry. When using them, you get a USD file with connections from outputs such as `output:out_variable:x`. This isn't standard USD, but it maps nicely to our own support for component connections, so we now do the necessary conversion on loading. Note that we don't do the reverse on saving, because we instead write split/join adaptors in an effort to adhere to the USD spec (at least as far as we understand it).

I'm especially baffled by this, because if you create an Arnold universe containing a component connection, and write it to USD via `AiSceneWrite()`, you get a compliant USD file utilising a `float_to_rgb` adaptor. So at least one person at Autodesk interprets the spec the way we do. They maybe just haven't spoken to the rest of the team ;)

Given my recent misadventure with `IECOREUSD_WRITE_CONFORMANT_RENDERMAN_ATTRIBUTES` I'm not sure how much I want to push this into 10.6.x. For now I've just made the PR to main so we can discuss - either way it's going to need a rebase before merging.