### PR TITLE
USD PointInstancerAlgo : Support `orientationsf` attribute

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@
 Fixes
 -----
 
+- USDScene : Fixed loading of float-precision orientations from the `PointInstancer.orientationsf` attribute. Previously only the half-precision `orientations` attribute was supported.
 - IECore.ls() : Fixed error when sequence started with `#`.
 
 10.6.7.1 (relative to 10.6.7.0)

--- a/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
+++ b/contrib/IECoreUSD/src/IECoreUSD/PointInstancerAlgo.cpp
@@ -85,7 +85,9 @@ IECore::ObjectPtr readPointInstancer( pxr::UsdGeomPointInstancer &pointInstancer
 	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetIdsAttr(), time, newPoints.get(), "instanceId" );
 
 	Canceller::check( canceller );
-	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetOrientationsAttr(), time, newPoints.get(), "orientation" );
+	pxr::UsdAttribute orientationsAttr;
+	pointInstancer.UsesOrientationsf( &orientationsAttr );
+	PrimitiveAlgo::readPrimitiveVariable( orientationsAttr, time, newPoints.get(), "orientation" );
 
 	Canceller::check( canceller );
 	PrimitiveAlgo::readPrimitiveVariable( pointInstancer.GetScalesAttr(), time, newPoints.get(), "scale" );
@@ -164,6 +166,7 @@ bool pointInstancerMightBeTimeVarying( pxr::UsdGeomPointInstancer &instancer )
 		instancer.GetProtoIndicesAttr().ValueMightBeTimeVarying() ||
 		instancer.GetIdsAttr().ValueMightBeTimeVarying() ||
 		instancer.GetOrientationsAttr().ValueMightBeTimeVarying() ||
+		instancer.GetOrientationsfAttr().ValueMightBeTimeVarying() ||
 		instancer.GetScalesAttr().ValueMightBeTimeVarying() ||
 		instancer.GetVelocitiesAttr().ValueMightBeTimeVarying() ||
 		instancer.GetAccelerationsAttr().ValueMightBeTimeVarying() ||

--- a/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
+++ b/contrib/IECoreUSD/test/IECoreUSD/USDSceneTest.py
@@ -3945,6 +3945,53 @@ class USDSceneTest( unittest.TestCase ) :
 		self.assertEqual( points["inactiveIds"], IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.Int64VectorData( [ 0, 2 ] ) ) )
 		self.assertEqual( points["invisibleIds"], IECoreScene.PrimitiveVariable( IECoreScene.PrimitiveVariable.Interpolation.Constant, IECore.Int64VectorData( [ 1, 4 ] ) ) )
 
+	def testPointInstancerOrientationTypes( self ) :
+
+		# Use the USD API to author point instancers with different
+		# flavours of orientation.
+
+		fileName = os.path.join( self.temporaryDirectory(), "pointInstancerOrientations.usda" )
+		stage = pxr.Usd.Stage.CreateNew( fileName )
+
+		# Different test values, so we can easily discern which we are loading.
+		floatOrientation = pxr.Gf.Quatf( pxr.Gf.Rotation( pxr.Gf.Vec3d( 1, 0, 0 ), math.pi ).GetQuat() )
+		halfOrientation = pxr.Gf.Quath( pxr.Gf.Rotation( pxr.Gf.Vec3d( 0, 1, 0 ), math.pi ).GetQuat() )
+
+		for name in [ "none", "float", "half", "both" ] :
+
+			pointInstancer = pxr.UsdGeom.PointInstancer.Define( stage, f"/{name}" )
+			pointInstancer.CreatePositionsAttr( [ ( v, v, v ) for v in range( 0, 5 ) ] )
+
+			if name in [ "float", "both" ] :
+				pointInstancer.CreateOrientationsfAttr( [ floatOrientation ] * 5 )
+			if name in [ "half", "both" ] :
+				pointInstancer.CreateOrientationsAttr( [ halfOrientation ] * 5 )
+
+		stage.GetRootLayer().Save()
+
+		# Check we can load the right orientation via a SceneInterface.
+
+		root = IECoreScene.SceneInterface.create( fileName, IECore.IndexedIO.OpenMode.Read )
+
+		for name in [ "none", "float", "half", "both" ] :
+
+			with self.subTest( name = name ) :
+
+				pointInstancer = root.child( name ).readObject( 0 )
+
+				if name == "none" :
+					self.assertNotIn( "orientation", pointInstancer )
+				else :
+					self.assertIn( "orientation", pointInstancer )
+					self.assertEqual( pointInstancer["orientation"].interpolation, IECoreScene.PrimitiveVariable.Interpolation.Vertex )
+					data = pointInstancer["orientation"].data
+					# We don't have a Quath type, so always load as Quatf.
+					self.assertIsInstance( data, IECore.QuatfVectorData )
+					if name in [ "float", "both" ] :
+						self.assertEqual( data[0], imath.Quatf( floatOrientation.GetReal(), *floatOrientation.GetImaginary() ) )
+					else :
+						self.assertEqual( data[0], imath.Quatf( halfOrientation.GetReal(), *halfOrientation.GetImaginary() ) )
+
 	def testArnoldArrayInputs( self ) :
 
 		def assertExpectedArrayInputs( network ) :


### PR DESCRIPTION
This is a float-precision version of the original half-precision `orientations` attribute. A separate attribute name is needed in USD because USD attributes are strongly typed. But Cortex primitive variables can take any data type so we stick with our standard `orientation` name regardless of type. This avoids any ambiguity about which attribute takes precedence.

This PR is for Cortex 10.6, destined for a Gaffer 1.6 patch version. For 10.7/1.7 we should also decide what to do when writing PointInstancers to USD. I'm inclined to always write to `orientationf`, but perhaps we'll want to gate it with an environment variable?