### PR TITLE
IECore.ls() fix backport for 10.5

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,11 @@
 10.5.x.x (relative to 10.5.18.0)
 ========
 
+Fixes
+-----
+
+- IECore.ls() : Fixed error when sequence started with `#`.
+
 10.5.18.0 (relative to 10.5.17.0)
 ========
 

--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
-10.5.x.x (relative to 10.5.18.0)
+10.5.x.x (relative to 10.5.18.1)
+========
+
+10.5.18.1 (relative to 10.5.18.0)
 ========
 
 Fixes

--- a/SConstruct
+++ b/SConstruct
@@ -55,7 +55,7 @@ SConsignFile()
 ieCoreMilestoneVersion = 10 # for announcing major milestones - may contain all of the below
 ieCoreMajorVersion = 5 # backwards-incompatible changes
 ieCoreMinorVersion = 18 # new backwards-compatible features
-ieCorePatchVersion = 0 # bug fixes
+ieCorePatchVersion = 1 # bug fixes
 ieCoreVersionSuffix = "" # used for alpha/beta releases. Example: "a1", "b2", etc.
 
 ###########################################################################################

--- a/src/IECore/FileSequenceFunctions.cpp
+++ b/src/IECore/FileSequenceFunctions.cpp
@@ -244,7 +244,7 @@ void IECore::ls( const std::string &sequencePath, FileSequencePtr &sequence, siz
 	{
 		const std::string fileName = it->path().PATH_TO_STRING;
 
-		if ( fileName.size() >= std::min( prefix.size(), suffix.size() ) && fileName.substr( 0, prefix.size() ) == prefix && fileName.substr( fileName.size() - suffix.size(), suffix.size() ) == suffix )
+		if ( fileName.size() >= prefix.size() + suffix.size() && fileName.substr( 0, prefix.size() ) == prefix && fileName.substr( fileName.size() - suffix.size(), suffix.size() ) == suffix )
 		{
 			files.push_back( ( dir / boost::filesystem::path( fileName ) ).string() );
 		}

--- a/test/IECore/FileSequence.py
+++ b/test/IECore/FileSequence.py
@@ -465,6 +465,28 @@ class testLs( unittest.TestCase ) :
 		l = IECore.ls( os.path.join( "test", "sequences", "lsTest", "a.###.tif" ) )
 		self.assertFalse( l )
 
+	def testShortFileInDirectory( self ) :
+
+		"""A directory entry shorter than the sequence's suffix must not cause a
+		crash (unsigned underflow in substr) when ls() scans the directory."""
+
+		self.tearDown()
+		os.makedirs( os.path.join( "test", "sequences", "lsTest" ) )
+
+		# A sequence with an empty prefix (section before #) and a long suffix (section after)
+		s = IECore.FileSequence( os.path.join( "test", "sequences", "lsTest", "#_a_very_long_filename.ext" ), IECore.FrameRange( 1, 1 ) )
+		for f in s.fileNames() :
+			self.touch( f )
+
+		# A file whose name is shorter than the sequence's suffix in the same directory.
+		# Previously this triggered:
+		# IndexError: basic_string::substr: __pos (which is 18446744073709551582) > this->size() (which is 4)
+		self.touch( os.path.join( "test", "sequences", "lsTest", "a.b" ) )
+
+		l = IECore.ls( s.fileName, minSequenceSize=1 )
+		self.assertTrue( l )
+		self.assertEqual( l.frameList.asList(), [ 1 ] )
+
 	def tearDown( self ) :
 
 		if os.path.exists( os.path.join( "test", "sequences" ) ) :


### PR DESCRIPTION
Backports https://github.com/ImageEngine/cortex/pull/1556 to RB-10.5, and sets up a new release.
