### PR TITLE
FileSequenceFunctions : Fix error in ls() for sequences starting with #

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
 10.6.x.x (relative to 10.6.7.1)
 ========
 
+Fixes
+-----
 
+- IECore.ls() : Fixed error when sequence started with `#`.
 
 10.6.7.1 (relative to 10.6.7.0)
 ========

--- a/src/IECore/FileSequenceFunctions.cpp
+++ b/src/IECore/FileSequenceFunctions.cpp
@@ -244,7 +244,7 @@ void IECore::ls( const std::string &sequencePath, FileSequencePtr &sequence, siz
 	{
 		const std::string fileName = it->path().PATH_TO_STRING;
 
-		if ( fileName.size() >= std::min( prefix.size(), suffix.size() ) && fileName.substr( 0, prefix.size() ) == prefix && fileName.substr( fileName.size() - suffix.size(), suffix.size() ) == suffix )
+		if ( fileName.size() >= prefix.size() + suffix.size() && fileName.substr( 0, prefix.size() ) == prefix && fileName.substr( fileName.size() - suffix.size(), suffix.size() ) == suffix )
 		{
 			files.push_back( ( dir / boost::filesystem::path( fileName ) ).string() );
 		}

--- a/test/IECore/FileSequence.py
+++ b/test/IECore/FileSequence.py
@@ -465,6 +465,28 @@ class testLs( unittest.TestCase ) :
 		l = IECore.ls( os.path.join( "test", "sequences", "lsTest", "a.###.tif" ) )
 		self.assertFalse( l )
 
+	def testShortFileInDirectory( self ) :
+
+		"""A directory entry shorter than the sequence's suffix must not cause a
+		crash (unsigned underflow in substr) when ls() scans the directory."""
+
+		self.tearDown()
+		os.makedirs( os.path.join( "test", "sequences", "lsTest" ) )
+
+		# A sequence with an empty prefix (section before #) and a long suffix (section after)
+		s = IECore.FileSequence( os.path.join( "test", "sequences", "lsTest", "#_a_very_long_filename.ext" ), IECore.FrameRange( 1, 1 ) )
+		for f in s.fileNames() :
+			self.touch( f )
+
+		# A file whose name is shorter than the sequence's suffix in the same directory.
+		# Previously this triggered:
+		# IndexError: basic_string::substr: __pos (which is 18446744073709551582) > this->size() (which is 4)
+		self.touch( os.path.join( "test", "sequences", "lsTest", "a.b" ) )
+
+		l = IECore.ls( s.fileName, minSequenceSize=1 )
+		self.assertTrue( l )
+		self.assertEqual( l.frameList.asList(), [ 1 ] )
+
 	def tearDown( self ) :
 
 		if os.path.exists( os.path.join( "test", "sequences" ) ) :


### PR DESCRIPTION
The sequence overload of IECore::ls() could error with:
```
IndexError: basic_string::substr: __pos (which is 18446744073709551582) > this->size() (which is 4)
```

when scanning a directory that contained an entry shorter than the sequence's derived suffix. The length guard used
`std::min( prefix.size(), suffix.size() )`, which let short directory entries pass. The subsequent `fileName.size() - suffix.size()` is an unsigned subtraction that underflowed to a huge value, which was then passed to std::string::substr.

Replaced the guard with `prefix.size() + suffix.size()`. Since prefix and suffix are the non-overlapping leading/trailing parts of the name, a match must be at least as long as both combined.

Generally describe what this PR will do, and why it is needed.

- List specific new features and changes to project components

### Related Issues ###

`IECore.ls( fileSequencePath )` could raise an `IndexError` if the `fileSequencePath` started with `#` and the same directory had any files or directories with fewer characters than `fileSequencePath`.

### Checklist ###

- [x] I have read the [contribution guidelines](https://github.com/ImageEngine/cortex/blob/main/CONTRIBUTING.md).
- [x] I have updated the documentation, if applicable.
- [x] I have tested my change(s) in the test suite, and added new test cases where necessary.
- [x] My code follows the Cortex project's prevailing coding style and conventions.
