### PR TITLE
ImageReader, TextureLoader : Remove special case for png colorspaces

### DIFF
--- a/Changes
+++ b/Changes
@@ -14,6 +14,11 @@ Improvements
 - PrimitiveVariable : Added `format_as` overload for `Interpolation`, so that it can be passed to `fmt::format()`.
 - AlembicScene : Added support for reading `P3d` and `N3d` GeomParams.
 
+Fixes
+-----
+
+- ImageReader, TextureLoader : Removed special case for colorspaces when opening pngs.
+
 Build
 -----
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,13 @@
-10.7.x.x (relative to 10.7.1.0)
+10.7.x.x (relative to 10.7.1.1)
 ========
 
+10.7.1.1 (relative to 10.7.1.0)
+========
 
+Fixes
+-----
+
+- ImageReader, TextureLoader : Removed special case for colorspaces when opening pngs.
 
 10.7.1.0 (relative to 10.7.0.0)
 ========
@@ -13,11 +19,6 @@ Improvements
 - TypeId : Added `format_as` overload, so that TypeIds can be passed to `fmt::format()`.
 - PrimitiveVariable : Added `format_as` overload for `Interpolation`, so that it can be passed to `fmt::format()`.
 - AlembicScene : Added support for reading `P3d` and `N3d` GeomParams.
-
-Fixes
------
-
-- ImageReader, TextureLoader : Removed special case for colorspaces when opening pngs.
 
 Build
 -----

--- a/SConstruct
+++ b/SConstruct
@@ -54,7 +54,7 @@ SConsignFile()
 ieCoreMilestoneVersion = 10 # for announcing major milestones - may contain all of the below
 ieCoreMajorVersion = 7 # backwards-incompatible changes
 ieCoreMinorVersion = 1 # new backwards-compatible features
-ieCorePatchVersion = 0 # bug fixes
+ieCorePatchVersion = 1 # bug fixes
 ieCoreVersionSuffix = "" # used for alpha/beta releases. Example: "a1", "b2", etc.
 
 ###########################################################################################

--- a/src/IECoreGL/TextureLoader.cpp
+++ b/src/IECoreGL/TextureLoader.cpp
@@ -145,30 +145,14 @@ TexturePtr TextureLoader::load( const std::string &name, int maximumResolution )
 	}
 
 	// This logic feels pretty broken - why do we ask the current color config's
-	// display transform to decide what colorspace a file is stored in?  Why special
-	// case just png.  But I've currently copied this logic from ImageReader in the
+	// display transform to decide what colorspace a file is stored in?
+	// But I've currently copied this logic from ImageReader in the
 	// name of backwards compatibility
 	std::string linearColorSpace;
 	std::string currentColorSpace;
 	OIIO::string_view fileFormat = imageBuf.file_format_name();
-	if( fileFormat == "png" )
-	{
-		// The most common use for loading PNGs via Cortex is for icons in Gaffer.
-		// If we were to use the OCIO config to guess the colorspaces as below, we
-		// would get it spectacularly wrong. For instance, with an ACES config the
-		// resulting icons are so washed out as to be illegible. Instead, we hardcode
-		// the rudimentary colour spaces much more likely to be associated with a PNG.
-		// These are supported by OIIO regardless of what OCIO config is in use.
-		/// \todo Should this apply to other formats too? Can we somehow fix
-		/// `OpenImageIOAlgo::colorSpace` instead?
-		linearColorSpace = "linear";
-		currentColorSpace = "sRGB";
-	}
-	else
-	{
-		linearColorSpace = IECoreImage::OpenImageIOAlgo::colorSpace( "", imageBuf.spec() );
-		currentColorSpace = IECoreImage::OpenImageIOAlgo::colorSpace( fileFormat, imageBuf.spec() );
-	}
+	linearColorSpace = IECoreImage::OpenImageIOAlgo::colorSpace( "", imageBuf.spec() );
+	currentColorSpace = IECoreImage::OpenImageIOAlgo::colorSpace( fileFormat, imageBuf.spec() );
 
 	if( !OIIO::ImageBufAlgo::colorconvert( imageBuf, imageBuf, currentColorSpace, linearColorSpace ) )
 	{

--- a/src/IECoreImage/ImageReader.cpp
+++ b/src/IECoreImage/ImageReader.cpp
@@ -479,24 +479,8 @@ class ImageReader::Implementation
 					OIIO::TypeString, &fileFormat
 				);
 
-				if( strcmp( fileFormat, "png" ) == 0 )
-				{
-					// The most common use for loading PNGs via Cortex is for icons in Gaffer.
-					// If we were to use the OCIO config to guess the colorspaces as below, we
-					// would get it spectacularly wrong. For instance, with an ACES config the
-					// resulting icons are so washed out as to be illegible. Instead, we hardcode
-					// the rudimentary colour spaces much more likely to be associated with a PNG.
-					// These are supported by OIIO regardless of what OCIO config is in use.
-					/// \todo Should this apply to other formats too? Can we somehow fix
-					/// `OpenImageIOAlgo::colorSpace` instead?
-					m_linearColorSpace = "linear";
-					m_currentColorSpace = "sRGB";
-				}
-				else
-				{
-					m_linearColorSpace = OpenImageIOAlgo::colorSpace( "", *spec );
-					m_currentColorSpace = OpenImageIOAlgo::colorSpace( fileFormat, *spec );
-				}
+				m_linearColorSpace = OpenImageIOAlgo::colorSpace( "", *spec );
+				m_currentColorSpace = OpenImageIOAlgo::colorSpace( fileFormat, *spec );
 
 				return true;
 			}


### PR DESCRIPTION
OIIO 3 doesn't have "linear" built-in anymore, and it now needs to come from the config.

This is causing errors when trying to open png files, as often there isn't a colorspace specifically called "linear".

The original reasons for hard-coding that colorspace don't seem to apply anymore, neither ImageEngine nor gaffer are loading UI icons that way, so it seems reasonable to remove it, and treat png files just like any other image.

Generally describe what this PR will do, and why it is needed.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
