### PR TITLE
Add `fmt` 12.2.0 compatibility

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,13 @@ Improvements
 ------------
 
 - PathMatcher : Added `in()` and `containing()` methods.
+- TypeId : Added `format_as` overload, so that TypeIds can be passed to `fmt::format()`.
+- PrimitiveVariable : Added `format_as` overload for `Interpolation`, so that it can be passed to `fmt::format()`.
+
+Build
+-----
+
+- LibFormat : Added compatibility with `fmt` 12.2.0.
 
 10.7.0.0
 ========

--- a/SConstruct
+++ b/SConstruct
@@ -873,10 +873,6 @@ if env["PLATFORM"] != "win32" :
 		if clangVersion >= [ 15, 0, 0 ] :
 			env.Append( CXXFLAGS = [ "-DBOOST_NO_CXX98_FUNCTION_BASE", "-D_HAS_AUTO_PTR_ETC=0" ] )
 		if clangVersion >= [ 16, 0, 0 ] :
-			# XCode 16 warns about deprecations in fmtlib. Overriding `FMT_DEPRECATED`
-			# allows us to remove the [[deprecated]] attributes and still build with
-			# `-Werror,-Wdeprecated-declarations`.
-			env.Append( CPPDEFINES = [ ( "FMT_DEPRECATED", "" ), ] )
 			# Disable new warnings about ObjectInterpolator::InterpolatorDescription's reinterpret_cast.
 			env.Append( CXXFLAGS = [ "-Wno-cast-function-type-mismatch" ] )
 		# Disable FMA on arm64 builds to limit floating point discrepancies with x86_64 builds.

--- a/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
+++ b/contrib/IECoreAlembic/src/IECoreAlembic/AlembicScene.cpp
@@ -836,7 +836,7 @@ class AlembicScene::AlembicReader : public AlembicIO
 			IECore::msg(
 				IECore::Msg::Warning,
 				"AlembicScene::readAttributeAtSample",
-				"Unsupported attribute type datatype: \"{}\" extent:{} interpretation:\"{}\"", pod, extent, getInterpretation()
+				"Unsupported attribute type datatype: \"{}\" extent:{} interpretation:\"{}\"", fmt::underlying( pod ), extent, getInterpretation()
 			);
 
 			return nullptr;

--- a/include/IECore/TypeIds.h
+++ b/include/IECore/TypeIds.h
@@ -326,6 +326,12 @@ enum TypeId
 
 };
 
+/// Enable fmtlib formatting of TypeId as its numeric value.
+inline int format_as( TypeId typeId )
+{
+	return static_cast<int>( typeId );
+}
+
 } // namespace IECore
 
 #endif // IE_CORE_TYPEIDS_H

--- a/include/IECoreScene/PrimitiveVariable.inl
+++ b/include/IECoreScene/PrimitiveVariable.inl
@@ -181,6 +181,12 @@ typename PrimitiveVariable::IndexedView<T>::Iterator PrimitiveVariable::IndexedV
 /// A simple type to hold named PrimitiveVariables.
 typedef std::map<std::string, PrimitiveVariable> PrimitiveVariableMap;
 
+/// Enable fmtlib formatting of Interpolation as its numeric value.
+inline int format_as( PrimitiveVariable::Interpolation interpolation )
+{
+	return static_cast<int>( interpolation );
+}
+
 } // namespace IECoreScene
 
 #endif // IECORESCENE_PRIMITIVEVARIABLE_INL

--- a/src/IECore/StreamIndexedIO.cpp
+++ b/src/IECore/StreamIndexedIO.cpp
@@ -579,6 +579,12 @@ protected :
 
 };
 
+/// Enable fmtlib formatting of NodeType as its numeric value.
+inline int format_as( NodeBase::NodeType nodeType )
+{
+	return static_cast<int>( nodeType );
+}
+
 /// Class that represents small data nodes
 class SmallDataNode : public NodeBase
 {


### PR DESCRIPTION
This allows Cortex to build with modern versions of `libfmt` while maintaining compatibility with our current version of 9.1.0. As a result we can remove the `FMT_DEPRECATED` workaround recently added for Xcode 16, as the `format_as()` overloads in this PR mean that we're no longer hitting deprecated functionality in `libfmt` 9.1.0.